### PR TITLE
Issue #13670 - Returning ISE in all getParameter use cases outlined by Servlet 6.1 spec

### DIFF
--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -1237,7 +1237,7 @@ public class ServletApiRequest implements HttpServletRequest
         {
             return getParameters().getValue(name);
         }
-        catch (IllegalStateException | VirtualMachineError e)
+        catch (IllegalStateException | VirtualMachineError | LinkageError e)
         {
             throw e;
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -1233,28 +1233,80 @@ public class ServletApiRequest implements HttpServletRequest
     @Override
     public String getParameter(String name)
     {
-        return getParameters().getValue(name);
+        try
+        {
+            return getParameters().getValue(name);
+        }
+        catch (IllegalStateException e)
+        {
+            throw e;
+        }
+        catch (Throwable t)
+        {
+            // Per Servlet https://github.com/jakartaee/servlet/issues/431 this should only
+            // ever throw an IllegalStateException
+            throw new IllegalStateException(t);
+        }
     }
 
     @Override
     public Enumeration<String> getParameterNames()
     {
-        return Collections.enumeration(getParameters().getNames());
+        try
+        {
+            return Collections.enumeration(getParameters().getNames());
+        }
+        catch (IllegalStateException e)
+        {
+            throw e;
+        }
+        catch (Throwable t)
+        {
+            // Per Servlet https://github.com/jakartaee/servlet/issues/431 this should only
+            // ever throw an IllegalStateException
+            throw new IllegalStateException(t);
+        }
     }
 
     @Override
     public String[] getParameterValues(String name)
     {
-        List<String> vals = getParameters().getValues(name);
-        if (vals == null)
-            return null;
-        return vals.toArray(new String[0]);
+        try
+        {
+            List<String> vals = getParameters().getValues(name);
+            if (vals == null)
+                return null;
+            return vals.toArray(new String[0]);
+        }
+        catch (IllegalStateException e)
+        {
+            throw e;
+        }
+        catch (Throwable t)
+        {
+            // Per Servlet https://github.com/jakartaee/servlet/issues/431 this should only
+            // ever throw an IllegalStateException
+            throw new IllegalStateException(t);
+        }
     }
 
     @Override
     public Map<String, String[]> getParameterMap()
     {
-        return Collections.unmodifiableMap(getParameters().toStringArrayMap());
+        try
+        {
+            return Collections.unmodifiableMap(getParameters().toStringArrayMap());
+        }
+        catch (IllegalStateException e)
+        {
+            throw e;
+        }
+        catch (Throwable t)
+        {
+            // Per Servlet https://github.com/jakartaee/servlet/issues/431 this should only
+            // ever throw an IllegalStateException
+            throw new IllegalStateException(t);
+        }
     }
 
     public Fields getParameters()

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -1237,7 +1237,7 @@ public class ServletApiRequest implements HttpServletRequest
         {
             return getParameters().getValue(name);
         }
-        catch (IllegalStateException e)
+        catch (IllegalStateException | VirtualMachineError e)
         {
             throw e;
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
@@ -779,40 +779,6 @@ public class RequestTest
         assertThat(response.getContent(), is("GOOD: ISE Occurred"));
     }
 
-    @Test
-    public void testGetParameterNameISE() throws Exception
-    {
-        startServer(new HttpServlet()
-        {
-            @Override
-            protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
-            {
-                try
-                {
-                    request.getParameter("foo");
-                    resp.setStatus(500);
-                    resp.getWriter().print("BAD: ISE Should have Occurred");
-                }
-                catch (IllegalStateException e)
-                {
-                    resp.setStatus(200);
-                    resp.getWriter().print("GOOD: ISE Occurred");
-                }
-            }
-        });
-
-        String rawResponse = _connector.getResponse(
-            """
-                POST /test/parameters?x=%80 HTTP/1.1\r
-                Host: localhost\r
-                Connection: close\r
-                \r
-                """);
-        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
-        assertThat(response.getStatus(), is(HttpStatus.OK_200));
-        assertThat(response.getContent(), is("GOOD: ISE Occurred"));
-    }
-
     static Stream<Arguments> suspiciousCharactersLegacy()
     {
         return Stream.of(

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestTest.java
@@ -37,6 +37,7 @@ import java.util.stream.Stream;
 
 import jakarta.servlet.MultipartConfigElement;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
@@ -692,7 +693,6 @@ public class RequestTest
                 out.println(Arrays.asList(request.getParameterValues("b")));
                 out.println(Arrays.asList(request.getParameterValues("c")));
                 out.println(Arrays.asList(request.getParameterValues("d")));
-
             }
         });
 
@@ -717,6 +717,100 @@ public class RequestTest
             []
             [xyz]
             """));
+    }
+
+    public record ParameterCase(String purpose, Consumer<HttpServletRequest> requestAction)
+    {
+        @Override
+        public String toString()
+        {
+            return purpose;
+        }
+    }
+
+    public static Stream<Arguments> parameterISECases()
+    {
+        List<Arguments> cases = new ArrayList<>();
+
+        cases.add(Arguments.of(new ParameterCase("getParameter(String)",
+            (request) -> request.getParameter("x"))));
+        cases.add(Arguments.of(new ParameterCase("getParameterNames()",
+            ServletRequest::getParameterNames)));
+        cases.add(Arguments.of(new ParameterCase("getParameterValues(String)",
+            (request) -> request.getParameterValues("x"))));
+        cases.add(Arguments.of(new ParameterCase("getParameterMap()",
+            ServletRequest::getParameterMap)));
+
+        return cases.stream();
+    }
+
+    @ParameterizedTest
+    @MethodSource("parameterISECases")
+    public void testGetParameterISE(ParameterCase parameterCase) throws Exception
+    {
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
+            {
+                try
+                {
+                    parameterCase.requestAction.accept(request);
+                    resp.setStatus(500);
+                    resp.getWriter().print("BAD: ISE Should have Occurred");
+                }
+                catch (IllegalStateException e)
+                {
+                    resp.setStatus(200);
+                    resp.getWriter().print("GOOD: ISE Occurred");
+                }
+            }
+        });
+
+        String rawResponse = _connector.getResponse(
+            """
+                POST /test/parameters?x=%80 HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContent(), is("GOOD: ISE Occurred"));
+    }
+
+    @Test
+    public void testGetParameterNameISE() throws Exception
+    {
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
+            {
+                try
+                {
+                    request.getParameter("foo");
+                    resp.setStatus(500);
+                    resp.getWriter().print("BAD: ISE Should have Occurred");
+                }
+                catch (IllegalStateException e)
+                {
+                    resp.setStatus(200);
+                    resp.getWriter().print("GOOD: ISE Occurred");
+                }
+            }
+        });
+
+        String rawResponse = _connector.getResponse(
+            """
+                POST /test/parameters?x=%80 HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContent(), is("GOOD: ISE Occurred"));
     }
 
     static Stream<Arguments> suspiciousCharactersLegacy()


### PR DESCRIPTION
As outlined in Servlet 6.1 (EE11) Spec, the getParameter*() methods should only ever return ISE.

See details in ...

* #13670