### PR TITLE
Issue #9987 - Document how to use virtual KeyStores

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.security.KeyStore;
 import java.security.Security;
 import java.time.Duration;
 import java.util.List;
@@ -2195,5 +2196,51 @@ public class HTTPServerDocs
         server.setHandler(reverseProxy);
         server.start();
         // end::proxyReverseLoadBalancer[]
+    }
+
+    public void virtualKeyStore() throws Exception
+    {
+        // tag::virtualKeyStore[]
+        Server server = new Server();
+
+        // The HTTP configuration object.
+        HttpConfiguration httpConfig = new HttpConfiguration();
+        // Add the SecureRequestCustomizer because TLS is used.
+        httpConfig.addCustomizer(new SecureRequestCustomizer());
+
+        // The ConnectionFactory for HTTP/1.1.
+        HttpConnectionFactory http11 = new HttpConnectionFactory(httpConfig);
+
+        // Configure the SslContextFactory for a virtual keystore.
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+
+        // Specify the keystore type and provider for the virtual keystore.
+        // For Windows Certificate Store, use "Windows-MY" type and "SunMSCAPI" provider.
+        String keystoreType = "Windows-MY";
+        String keystoreProvider = "SunMSCAPI";
+        sslContextFactory.setKeyStoreType(keystoreType);
+        sslContextFactory.setKeyStoreProvider(keystoreProvider);
+
+        // Manually load the virtual keystore.
+        // Virtual keystores don't read from a file, so pass null to load().
+        KeyStore keyStore = KeyStore.getInstance(keystoreType, keystoreProvider);
+        keyStore.load(null, null);
+
+        // Pass the loaded keystore to SslContextFactory.
+        sslContextFactory.setKeyStore(keyStore);
+
+        // Optionally, configure the certificate alias if multiple certificates exist.
+        // sslContextFactory.setCertAlias("my-certificate-alias");
+
+        // The ConnectionFactory for TLS.
+        SslConnectionFactory tls = new SslConnectionFactory(sslContextFactory, http11.getProtocol());
+
+        // The ServerConnector instance.
+        ServerConnector connector = new ServerConnector(server, tls, http11);
+        connector.setPort(8443);
+
+        server.addConnector(connector);
+        server.start();
+        // end::virtualKeyStore[]
     }
 }

--- a/documentation/jetty/modules/operations-guide/pages/keystore/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/keystore/index.adoc
@@ -272,3 +272,64 @@ Now you can distribute `client_keystore.p12` to your client(s).
 // TODO: add a section about renewal?
 
 Refer to the section about configuring xref:protocols/index.adoc#ssl[secure protocols] to configure the secure connector to require client authentication.
+
+[[virtual]]
+== Using Virtual KeyStores
+
+Virtual KeyStores are keystores that do not have a backing file on the filesystem.
+Instead, they are managed by the operating system or by specialized hardware, and are accessed through a Java Security Provider.
+
+Examples of virtual keystores include the Windows Certificate Store, PKCS11 hardware security modules (HSMs) and smartcards, and the macOS Keychain.
+
+=== Common Virtual KeyStore Types
+
+[cols="1,1,2"]
+|===
+|Type |Provider |Description
+
+|`Windows-MY`
+|`SunMSCAPI`
+|Windows personal certificate store (current user)
+
+|`Windows-ROOT`
+|`SunMSCAPI`
+|Windows root certificate store
+
+|`PKCS11`
+|`SunPKCS11`
+|Hardware security modules and smartcards
+
+|`KeychainStore`
+|`Apple`
+|macOS Keychain
+|===
+
+=== Configuring Virtual KeyStores
+
+Virtual keystores require programmatic configuration because Jetty's `SslContextFactory` cannot load them from a file path.
+You must manually instantiate and load the `KeyStore`, then pass it to `SslContextFactory`.
+
+The following example shows how to configure a server to use the Windows Certificate Store:
+
+[,java,indent=0]
+----
+include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=virtualKeyStore]
+----
+
+The key steps are:
+
+. Create the `SslContextFactory.Server` instance.
+. Set the keystore type and provider to match the virtual keystore.
+. Instantiate the `KeyStore` using `KeyStore.getInstance(type, provider)`.
+. Load the keystore by calling `load(null, null)` -- virtual keystores do not read from an `InputStream`.
+. Pass the loaded `KeyStore` to `SslContextFactory` using `setKeyStore()`.
+
+=== Important Considerations
+
+* Virtual keystores may require platform-specific security permissions.
+* Some virtual keystores (like Windows certificate stores) may prompt for user authentication when accessing private keys.
+* The `SunMSCAPI` provider on Windows only supports RSA-based cipher suites; other algorithms like ECDSA may not be available.
+* PKCS11 keystores require additional configuration via a provider configuration file.
+* Consider the security implications and limitations of each provider before deploying to production.
+
+For more details on Java security providers and keystore types, refer to the https://docs.oracle.com/en/java/javase/17/security/java-cryptography-architecture-jca-reference-guide.html[Java Cryptography Architecture (JCA) Reference Guide].

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -467,6 +467,8 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/ht
 
 You can customize the SSL/TLS provider as explained in <<connector-protocol-tls-conscrypt,this section>>.
 
+If you need to use a virtual KeyStore (such as the Windows Certificate Store, PKCS11 hardware security modules, or macOS Keychain), refer to xref:operations-guide:keystore/index.adoc#virtual[this section].
+
 [[connector-protocol-http2]]
 ==== Clear-Text HTTP/2
 
@@ -512,6 +514,7 @@ The fact that the HTTP/2 protocol comes before the HTTP/1.1 protocol indicates t
 Note also that the default protocol set in the ALPN ``ConnectionFactory``, which is used in case ALPN is not supported by the client, is HTTP/1.1 -- if the client does not support ALPN is probably an old client so HTTP/1.1 is the safest choice.
 
 You can customize the SSL/TLS provider as explained in <<connector-protocol-tls-conscrypt,this section>>.
+If you need to use a virtual KeyStore (such as the Windows Certificate Store, PKCS11 hardware security modules, or macOS Keychain), refer to xref:operations-guide:keystore/index.adoc#virtual[this section].
 
 [[connector-protocol-http3]]
 ==== HTTP/3


### PR DESCRIPTION
  Fixes #9987
  Fixes #9977
  
- Add documentation for using virtual KeyStores (keystores without file backing) with Jetty's SslContextFactory
- Document common virtual keystore types: Windows-MY, Windows-ROOT, PKCS11, KeychainStore
- Add example code showing how to manually load and configure a virtual keystore
- Add cross-references from the programming guide to the new documentation

