### PR TITLE
Issue #13647 - Add ContainerLifeCycleMap

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/arch/bean.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/arch/bean.adoc
@@ -52,6 +52,13 @@ Jetty components that contain other components implement the `org.eclipse.jetty.
 When a `ContainerLifeCycle` is started, it also starts recursively all its managed beans (if they implement `LifeCycle`); unmanaged beans are not started during the `ContainerLifeCycle` start cycle.
 Likewise, stopping a `ContainerLifeCycle` stops recursively and in reverse order all its managed beans; unmanaged beans are not stopped during the `ContainerLifeCycle` stop cycle.
 
+[NOTE]
+====
+Unless explicitly documented otherwise, `Container` and `ContainerLifeCycle` implementations are not thread-safe for concurrent mutation/traversal of the component tree.
+Applications should generally compose the tree during setup, then start it.
+If concurrent access or mutation is required, applications must provide external synchronization.
+====
+
 Components can also be started and stopped individually, therefore activating or deactivating the functionalities that they offer.
 
 Applications should first compose components in the desired structure, and then start the root component:
@@ -140,6 +147,7 @@ attributes.removeAttribute("myService");
 
 `ContainerLifeCycleMap<K, V extends LifeCycle>` implements the `Map` interface while managing map values as beans.
 This is useful when you need to maintain a keyed collection of lifecycle-managed components.
+`ContainerLifeCycleMap` follows the same thread-safety semantics as `ContainerLifeCycle` (external synchronization is required for concurrent access/mutation).
 
 [,java,indent=0]
 ----

--- a/documentation/jetty/modules/programming-guide/pages/arch/bean.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/arch/bean.adoc
@@ -108,6 +108,59 @@ If you need component tree features such as automatic xref:arch/jmx.adoc[export 
 You can make the long-lived container efficient at adding/removing the short-lived components using a data structure that is not part of the component tree, and make the long-lived container handle the JMX and dump features for the short-lived components.
 ====
 
+[[bean-collections]]
+== Bean Container Collections
+
+Jetty provides specialized collection classes that automatically manage their elements as beans in a `ContainerLifeCycle`.
+When elements are added to these collections, they are registered as managed beans; when removed, they are unregistered.
+This ensures that lifecycle events (start, stop) are properly propagated to collection elements.
+
+[[attribute-container-map]]
+=== AttributeContainerMap
+
+`AttributeContainerMap` implements the `Attributes` interface while managing attribute values as beans.
+When you set an attribute, the value is added as a managed bean; when you remove an attribute, the bean is removed.
+
+[,java,indent=0]
+----
+AttributeContainerMap attributes = new AttributeContainerMap();
+
+// Add a LifeCycle as an attribute - it becomes a managed bean
+attributes.setAttribute("myService", new MyService());
+
+// Start the container - all managed attribute values are started
+attributes.start();
+
+// Remove the attribute - the bean is stopped and removed
+attributes.removeAttribute("myService");
+----
+
+[[container-lifecycle-map]]
+=== ContainerLifeCycleMap
+
+`ContainerLifeCycleMap<K, V extends LifeCycle>` implements the `Map` interface while managing map values as beans.
+This is useful when you need to maintain a keyed collection of lifecycle-managed components.
+
+[,java,indent=0]
+----
+ContainerLifeCycleMap<String, Connector> connectors = new ContainerLifeCycleMap<>();
+
+// Add connectors - they become managed beans
+connectors.put("http", new ServerConnector(server));
+connectors.put("https", new ServerConnector(server, sslContextFactory));
+
+// Start the container - all connectors are started
+connectors.start();
+
+// Access connectors by key
+Connector http = connectors.get("http");
+
+// Remove a connector - it is stopped and removed as a bean
+connectors.remove("http");
+----
+
+The collection views returned by `keySet()`, `values()`, and `entrySet()` are wrapped to properly manage beans when elements are removed through these views.
+
 [[listener]]
 == Jetty Component Listeners
 

--- a/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
+++ b/jetty-core/jetty-compression/jetty-compression-server/src/main/java/org/eclipse/jetty/compression/server/CompressionHandler.java
@@ -40,6 +40,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.component.ContainerLifeCycleMap;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,18 +57,21 @@ public class CompressionHandler extends Handler.Wrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(CompressionHandler.class);
     private final HttpField varyAcceptEncoding = new PreEncodedHttpField(HttpHeader.VARY, HttpHeader.ACCEPT_ENCODING.asString());
-    private final Map<String, Compression> supportedEncodings = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    private final ContainerLifeCycleMap<String, Compression> supportedEncodings =
+        new ContainerLifeCycleMap<>(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
     private final PathMappings<CompressionConfig> pathConfigs = new PathMappings<>();
 
     public CompressionHandler()
     {
         installBean(pathConfigs);
+        installBean(supportedEncodings);
     }
 
     public CompressionHandler(Handler handler)
     {
         super(handler);
         installBean(pathConfigs);
+        installBean(supportedEncodings);
     }
 
     /**
@@ -78,10 +82,8 @@ public class CompressionHandler extends Handler.Wrapper
      */
     public Compression putCompression(Compression compression)
     {
-        Compression previous = supportedEncodings.put(compression.getEncodingName(), compression);
         compression.setContainer(this);
-        updateBean(previous, compression, true);
-        return previous;
+        return supportedEncodings.put(compression.getEncodingName(), compression);
     }
 
     /**
@@ -92,9 +94,7 @@ public class CompressionHandler extends Handler.Wrapper
      */
     public Compression removeCompression(String encodingName)
     {
-        Compression compression = supportedEncodings.remove(encodingName);
-        removeBean(compression);
-        return compression;
+        return supportedEncodings.remove(encodingName);
     }
 
     /**

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/Container.java
@@ -20,7 +20,12 @@ import java.util.EventListener;
 import java.util.List;
 
 /**
- * A Container
+ * A Container.
+ * <p>
+ * Unless explicitly documented by an implementation, {@link Container} implementations are not thread-safe
+ * for concurrent mutation and traversal of the containment tree. Applications that access or modify
+ * containers from multiple threads must provide external synchronization.
+ * </p>
  */
 public interface Container
 {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jetty.util.TypeUtil;
-import org.eclipse.jetty.util.thread.AutoLock;
 
 /**
  * A {@link Map} implementation that manages its values as beans in a {@link ContainerLifeCycle}.
@@ -36,13 +35,16 @@ import org.eclipse.jetty.util.thread.AutoLock;
  * The lifecycle of the values is tied to this container: when the container starts,
  * all managed values are started; when it stops, they are stopped.
  * </p>
+ * <p>
+ * Like {@link ContainerLifeCycle}, this class is not thread-safe for concurrent mutation or access.
+ * Applications must provide external synchronization if instances are shared between threads.
+ * </p>
  *
  * @param <K> the type of keys maintained by this map
  * @param <V> the type of mapped values, must extend {@link LifeCycle}
  */
 public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLifeCycle implements Map<K, V>
 {
-    private final AutoLock _lock = new AutoLock();
     private final Map<K, V> _map;
 
     /**
@@ -70,92 +72,65 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
     @Override
     public int size()
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return _map.size();
-        }
+        return _map.size();
     }
 
     @Override
     public boolean isEmpty()
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return _map.isEmpty();
-        }
+        return _map.isEmpty();
     }
 
     @Override
     public boolean containsKey(Object key)
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return _map.containsKey(key);
-        }
+        return _map.containsKey(key);
     }
 
     @Override
     public boolean containsValue(Object value)
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return _map.containsValue(value);
-        }
+        return _map.containsValue(value);
     }
 
     @Override
     public V get(Object key)
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return _map.get(key);
-        }
+        return _map.get(key);
     }
 
     @Override
     public V put(K key, V value)
     {
-        try (AutoLock l = _lock.lock())
-        {
-            V old = _map.put(key, value);
-            updateBean(old, value);
-            return old;
-        }
+        V old = _map.put(key, value);
+        updateBean(old, value);
+        return old;
     }
 
     @Override
     public V remove(Object key)
     {
-        try (AutoLock l = _lock.lock())
-        {
-            V removed = _map.remove(key);
-            if (removed != null)
-                removeBean(removed);
-            return removed;
-        }
+        V removed = _map.remove(key);
+        if (removed != null)
+            removeBean(removed);
+        return removed;
     }
 
     @Override
     public void putAll(Map<? extends K, ? extends V> m)
     {
-        try (AutoLock l = _lock.lock())
+        for (Entry<? extends K, ? extends V> entry : m.entrySet())
         {
-            for (Entry<? extends K, ? extends V> entry : m.entrySet())
-            {
-                V old = _map.put(entry.getKey(), entry.getValue());
-                updateBean(old, entry.getValue());
-            }
+            V old = _map.put(entry.getKey(), entry.getValue());
+            updateBean(old, entry.getValue());
         }
     }
 
     @Override
     public void clear()
     {
-        try (AutoLock l = _lock.lock())
-        {
-            _map.clear();
-            removeBeans();
-        }
+        _map.clear();
+        removeBeans();
     }
 
     @Override
@@ -180,19 +155,13 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
     public void dump(Appendable out, String indent) throws IOException
     {
         Dumpable.dumpObject(out, this);
-        try (AutoLock l = _lock.lock())
-        {
-            Dumpable.dumpMapEntries(out, indent, _map, true);
-        }
+        Dumpable.dumpMapEntries(out, indent, _map, true);
     }
 
     @Override
     public String toString()
     {
-        try (AutoLock l = _lock.lock())
-        {
-            return String.format("%s@%x{size=%d}", TypeUtil.toShortName(this.getClass()), hashCode(), _map.size());
-        }
+        return String.format("%s@%x{size=%d}", TypeUtil.toShortName(this.getClass()), hashCode(), _map.size());
     }
 
     /**
@@ -283,11 +252,8 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
         {
             if (!(o instanceof Entry<?, ?> e))
                 return false;
-            try (AutoLock l = _lock.lock())
-            {
-                V value = _map.get(e.getKey());
-                return value != null && value.equals(e.getValue());
-            }
+            V value = _map.get(e.getKey());
+            return value != null && value.equals(e.getValue());
         }
 
         @Override
@@ -295,17 +261,14 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
         {
             if (!(o instanceof Entry<?, ?> e))
                 return false;
-            try (AutoLock l = _lock.lock())
+            V value = _map.get(e.getKey());
+            if (value != null && value.equals(e.getValue()))
             {
-                V value = _map.get(e.getKey());
-                if (value != null && value.equals(e.getValue()))
-                {
-                    _map.remove(e.getKey());
-                    removeBean(value);
-                    return true;
-                }
-                return false;
+                _map.remove(e.getKey());
+                removeBean(value);
+                return true;
             }
+            return false;
         }
 
         @Override
@@ -325,11 +288,8 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
 
         KeyIterator()
         {
-            try (AutoLock l = _lock.lock())
-            {
-                // Create a copy to avoid ConcurrentModificationException
-                _iterator = new HashMap<>(_map).entrySet().iterator();
-            }
+            // Create a copy to avoid ConcurrentModificationException
+            _iterator = new HashMap<>(_map).entrySet().iterator();
         }
 
         @Override
@@ -365,11 +325,8 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
 
         ValueIterator()
         {
-            try (AutoLock l = _lock.lock())
-            {
-                // Create a copy to avoid ConcurrentModificationException
-                _iterator = new HashMap<>(_map).entrySet().iterator();
-            }
+            // Create a copy to avoid ConcurrentModificationException
+            _iterator = new HashMap<>(_map).entrySet().iterator();
         }
 
         @Override
@@ -405,11 +362,8 @@ public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLife
 
         EntryIterator()
         {
-            try (AutoLock l = _lock.lock())
-            {
-                // Create a copy to avoid ConcurrentModificationException
-                _iterator = new HashMap<>(_map).entrySet().iterator();
-            }
+            // Create a copy to avoid ConcurrentModificationException
+            _iterator = new HashMap<>(_map).entrySet().iterator();
         }
 
         @Override

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
@@ -43,7 +43,29 @@ import org.eclipse.jetty.util.thread.AutoLock;
 public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLifeCycle implements Map<K, V>
 {
     private final AutoLock _lock = new AutoLock();
-    private final Map<K, V> _map = new HashMap<>();
+    private final Map<K, V> _map;
+
+    /**
+     * Creates a new ContainerLifeCycleMap backed by a HashMap.
+     */
+    public ContainerLifeCycleMap()
+    {
+        _map = new HashMap<>();
+    }
+
+    /**
+     * Creates a new ContainerLifeCycleMap backed by the provided Map.
+     * <p>
+     * This allows using custom Map implementations, such as a TreeMap
+     * with case-insensitive key ordering.
+     * </p>
+     *
+     * @param map the backing Map implementation to use
+     */
+    public ContainerLifeCycleMap(Map<K, V> map)
+    {
+        _map = map;
+    }
 
     @Override
     public int size()

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/ContainerLifeCycleMap.java
@@ -1,0 +1,462 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.component;
+
+import java.io.IOException;
+import java.util.AbstractCollection;
+import java.util.AbstractSet;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.thread.AutoLock;
+
+/**
+ * A {@link Map} implementation that manages its values as beans in a {@link ContainerLifeCycle}.
+ * <p>
+ * When values are added to the map via {@link #put(Object, Object)} or {@link #putAll(Map)},
+ * they are also added as managed beans. When values are removed via {@link #remove(Object)},
+ * {@link #clear()}, or through collection views, they are removed as beans.
+ * </p>
+ * <p>
+ * The lifecycle of the values is tied to this container: when the container starts,
+ * all managed values are started; when it stops, they are stopped.
+ * </p>
+ *
+ * @param <K> the type of keys maintained by this map
+ * @param <V> the type of mapped values, must extend {@link LifeCycle}
+ */
+public class ContainerLifeCycleMap<K, V extends LifeCycle> extends ContainerLifeCycle implements Map<K, V>
+{
+    private final AutoLock _lock = new AutoLock();
+    private final Map<K, V> _map = new HashMap<>();
+
+    @Override
+    public int size()
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return _map.size();
+        }
+    }
+
+    @Override
+    public boolean isEmpty()
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return _map.isEmpty();
+        }
+    }
+
+    @Override
+    public boolean containsKey(Object key)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return _map.containsKey(key);
+        }
+    }
+
+    @Override
+    public boolean containsValue(Object value)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return _map.containsValue(value);
+        }
+    }
+
+    @Override
+    public V get(Object key)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return _map.get(key);
+        }
+    }
+
+    @Override
+    public V put(K key, V value)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            V old = _map.put(key, value);
+            updateBean(old, value);
+            return old;
+        }
+    }
+
+    @Override
+    public V remove(Object key)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            V removed = _map.remove(key);
+            if (removed != null)
+                removeBean(removed);
+            return removed;
+        }
+    }
+
+    @Override
+    public void putAll(Map<? extends K, ? extends V> m)
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            for (Entry<? extends K, ? extends V> entry : m.entrySet())
+            {
+                V old = _map.put(entry.getKey(), entry.getValue());
+                updateBean(old, entry.getValue());
+            }
+        }
+    }
+
+    @Override
+    public void clear()
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            _map.clear();
+            removeBeans();
+        }
+    }
+
+    @Override
+    public Set<K> keySet()
+    {
+        return new KeySet();
+    }
+
+    @Override
+    public Collection<V> values()
+    {
+        return new Values();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet()
+    {
+        return new EntrySet();
+    }
+
+    @Override
+    public void dump(Appendable out, String indent) throws IOException
+    {
+        Dumpable.dumpObject(out, this);
+        try (AutoLock l = _lock.lock())
+        {
+            Dumpable.dumpMapEntries(out, indent, _map, true);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        try (AutoLock l = _lock.lock())
+        {
+            return String.format("%s@%x{size=%d}", TypeUtil.toShortName(this.getClass()), hashCode(), _map.size());
+        }
+    }
+
+    /**
+     * A wrapped key set that intercepts removal operations to properly remove beans.
+     */
+    private class KeySet extends AbstractSet<K>
+    {
+        @Override
+        public Iterator<K> iterator()
+        {
+            return new KeyIterator();
+        }
+
+        @Override
+        public int size()
+        {
+            return ContainerLifeCycleMap.this.size();
+        }
+
+        @Override
+        public boolean contains(Object o)
+        {
+            return ContainerLifeCycleMap.this.containsKey(o);
+        }
+
+        @Override
+        public boolean remove(Object o)
+        {
+            return ContainerLifeCycleMap.this.remove(o) != null;
+        }
+
+        @Override
+        public void clear()
+        {
+            ContainerLifeCycleMap.this.clear();
+        }
+    }
+
+    /**
+     * A wrapped values collection that intercepts removal operations to properly remove beans.
+     */
+    private class Values extends AbstractCollection<V>
+    {
+        @Override
+        public Iterator<V> iterator()
+        {
+            return new ValueIterator();
+        }
+
+        @Override
+        public int size()
+        {
+            return ContainerLifeCycleMap.this.size();
+        }
+
+        @Override
+        public boolean contains(Object o)
+        {
+            return ContainerLifeCycleMap.this.containsValue(o);
+        }
+
+        @Override
+        public void clear()
+        {
+            ContainerLifeCycleMap.this.clear();
+        }
+    }
+
+    /**
+     * A wrapped entry set that intercepts removal and setValue operations to properly manage beans.
+     */
+    private class EntrySet extends AbstractSet<Entry<K, V>>
+    {
+        @Override
+        public Iterator<Entry<K, V>> iterator()
+        {
+            return new EntryIterator();
+        }
+
+        @Override
+        public int size()
+        {
+            return ContainerLifeCycleMap.this.size();
+        }
+
+        @Override
+        public boolean contains(Object o)
+        {
+            if (!(o instanceof Entry<?, ?> e))
+                return false;
+            try (AutoLock l = _lock.lock())
+            {
+                V value = _map.get(e.getKey());
+                return value != null && value.equals(e.getValue());
+            }
+        }
+
+        @Override
+        public boolean remove(Object o)
+        {
+            if (!(o instanceof Entry<?, ?> e))
+                return false;
+            try (AutoLock l = _lock.lock())
+            {
+                V value = _map.get(e.getKey());
+                if (value != null && value.equals(e.getValue()))
+                {
+                    _map.remove(e.getKey());
+                    removeBean(value);
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        @Override
+        public void clear()
+        {
+            ContainerLifeCycleMap.this.clear();
+        }
+    }
+
+    /**
+     * Iterator over keys that properly removes beans when iterator.remove() is called.
+     */
+    private class KeyIterator implements Iterator<K>
+    {
+        private final Iterator<Entry<K, V>> _iterator;
+        private Entry<K, V> _current;
+
+        KeyIterator()
+        {
+            try (AutoLock l = _lock.lock())
+            {
+                // Create a copy to avoid ConcurrentModificationException
+                _iterator = new HashMap<>(_map).entrySet().iterator();
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return _iterator.hasNext();
+        }
+
+        @Override
+        public K next()
+        {
+            _current = _iterator.next();
+            return _current.getKey();
+        }
+
+        @Override
+        public void remove()
+        {
+            if (_current == null)
+                throw new IllegalStateException();
+            ContainerLifeCycleMap.this.remove(_current.getKey());
+            _current = null;
+        }
+    }
+
+    /**
+     * Iterator over values that properly removes beans when iterator.remove() is called.
+     */
+    private class ValueIterator implements Iterator<V>
+    {
+        private final Iterator<Entry<K, V>> _iterator;
+        private Entry<K, V> _current;
+
+        ValueIterator()
+        {
+            try (AutoLock l = _lock.lock())
+            {
+                // Create a copy to avoid ConcurrentModificationException
+                _iterator = new HashMap<>(_map).entrySet().iterator();
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return _iterator.hasNext();
+        }
+
+        @Override
+        public V next()
+        {
+            _current = _iterator.next();
+            return _current.getValue();
+        }
+
+        @Override
+        public void remove()
+        {
+            if (_current == null)
+                throw new IllegalStateException();
+            ContainerLifeCycleMap.this.remove(_current.getKey());
+            _current = null;
+        }
+    }
+
+    /**
+     * Iterator over entries that properly manages beans when iterator.remove() or entry.setValue() is called.
+     */
+    private class EntryIterator implements Iterator<Entry<K, V>>
+    {
+        private final Iterator<Entry<K, V>> _iterator;
+        private Entry<K, V> _current;
+
+        EntryIterator()
+        {
+            try (AutoLock l = _lock.lock())
+            {
+                // Create a copy to avoid ConcurrentModificationException
+                _iterator = new HashMap<>(_map).entrySet().iterator();
+            }
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return _iterator.hasNext();
+        }
+
+        @Override
+        public Entry<K, V> next()
+        {
+            _current = _iterator.next();
+            // Return a wrapped entry that intercepts setValue
+            return new WrappedEntry(_current.getKey());
+        }
+
+        @Override
+        public void remove()
+        {
+            if (_current == null)
+                throw new IllegalStateException();
+            ContainerLifeCycleMap.this.remove(_current.getKey());
+            _current = null;
+        }
+    }
+
+    /**
+     * A wrapped entry that intercepts setValue to properly manage beans.
+     */
+    private class WrappedEntry implements Entry<K, V>
+    {
+        private final K _key;
+
+        WrappedEntry(K key)
+        {
+            _key = key;
+        }
+
+        @Override
+        public K getKey()
+        {
+            return _key;
+        }
+
+        @Override
+        public V getValue()
+        {
+            return ContainerLifeCycleMap.this.get(_key);
+        }
+
+        @Override
+        public V setValue(V value)
+        {
+            return ContainerLifeCycleMap.this.put(_key, value);
+        }
+
+        @Override
+        public boolean equals(Object o)
+        {
+            if (!(o instanceof Entry<?, ?> e))
+                return false;
+            return _key.equals(e.getKey()) && getValue().equals(e.getValue());
+        }
+
+        @Override
+        public int hashCode()
+        {
+            V value = getValue();
+            return _key.hashCode() ^ (value == null ? 0 : value.hashCode());
+        }
+    }
+}

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/AttributeContainerMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/AttributeContainerMapTest.java
@@ -229,8 +229,8 @@ public class AttributeContainerMapTest
     private static class TestLifeCycle extends AbstractLifeCycle
     {
         private final String _name;
-        final AtomicInteger started = new AtomicInteger();
-        final AtomicInteger stopped = new AtomicInteger();
+        private final AtomicInteger started = new AtomicInteger();
+        private final AtomicInteger stopped = new AtomicInteger();
 
         TestLifeCycle(String name)
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/AttributeContainerMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/AttributeContainerMapTest.java
@@ -1,0 +1,260 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.component;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AttributeContainerMapTest
+{
+    @Test
+    public void testSetGetRemoveAttribute() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        // Test setAttribute
+        assertNull(map.setAttribute("key1", bean1));
+        assertNull(map.setAttribute("key2", bean2));
+
+        // Test getAttribute
+        assertEquals(bean1, map.getAttribute("key1"));
+        assertEquals(bean2, map.getAttribute("key2"));
+        assertNull(map.getAttribute("nonexistent"));
+
+        // Test getAttributeNameSet
+        Set<String> names = map.getAttributeNameSet();
+        assertThat(names, containsInAnyOrder("key1", "key2"));
+
+        // Test removeAttribute
+        assertEquals(bean1, map.removeAttribute("key1"));
+        assertNull(map.getAttribute("key1"));
+        assertNull(map.removeAttribute("nonexistent"));
+
+        // Verify key1 is removed from names
+        names = map.getAttributeNameSet();
+        assertThat(names, containsInAnyOrder("key2"));
+    }
+
+    @Test
+    public void testSetAttributeReplacesOldValue() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        assertNull(map.setAttribute("key", bean1));
+        assertEquals(bean1, map.setAttribute("key", bean2));
+        assertEquals(bean2, map.getAttribute("key"));
+    }
+
+    @Test
+    public void testClearAttributes() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.setAttribute("key1", bean1);
+        map.setAttribute("key2", bean2);
+
+        map.clearAttributes();
+
+        assertNull(map.getAttribute("key1"));
+        assertNull(map.getAttribute("key2"));
+        assertThat(map.getAttributeNameSet(), empty());
+    }
+
+    @Test
+    public void testBeanAddedOnSetAttribute() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean = new TestLifeCycle("bean");
+
+        map.setAttribute("key", bean);
+
+        // Bean should be added to the container
+        assertTrue(map.contains(bean));
+    }
+
+    @Test
+    public void testBeanRemovedOnRemoveAttribute() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean = new TestLifeCycle("bean");
+
+        map.setAttribute("key", bean);
+        assertTrue(map.contains(bean));
+
+        map.removeAttribute("key");
+        assertFalse(map.contains(bean));
+    }
+
+    @Test
+    public void testBeanReplacedOnSetAttribute() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.setAttribute("key", bean1);
+        assertTrue(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+
+        map.setAttribute("key", bean2);
+        assertFalse(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+    }
+
+    @Test
+    public void testBeansRemovedOnClearAttributes() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.setAttribute("key1", bean1);
+        map.setAttribute("key2", bean2);
+        assertTrue(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+
+        map.clearAttributes();
+        assertFalse(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testLifeCycleManagement() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.setAttribute("key1", bean1);
+        map.setAttribute("key2", bean2);
+
+        // Beans should not be started yet
+        assertEquals(0, bean1.started.get());
+        assertEquals(0, bean2.started.get());
+
+        // Start the container
+        map.start();
+
+        // Beans should now be started
+        assertEquals(1, bean1.started.get());
+        assertEquals(1, bean2.started.get());
+        assertTrue(bean1.isStarted());
+        assertTrue(bean2.isStarted());
+
+        // Stop the container
+        map.stop();
+
+        // Beans should now be stopped
+        assertEquals(1, bean1.stopped.get());
+        assertEquals(1, bean2.stopped.get());
+        assertTrue(bean1.isStopped());
+        assertTrue(bean2.isStopped());
+    }
+
+    @Test
+    public void testLifeCycleAddWhileRunning() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.setAttribute("key1", bean1);
+        map.start();
+
+        assertEquals(1, bean1.started.get());
+        assertEquals(0, bean2.started.get());
+
+        // Add bean2 while container is running
+        map.setAttribute("key2", bean2);
+
+        // bean2 is added as unmanaged since container is already started
+        // The bean needs to be started separately or managed explicitly
+        assertTrue(map.contains(bean2));
+    }
+
+    @Test
+    public void testNonLifeCycleAttribute() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        String stringValue = "hello";
+
+        map.setAttribute("key", stringValue);
+        assertEquals(stringValue, map.getAttribute("key"));
+
+        map.start();
+        map.stop();
+
+        // String value should still be accessible
+        assertEquals(stringValue, map.getAttribute("key"));
+    }
+
+    @Test
+    public void testToString() throws Exception
+    {
+        AttributeContainerMap map = new AttributeContainerMap();
+        map.setAttribute("key1", "value1");
+        map.setAttribute("key2", "value2");
+
+        String str = map.toString();
+        assertTrue(str.contains("size=2"));
+    }
+
+    private static class TestLifeCycle extends AbstractLifeCycle
+    {
+        private final String _name;
+        final AtomicInteger started = new AtomicInteger();
+        final AtomicInteger stopped = new AtomicInteger();
+
+        TestLifeCycle(String name)
+        {
+            _name = name;
+        }
+
+        @Override
+        protected void doStart() throws Exception
+        {
+            started.incrementAndGet();
+            super.doStart();
+        }
+
+        @Override
+        protected void doStop() throws Exception
+        {
+            stopped.incrementAndGet();
+            super.doStop();
+        }
+
+        @Override
+        public String toString()
+        {
+            return _name;
+        }
+    }
+}

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -419,8 +419,8 @@ public class ContainerLifeCycleMapTest
     private static class TestLifeCycle extends AbstractLifeCycle
     {
         private final String _name;
-        final AtomicInteger started = new AtomicInteger();
-        final AtomicInteger stopped = new AtomicInteger();
+        private final AtomicInteger started = new AtomicInteger();
+        private final AtomicInteger stopped = new AtomicInteger();
 
         TestLifeCycle(String name)
         {

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -13,17 +13,24 @@
 
 package org.eclipse.jetty.util.component;
 
+import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -355,25 +362,18 @@ public class ContainerLifeCycleMapTest
         assertTrue(map.contains(bean2));
     }
 
-    @Test
-    public void testKeySetClear() throws Exception
+    public static Stream<Arguments> clearViewSource()
     {
-        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
-        TestLifeCycle bean1 = new TestLifeCycle("bean1");
-        TestLifeCycle bean2 = new TestLifeCycle("bean2");
-
-        map.put("key1", bean1);
-        map.put("key2", bean2);
-
-        map.keySet().clear();
-
-        assertTrue(map.isEmpty());
-        assertFalse(map.contains(bean1));
-        assertFalse(map.contains(bean2));
+        return Stream.of(
+            Arguments.of("keySet", (Consumer<ContainerLifeCycleMap<String, TestLifeCycle>>)map -> map.keySet().clear()),
+            Arguments.of("values", (Consumer<ContainerLifeCycleMap<String, TestLifeCycle>>)map -> map.values().clear()),
+            Arguments.of("entrySet", (Consumer<ContainerLifeCycleMap<String, TestLifeCycle>>)map -> map.entrySet().clear())
+        );
     }
 
-    @Test
-    public void testValuesClear() throws Exception
+    @ParameterizedTest
+    @MethodSource("clearViewSource")
+    public void testClearViaView(String viewName, Consumer<ContainerLifeCycleMap<String, TestLifeCycle>> clearOp) throws Exception
     {
         ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
         TestLifeCycle bean1 = new TestLifeCycle("bean1");
@@ -382,24 +382,7 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        map.values().clear();
-
-        assertTrue(map.isEmpty());
-        assertFalse(map.contains(bean1));
-        assertFalse(map.contains(bean2));
-    }
-
-    @Test
-    public void testEntrySetClear() throws Exception
-    {
-        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
-        TestLifeCycle bean1 = new TestLifeCycle("bean1");
-        TestLifeCycle bean2 = new TestLifeCycle("bean2");
-
-        map.put("key1", bean1);
-        map.put("key2", bean2);
-
-        map.entrySet().clear();
+        clearOp.accept(map);
 
         assertTrue(map.isEmpty());
         assertFalse(map.contains(bean1));
@@ -484,6 +467,58 @@ public class ContainerLifeCycleMapTest
         assertEquals(1, bean2.stopped.get());
         assertTrue(bean1.isStopped());
         assertTrue(bean2.isStopped());
+    }
+
+    @Test
+    public void testDump() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        map.put("key1", new TestLifeCycle("bean1"));
+
+        StringWriter sw = new StringWriter();
+        map.dump(sw, "");
+        String dump = sw.toString();
+
+        assertThat(dump, containsString("key1"));
+        assertThat(dump, containsString("bean1"));
+    }
+
+    @Test
+    public void testPutWhileRunning() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        map.start();
+
+        TestLifeCycle bean = new TestLifeCycle("bean");
+        map.put("key", bean);
+
+        // Bean should be added to the map
+        assertTrue(map.containsKey("key"));
+        assertTrue(map.contains(bean));
+    }
+
+    @Test
+    public void testNullValue()
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        // Null values are allowed (HashMap behavior)
+        map.put("key", null);
+        assertTrue(map.containsKey("key"));
+        assertNull(map.get("key"));
+        // Remove returns null as the value
+        assertNull(map.remove("key"));
+        assertFalse(map.containsKey("key"));
+    }
+
+    @Test
+    public void testEntrySetContains() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean = new TestLifeCycle("bean");
+        map.put("key", bean);
+
+        Map.Entry<String, TestLifeCycle> entry = Map.entry("key", bean);
+        assertTrue(map.entrySet().contains(entry));
     }
 
     private static class TestLifeCycle extends AbstractLifeCycle

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -1,0 +1,450 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.util.component;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ContainerLifeCycleMapTest
+{
+    @Test
+    public void testPutGetRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        // Test put
+        assertNull(map.put("key1", bean1));
+        assertNull(map.put("key2", bean2));
+
+        // Test get
+        assertEquals(bean1, map.get("key1"));
+        assertEquals(bean2, map.get("key2"));
+        assertNull(map.get("nonexistent"));
+
+        // Test size
+        assertEquals(2, map.size());
+        assertFalse(map.isEmpty());
+
+        // Test containsKey/containsValue
+        assertTrue(map.containsKey("key1"));
+        assertTrue(map.containsValue(bean1));
+        assertFalse(map.containsKey("nonexistent"));
+
+        // Test remove
+        assertEquals(bean1, map.remove("key1"));
+        assertNull(map.get("key1"));
+        assertNull(map.remove("nonexistent"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testPutReplacesOldValue() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        assertNull(map.put("key", bean1));
+        assertEquals(bean1, map.put("key", bean2));
+        assertEquals(bean2, map.get("key"));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testPutAll() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        Map<String, TestLifeCycle> other = new HashMap<>();
+        other.put("key1", bean1);
+        other.put("key2", bean2);
+
+        map.putAll(other);
+
+        assertEquals(2, map.size());
+        assertEquals(bean1, map.get("key1"));
+        assertEquals(bean2, map.get("key2"));
+        assertTrue(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+    }
+
+    @Test
+    public void testClear() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        map.clear();
+
+        assertTrue(map.isEmpty());
+        assertEquals(0, map.size());
+        assertNull(map.get("key1"));
+        assertNull(map.get("key2"));
+    }
+
+    @Test
+    public void testBeanAddedOnPut() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean = new TestLifeCycle("bean");
+
+        map.put("key", bean);
+
+        // Bean should be added to the container
+        assertTrue(map.contains(bean));
+    }
+
+    @Test
+    public void testBeanRemovedOnRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean = new TestLifeCycle("bean");
+
+        map.put("key", bean);
+        assertTrue(map.contains(bean));
+
+        map.remove("key");
+        assertFalse(map.contains(bean));
+    }
+
+    @Test
+    public void testBeanReplacedOnPut() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key", bean1);
+        assertTrue(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+
+        map.put("key", bean2);
+        assertFalse(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+    }
+
+    @Test
+    public void testBeansRemovedOnClear() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+        assertTrue(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+
+        map.clear();
+        assertFalse(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testLifeCycleManagement() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        // Beans should not be started yet
+        assertEquals(0, bean1.started.get());
+        assertEquals(0, bean2.started.get());
+
+        // Start the container
+        map.start();
+
+        // Beans should now be started
+        assertEquals(1, bean1.started.get());
+        assertEquals(1, bean2.started.get());
+        assertTrue(bean1.isStarted());
+        assertTrue(bean2.isStarted());
+
+        // Stop the container
+        map.stop();
+
+        // Beans should now be stopped
+        assertEquals(1, bean1.stopped.get());
+        assertEquals(1, bean2.stopped.get());
+        assertTrue(bean1.isStopped());
+        assertTrue(bean2.isStopped());
+    }
+
+    @Test
+    public void testKeySet() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        Set<String> keys = map.keySet();
+        assertEquals(2, keys.size());
+        assertTrue(keys.contains("key1"));
+        assertTrue(keys.contains("key2"));
+    }
+
+    @Test
+    public void testKeySetRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        // Remove via keySet
+        map.keySet().remove("key1");
+
+        assertNull(map.get("key1"));
+        assertFalse(map.contains(bean1));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testKeySetIteratorRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        // Remove via keySet iterator
+        Iterator<String> iter = map.keySet().iterator();
+        while (iter.hasNext())
+        {
+            String key = iter.next();
+            if (key.equals("key1"))
+            {
+                iter.remove();
+            }
+        }
+
+        assertNull(map.get("key1"));
+        assertFalse(map.contains(bean1));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testValuesIteratorRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        // Remove via values iterator
+        Iterator<TestLifeCycle> iter = map.values().iterator();
+        while (iter.hasNext())
+        {
+            TestLifeCycle value = iter.next();
+            if (value == bean1)
+            {
+                iter.remove();
+            }
+        }
+
+        assertNull(map.get("key1"));
+        assertFalse(map.contains(bean1));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testEntrySet() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        Set<Map.Entry<String, TestLifeCycle>> entries = map.entrySet();
+        assertEquals(2, entries.size());
+    }
+
+    @Test
+    public void testEntrySetIteratorRemove() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        // Remove via entrySet iterator
+        Iterator<Map.Entry<String, TestLifeCycle>> iter = map.entrySet().iterator();
+        while (iter.hasNext())
+        {
+            Map.Entry<String, TestLifeCycle> entry = iter.next();
+            if (entry.getKey().equals("key1"))
+            {
+                iter.remove();
+            }
+        }
+
+        assertNull(map.get("key1"));
+        assertFalse(map.contains(bean1));
+        assertEquals(1, map.size());
+    }
+
+    @Test
+    public void testEntrySetValue() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+
+        // Set value via entry
+        for (Map.Entry<String, TestLifeCycle> entry : map.entrySet())
+        {
+            if (entry.getKey().equals("key1"))
+            {
+                entry.setValue(bean2);
+            }
+        }
+
+        assertEquals(bean2, map.get("key1"));
+        assertFalse(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+    }
+
+    @Test
+    public void testKeySetClear() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        map.keySet().clear();
+
+        assertTrue(map.isEmpty());
+        assertFalse(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testValuesClear() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        map.values().clear();
+
+        assertTrue(map.isEmpty());
+        assertFalse(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testEntrySetClear() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("key1", bean1);
+        map.put("key2", bean2);
+
+        map.entrySet().clear();
+
+        assertTrue(map.isEmpty());
+        assertFalse(map.contains(bean1));
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testToString() throws Exception
+    {
+        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
+        map.put("key1", new TestLifeCycle("bean1"));
+        map.put("key2", new TestLifeCycle("bean2"));
+
+        String str = map.toString();
+        assertTrue(str.contains("size=2"));
+    }
+
+    private static class TestLifeCycle extends AbstractLifeCycle
+    {
+        private final String _name;
+        final AtomicInteger started = new AtomicInteger();
+        final AtomicInteger stopped = new AtomicInteger();
+
+        TestLifeCycle(String name)
+        {
+            _name = name;
+        }
+
+        @Override
+        protected void doStart() throws Exception
+        {
+            started.incrementAndGet();
+            super.doStart();
+        }
+
+        @Override
+        protected void doStop() throws Exception
+        {
+            stopped.incrementAndGet();
+            super.doStop();
+        }
+
+        @Override
+        public String toString()
+        {
+            return _name;
+        }
+    }
+}

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 
@@ -234,33 +235,51 @@ public class ContainerLifeCycleMapTest
         assertEquals(1, map.size());
     }
 
-    @Test
-    public void testKeySetIteratorRemove() throws Exception
+    public static Stream<Arguments> iteratorRemoveSource()
     {
-        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
-        TestLifeCycle bean1 = new TestLifeCycle("bean1");
-        TestLifeCycle bean2 = new TestLifeCycle("bean2");
-
-        map.put("key1", bean1);
-        map.put("key2", bean2);
-
-        Iterator<String> iter = map.keySet().iterator();
-        while (iter.hasNext())
-        {
-            String key = iter.next();
-            if (key.equals("key1"))
+        return Stream.of(
+            Arguments.of("keySet", (BiConsumer<ContainerLifeCycleMap<String, TestLifeCycle>, TestLifeCycle>)(map, bean) ->
             {
-                iter.remove();
-            }
-        }
-
-        assertNull(map.get("key1"));
-        assertFalse(map.contains(bean1));
-        assertEquals(1, map.size());
+                Iterator<String> iter = map.keySet().iterator();
+                while (iter.hasNext())
+                {
+                    if (iter.next().equals("key1"))
+                    {
+                        iter.remove();
+                        break;
+                    }
+                }
+            }),
+            Arguments.of("values", (BiConsumer<ContainerLifeCycleMap<String, TestLifeCycle>, TestLifeCycle>)(map, bean) ->
+            {
+                Iterator<TestLifeCycle> iter = map.values().iterator();
+                while (iter.hasNext())
+                {
+                    if (iter.next() == bean)
+                    {
+                        iter.remove();
+                        break;
+                    }
+                }
+            }),
+            Arguments.of("entrySet", (BiConsumer<ContainerLifeCycleMap<String, TestLifeCycle>, TestLifeCycle>)(map, bean) ->
+            {
+                Iterator<Map.Entry<String, TestLifeCycle>> iter = map.entrySet().iterator();
+                while (iter.hasNext())
+                {
+                    if (iter.next().getKey().equals("key1"))
+                    {
+                        iter.remove();
+                        break;
+                    }
+                }
+            })
+        );
     }
 
-    @Test
-    public void testValuesIteratorRemove() throws Exception
+    @ParameterizedTest
+    @MethodSource("iteratorRemoveSource")
+    public void testIteratorRemoveViaView(String viewName, BiConsumer<ContainerLifeCycleMap<String, TestLifeCycle>, TestLifeCycle> removeOp) throws Exception
     {
         ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
         TestLifeCycle bean1 = new TestLifeCycle("bean1");
@@ -269,15 +288,7 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        Iterator<TestLifeCycle> iter = map.values().iterator();
-        while (iter.hasNext())
-        {
-            TestLifeCycle value = iter.next();
-            if (value == bean1)
-            {
-                iter.remove();
-            }
-        }
+        removeOp.accept(map, bean1);
 
         assertNull(map.get("key1"));
         assertFalse(map.contains(bean1));
@@ -296,31 +307,6 @@ public class ContainerLifeCycleMapTest
 
         Set<Map.Entry<String, TestLifeCycle>> entries = map.entrySet();
         assertEquals(2, entries.size());
-    }
-
-    @Test
-    public void testEntrySetIteratorRemove() throws Exception
-    {
-        ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
-        TestLifeCycle bean1 = new TestLifeCycle("bean1");
-        TestLifeCycle bean2 = new TestLifeCycle("bean2");
-
-        map.put("key1", bean1);
-        map.put("key2", bean2);
-
-        Iterator<Map.Entry<String, TestLifeCycle>> iter = map.entrySet().iterator();
-        while (iter.hasNext())
-        {
-            Map.Entry<String, TestLifeCycle> entry = iter.next();
-            if (entry.getKey().equals("key1"))
-            {
-                iter.remove();
-            }
-        }
-
-        assertNull(map.get("key1"));
-        assertFalse(map.contains(bean1));
-        assertEquals(1, map.size());
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -46,25 +46,20 @@ public class ContainerLifeCycleMapTest
         TestLifeCycle bean1 = new TestLifeCycle("bean1");
         TestLifeCycle bean2 = new TestLifeCycle("bean2");
 
-        // Test put
         assertNull(map.put("key1", bean1));
         assertNull(map.put("key2", bean2));
 
-        // Test get
         assertEquals(bean1, map.get("key1"));
         assertEquals(bean2, map.get("key2"));
         assertNull(map.get("nonexistent"));
 
-        // Test size
         assertEquals(2, map.size());
         assertFalse(map.isEmpty());
 
-        // Test containsKey/containsValue
         assertTrue(map.containsKey("key1"));
         assertTrue(map.containsValue(bean1));
         assertFalse(map.containsKey("nonexistent"));
 
-        // Test remove
         assertEquals(bean1, map.remove("key1"));
         assertNull(map.get("key1"));
         assertNull(map.remove("nonexistent"));
@@ -129,8 +124,6 @@ public class ContainerLifeCycleMapTest
         TestLifeCycle bean = new TestLifeCycle("bean");
 
         map.put("key", bean);
-
-        // Bean should be added to the container
         assertTrue(map.contains(bean));
     }
 
@@ -190,23 +183,18 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        // Beans should not be started yet
         assertEquals(0, bean1.started.get());
         assertEquals(0, bean2.started.get());
 
-        // Start the container
         map.start();
 
-        // Beans should now be started
         assertEquals(1, bean1.started.get());
         assertEquals(1, bean2.started.get());
         assertTrue(bean1.isStarted());
         assertTrue(bean2.isStarted());
 
-        // Stop the container
         map.stop();
 
-        // Beans should now be stopped
         assertEquals(1, bean1.stopped.get());
         assertEquals(1, bean2.stopped.get());
         assertTrue(bean1.isStopped());
@@ -239,7 +227,6 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        // Remove via keySet
         map.keySet().remove("key1");
 
         assertNull(map.get("key1"));
@@ -257,7 +244,6 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        // Remove via keySet iterator
         Iterator<String> iter = map.keySet().iterator();
         while (iter.hasNext())
         {
@@ -283,7 +269,6 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        // Remove via values iterator
         Iterator<TestLifeCycle> iter = map.values().iterator();
         while (iter.hasNext())
         {
@@ -323,7 +308,6 @@ public class ContainerLifeCycleMapTest
         map.put("key1", bean1);
         map.put("key2", bean2);
 
-        // Remove via entrySet iterator
         Iterator<Map.Entry<String, TestLifeCycle>> iter = map.entrySet().iterator();
         while (iter.hasNext())
         {
@@ -348,7 +332,6 @@ public class ContainerLifeCycleMapTest
 
         map.put("key1", bean1);
 
-        // Set value via entry
         for (Map.Entry<String, TestLifeCycle> entry : map.entrySet())
         {
             if (entry.getKey().equals("key1"))
@@ -410,24 +393,20 @@ public class ContainerLifeCycleMapTest
         TestLifeCycle bean1 = new TestLifeCycle("bean1");
         TestLifeCycle bean2 = new TestLifeCycle("bean2");
 
-        // Put with lowercase key
         map.put("gzip", bean1);
 
-        // Get with different case should work
         assertEquals(bean1, map.get("GZIP"));
         assertEquals(bean1, map.get("Gzip"));
         assertEquals(bean1, map.get("gzip"));
         assertTrue(map.containsKey("GZIP"));
         assertTrue(map.containsKey("gzip"));
 
-        // Put with different case should replace
         map.put("GZIP", bean2);
         assertEquals(1, map.size());
         assertEquals(bean2, map.get("gzip"));
         assertFalse(map.contains(bean1));
         assertTrue(map.contains(bean2));
 
-        // Remove with different case should work
         assertEquals(bean2, map.remove("Gzip"));
         assertTrue(map.isEmpty());
         assertFalse(map.contains(bean2));
@@ -436,7 +415,6 @@ public class ContainerLifeCycleMapTest
     @Test
     public void testCustomMapLifeCycleManagement() throws Exception
     {
-        // Use a TreeMap with case-insensitive key ordering
         ContainerLifeCycleMap<String, TestLifeCycle> map =
             new ContainerLifeCycleMap<>(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
 
@@ -446,23 +424,18 @@ public class ContainerLifeCycleMapTest
         map.put("encoding1", bean1);
         map.put("encoding2", bean2);
 
-        // Beans should be added as managed beans
         assertTrue(map.contains(bean1));
         assertTrue(map.contains(bean2));
 
-        // Start the container
         map.start();
 
-        // Beans should now be started
         assertEquals(1, bean1.started.get());
         assertEquals(1, bean2.started.get());
         assertTrue(bean1.isStarted());
         assertTrue(bean2.isStarted());
 
-        // Stop the container
         map.stop();
 
-        // Beans should now be stopped
         assertEquals(1, bean1.stopped.get());
         assertEquals(1, bean2.stopped.get());
         assertTrue(bean1.isStopped());
@@ -492,7 +465,6 @@ public class ContainerLifeCycleMapTest
         TestLifeCycle bean = new TestLifeCycle("bean");
         map.put("key", bean);
 
-        // Bean should be added to the map
         assertTrue(map.containsKey("key"));
         assertTrue(map.contains(bean));
     }
@@ -501,11 +473,9 @@ public class ContainerLifeCycleMapTest
     public void testNullValue()
     {
         ContainerLifeCycleMap<String, TestLifeCycle> map = new ContainerLifeCycleMap<>();
-        // Null values are allowed (HashMap behavior)
         map.put("key", null);
         assertTrue(map.containsKey("key"));
         assertNull(map.get("key"));
-        // Remove returns null as the value
         assertNull(map.remove("key"));
         assertFalse(map.containsKey("key"));
     }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/ContainerLifeCycleMapTest.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
@@ -414,6 +415,75 @@ public class ContainerLifeCycleMapTest
 
         String str = map.toString();
         assertTrue(str.contains("size=2"));
+    }
+
+    @Test
+    public void testCustomMapCaseInsensitive() throws Exception
+    {
+        // Use a TreeMap with case-insensitive key ordering
+        ContainerLifeCycleMap<String, TestLifeCycle> map =
+            new ContainerLifeCycleMap<>(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        // Put with lowercase key
+        map.put("gzip", bean1);
+
+        // Get with different case should work
+        assertEquals(bean1, map.get("GZIP"));
+        assertEquals(bean1, map.get("Gzip"));
+        assertEquals(bean1, map.get("gzip"));
+        assertTrue(map.containsKey("GZIP"));
+        assertTrue(map.containsKey("gzip"));
+
+        // Put with different case should replace
+        map.put("GZIP", bean2);
+        assertEquals(1, map.size());
+        assertEquals(bean2, map.get("gzip"));
+        assertFalse(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+
+        // Remove with different case should work
+        assertEquals(bean2, map.remove("Gzip"));
+        assertTrue(map.isEmpty());
+        assertFalse(map.contains(bean2));
+    }
+
+    @Test
+    public void testCustomMapLifeCycleManagement() throws Exception
+    {
+        // Use a TreeMap with case-insensitive key ordering
+        ContainerLifeCycleMap<String, TestLifeCycle> map =
+            new ContainerLifeCycleMap<>(new TreeMap<>(String.CASE_INSENSITIVE_ORDER));
+
+        TestLifeCycle bean1 = new TestLifeCycle("bean1");
+        TestLifeCycle bean2 = new TestLifeCycle("bean2");
+
+        map.put("encoding1", bean1);
+        map.put("encoding2", bean2);
+
+        // Beans should be added as managed beans
+        assertTrue(map.contains(bean1));
+        assertTrue(map.contains(bean2));
+
+        // Start the container
+        map.start();
+
+        // Beans should now be started
+        assertEquals(1, bean1.started.get());
+        assertEquals(1, bean2.started.get());
+        assertTrue(bean1.isStarted());
+        assertTrue(bean2.isStarted());
+
+        // Stop the container
+        map.stop();
+
+        // Beans should now be stopped
+        assertEquals(1, bean1.stopped.get());
+        assertEquals(1, bean2.stopped.get());
+        assertTrue(bean1.isStopped());
+        assertTrue(bean2.isStopped());
     }
 
     private static class TestLifeCycle extends AbstractLifeCycle


### PR DESCRIPTION
  Fixes #13647

- Add `ContainerLifeCycleMap<K, V extends LifeCycle>` that implements `Map` while managing values as beans
- Values are automatically started/stopped with the container lifecycle
- Removal through `keySet()`, `values()`, `entrySet()` views also unregisters beans
- Add missing tests for `AttributeContainerMap`
- Update bean.adoc with documentation for both classes