### PR TITLE
Adding more testcases for ee9's HttpServletRequest.getLocale() behaviors

### DIFF
--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/RequestHeadersTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/RequestHeadersTest.java
@@ -120,6 +120,8 @@ public class RequestHeadersTest
             en;q=0.5,it     | it
             bogus           | en-US
             en_en           | <undefined>
+            ;-              | en-US
+            ";--            | <undefined>
             """)
     public void testLocale(String requestHeaderValue, String expectedLocale) throws Exception
     {


### PR DESCRIPTION
Just adding some more sanity checks for the new ee9 HttpServletRequest.getLocale() behaviors with bad inputs.

We no longer throw an exception during failures in parsing with the new codebase.