### PR TITLE
Issue #4184 - Add TabularData support to ConnectionStatisticsMBean

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/arch/io.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/arch/io.adoc
@@ -166,6 +166,9 @@ You can add as beans many `Connection.Listener` objects, each with its own logic
 
 The Jetty I/O library provides useful `Connection.Listener` implementations that you should evaluate before writing your own, for example link:{javadoc-url}/org/eclipse/jetty/io/ConnectionStatistics.html[`ConnectionStatistics`].
 
+`ConnectionStatistics` exposes its statistics via JMX.
+The `ConnectionStatisticsAsTabularData` attribute provides per-connection-class statistics as JMX `TabularData`, allowing JMX clients to display structured data with columns for connection counts, bytes transferred, messages transferred, and connection durations.
+
 Here is a simple example of a `Connection.Listener` used both on the client and on the server:
 
 [,java,indent=0]

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/jmx/ConnectionStatisticsMBean.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/jmx/ConnectionStatisticsMBean.java
@@ -17,6 +17,15 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.stream.Collectors;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
 
 import org.eclipse.jetty.io.ConnectionStatistics;
 import org.eclipse.jetty.jmx.ObjectMBean;
@@ -26,6 +35,77 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 @ManagedObject
 public class ConnectionStatisticsMBean extends ObjectMBean
 {
+    private static final String[] ITEM_NAMES = new String[]{
+        "name",
+        "connections",
+        "connectionsTotal",
+        "connectionsMax",
+        "connectionDurationMax",
+        "connectionDurationMean",
+        "connectionDurationStdDev",
+        "bytesIn",
+        "bytesOut",
+        "messagesIn",
+        "messagesOut"
+    };
+
+    private static final String[] ITEM_DESCRIPTIONS = new String[]{
+        "Connection class name",
+        "Current open connections",
+        "Total connections opened",
+        "Max concurrent connections",
+        "Max connection duration (ms)",
+        "Mean connection duration (ms)",
+        "Connection duration standard deviation",
+        "Total bytes received",
+        "Total bytes sent",
+        "Total messages received",
+        "Total messages sent"
+    };
+
+    @SuppressWarnings("rawtypes")
+    private static final OpenType[] ITEM_TYPES = new OpenType[]{
+        SimpleType.STRING,
+        SimpleType.LONG,
+        SimpleType.LONG,
+        SimpleType.LONG,
+        SimpleType.LONG,
+        SimpleType.DOUBLE,
+        SimpleType.DOUBLE,
+        SimpleType.LONG,
+        SimpleType.LONG,
+        SimpleType.LONG,
+        SimpleType.LONG
+    };
+
+    private static final CompositeType STATS_TYPE;
+    private static final TabularType STATS_TABLE_TYPE;
+
+    static
+    {
+        try
+        {
+            STATS_TYPE = new CompositeType(
+                "ConnectionStats",
+                "Connection statistics for a connection class",
+                ITEM_NAMES,
+                ITEM_DESCRIPTIONS,
+                ITEM_TYPES
+            );
+
+            STATS_TABLE_TYPE = new TabularType(
+                "ConnectionStatisticsTable",
+                "Table of connection statistics by connection class",
+                STATS_TYPE,
+                new String[]{"name"}
+            );
+        }
+        catch (OpenDataException e)
+        {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
     public ConnectionStatisticsMBean(Object object)
     {
         super(object);
@@ -41,5 +121,36 @@ public class ConnectionStatisticsMBean extends ObjectMBean
             .map(stats -> stats.dump())
             .map(dump -> dump.replaceAll("[\r\n]", " "))
             .collect(Collectors.toList());
+    }
+
+    @ManagedAttribute("ConnectionStatistics grouped by connection class as TabularData")
+    public TabularData getConnectionStatisticsAsTabularData() throws OpenDataException
+    {
+        ConnectionStatistics delegate = (ConnectionStatistics)getManagedObject();
+        Map<String, ConnectionStatistics.Stats> groups = delegate.getConnectionStatisticsGroups();
+
+        TabularDataSupport table = new TabularDataSupport(STATS_TABLE_TYPE);
+        for (ConnectionStatistics.Stats stats : groups.values())
+        {
+            CompositeData row = new CompositeDataSupport(
+                STATS_TYPE,
+                ITEM_NAMES,
+                new Object[]{
+                    stats.getName(),
+                    stats.getConnections(),
+                    stats.getConnectionsTotal(),
+                    stats.getConnectionsMax(),
+                    stats.getConnectionDurationMax(),
+                    stats.getConnectionDurationMean(),
+                    stats.getConnectionDurationStdDev(),
+                    stats.getReceivedBytes(),
+                    stats.getSentBytes(),
+                    stats.getReceivedMessages(),
+                    stats.getSentMessages()
+                }
+            );
+            table.put(row);
+        }
+        return table;
     }
 }

--- a/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/jmx/ConnectionStatisticsMBeanTest.java
+++ b/jetty-core/jetty-io/src/test/java/org/eclipse/jetty/io/jmx/ConnectionStatisticsMBeanTest.java
@@ -1,0 +1,202 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.io.jmx;
+
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
+
+import org.eclipse.jetty.io.ByteArrayEndPoint;
+import org.eclipse.jetty.io.Connection;
+import org.eclipse.jetty.io.ConnectionStatistics;
+import org.eclipse.jetty.io.EndPoint;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class ConnectionStatisticsMBeanTest
+{
+    @Test
+    public void testGetConnectionStatisticsAsTabularData() throws Exception
+    {
+        ConnectionStatistics statistics = new ConnectionStatistics();
+        statistics.start();
+
+        // Simulate a connection being opened and closed
+        EndPoint endPoint = new ByteArrayEndPoint();
+        TestConnection connection = new TestConnection(endPoint);
+        connection.setBytesIn(1024);
+        connection.setBytesOut(2048);
+        connection.setMessagesIn(10);
+        connection.setMessagesOut(20);
+
+        statistics.onOpened(connection);
+        statistics.onClosed(connection);
+
+        // Create the MBean and get TabularData
+        ConnectionStatisticsMBean mbean = new ConnectionStatisticsMBean(statistics);
+        TabularData tabularData = mbean.getConnectionStatisticsAsTabularData();
+
+        assertThat(tabularData, is(notNullValue()));
+        assertThat(tabularData.size(), is(1));
+
+        // Get the row for the test connection class
+        Collection<?> values = tabularData.values();
+        CompositeData row = (CompositeData)values.iterator().next();
+
+        assertThat(row.get("name"), is(TestConnection.class.getName()));
+        assertThat((Long)row.get("connectionsTotal"), is(1L));
+        assertThat((Long)row.get("bytesIn"), is(1024L));
+        assertThat((Long)row.get("bytesOut"), is(2048L));
+        assertThat((Long)row.get("messagesIn"), is(10L));
+        assertThat((Long)row.get("messagesOut"), is(20L));
+        assertThat((Long)row.get("connectionDurationMax"), is(greaterThanOrEqualTo(0L)));
+
+        statistics.stop();
+    }
+
+    @Test
+    public void testGetConnectionStatisticsGroups() throws Exception
+    {
+        ConnectionStatistics statistics = new ConnectionStatistics();
+        statistics.start();
+
+        EndPoint endPoint = new ByteArrayEndPoint();
+        TestConnection connection = new TestConnection(endPoint);
+        connection.setBytesIn(512);
+        connection.setBytesOut(1024);
+
+        statistics.onOpened(connection);
+        statistics.onClosed(connection);
+
+        ConnectionStatisticsMBean mbean = new ConnectionStatisticsMBean(statistics);
+        Collection<String> groups = mbean.getConnectionStatisticsGroups();
+
+        assertThat(groups, is(notNullValue()));
+        assertThat(groups.size(), is(1));
+
+        String group = groups.iterator().next();
+        assertThat(group.contains(TestConnection.class.getName()), is(true));
+
+        statistics.stop();
+    }
+
+    // Simple test connection implementation
+    private static class TestConnection implements Connection
+    {
+        private final EndPoint endPoint;
+        private final long createdTime;
+        private long bytesIn;
+        private long bytesOut;
+        private long messagesIn;
+        private long messagesOut;
+
+        TestConnection(EndPoint endPoint)
+        {
+            this.endPoint = endPoint;
+            this.createdTime = System.currentTimeMillis();
+        }
+
+        void setBytesIn(long bytesIn)
+        {
+            this.bytesIn = bytesIn;
+        }
+
+        void setBytesOut(long bytesOut)
+        {
+            this.bytesOut = bytesOut;
+        }
+
+        void setMessagesIn(long messagesIn)
+        {
+            this.messagesIn = messagesIn;
+        }
+
+        void setMessagesOut(long messagesOut)
+        {
+            this.messagesOut = messagesOut;
+        }
+
+        @Override
+        public void addEventListener(java.util.EventListener listener)
+        {
+        }
+
+        @Override
+        public void removeEventListener(java.util.EventListener listener)
+        {
+        }
+
+        @Override
+        public void onOpen()
+        {
+        }
+
+        @Override
+        public void onClose(Throwable cause)
+        {
+        }
+
+        @Override
+        public EndPoint getEndPoint()
+        {
+            return endPoint;
+        }
+
+        @Override
+        public void close()
+        {
+        }
+
+        @Override
+        public boolean onIdleExpired(TimeoutException timeoutException)
+        {
+            return false;
+        }
+
+        @Override
+        public long getCreatedTimeStamp()
+        {
+            return createdTime;
+        }
+
+        @Override
+        public long getBytesIn()
+        {
+            return bytesIn;
+        }
+
+        @Override
+        public long getBytesOut()
+        {
+            return bytesOut;
+        }
+
+        @Override
+        public long getMessagesIn()
+        {
+            return messagesIn;
+        }
+
+        @Override
+        public long getMessagesOut()
+        {
+            return messagesOut;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4184

- Add `ConnectionStatisticsAsTabularData` JMX attribute using open types (TabularData/CompositeData) so JMX clients can display per-protocol stats as a table instead of formatted strings.
- Keep `ConnectionStatisticsGroups` attribute for backward compatibility.
