### PR TITLE
 Issue #13933 - Enable all tests in PartialRFC2616Test in jetty-12.0.x

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -27,7 +27,6 @@ import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.server.handler.DumpHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -410,7 +409,6 @@ public class PartialRFC2616Test
      * @see <a href="https://www.rfc-editor.org/rfc/rfc2616#section-5.2">RFC 2616 - Section 5.2 - The Resource Identified by a Request</a>
      */
     @Test
-    @Disabled // TODO
     public void test521() throws Exception
     {
         // Default Host
@@ -494,7 +492,6 @@ public class PartialRFC2616Test
     }
 
     @Test
-    @Disabled // TODO
     public void test10418() throws Exception
     {
         // Expect Failure
@@ -550,7 +547,6 @@ public class PartialRFC2616Test
     }
 
     @Test
-    @Disabled // TODO
     public void test824() throws Exception
     {
         // Expect 100 not sent
@@ -609,7 +605,6 @@ public class PartialRFC2616Test
     }
 
     @Test
-    @Disabled // TODO
     public void test1423() throws Exception
     {
         try (StacklessLogging stackless = new StacklessLogging(HttpParser.class))

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -16,11 +16,14 @@ package org.eclipse.jetty.server;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpParser;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.LocalConnector.LocalEndPoint;
 import org.eclipse.jetty.server.handler.ContextHandler;
@@ -28,6 +31,9 @@ import org.eclipse.jetty.server.handler.DumpHandler;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -48,7 +54,10 @@ public class PartialRFC2616Test
     {
         server = new Server();
         connector = new LocalConnector(server);
-        connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setHttpCompliance(HttpCompliance.RFC2616);
+        HttpConfiguration httpConfiguration = connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration();
+        httpConfiguration.setHttpCompliance(HttpCompliance.RFC2616);
+        httpConfiguration.setUriCompliance(UriCompliance.JETTY_11);
+        httpConfiguration.setSendDateHeader(true);
         connector.setIdleTimeout(10000);
         server.addConnector(connector);
 
@@ -604,26 +613,54 @@ public class PartialRFC2616Test
         }
     }
 
-    @Test
-    public void test1423() throws Exception
+    public static Stream<Arguments> examples1423()
+    {
+        return Stream.of(
+            // No "Host" in HTTP/1.0 is allowed
+            Arguments.of(
+                """
+                    GET /R1 HTTP/1.0\r
+                    Connection: close\r
+                    \r
+                    """, 200),
+            // No "Host" in HTTP/1.1 is rejected with 400 Bad Request
+            Arguments.of("""
+                GET /R1 HTTP/1.1\r
+                Connection: close\r
+                \r
+                """, 400),
+            // Valid "Host" header
+            Arguments.of("""
+                GET /R1 HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                \r
+                """, 200)
+            // TODO: backport fix for this rule from jetty-12.1.x (where it is fixed)
+            /*
+            // An empty "Host" header is valid for HTTP/1.1
+            Arguments.of("""
+                GET /R1 HTTP/1.1\r
+                Host:\r
+                Connection: close\r
+                \r
+                """, 200)
+             */
+        );
+    }
+
+    /**
+     * Tests of <a href="https://www.rfc-editor.org/rfc/rfc2616#section-14.23">Host Header</a>
+     */
+    @ParameterizedTest
+    @MethodSource("examples1423")
+    public void test1423(String rawRequest, int expectedStatus) throws Exception
     {
         try (StacklessLogging stackless = new StacklessLogging(HttpParser.class))
         {
-            int offset = 0;
-            String response = connector.getResponse("GET /R1 HTTP/1.0\n" + "Connection: close\n" + "\n");
-            offset = checkContains(response, offset, "HTTP/1.1 200", "200") + 1;
-
-            offset = 0;
-            response = connector.getResponse("GET /R1 HTTP/1.1\n" + "Connection: close\n" + "\n");
-            offset = checkContains(response, offset, "HTTP/1.1 400", "400") + 1;
-
-            offset = 0;
-            response = connector.getResponse("GET /R1 HTTP/1.1\n" + "Host: localhost\n" + "Connection: close\n" + "\n");
-            offset = checkContains(response, offset, "HTTP/1.1 200", "200") + 1;
-
-            offset = 0;
-            response = connector.getResponse("GET /R1 HTTP/1.1\n" + "Host:\n" + "Connection: close\n" + "\n");
-            offset = checkContains(response, offset, "HTTP/1.1 200", "200") + 1;
+            String rawResponse = connector.getResponse(rawRequest);
+            HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+            assertThat(response.getStatus(), is(expectedStatus));
         }
     }
 


### PR DESCRIPTION
Enable all tests in `PartialRFC2616Test` from branch `jetty-12.0.x`