### PR TITLE
Issue #13961 - Fix duplicate Server and Date headers in ProxyHandler

### DIFF
--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -89,15 +89,6 @@ public abstract class ProxyHandler extends Handler.Abstract
         HttpHeader.TRAILER,
         HttpHeader.UPGRADE
     );
-    private static final EnumSet<HttpHeader> SINGLE_VALUE_HEADERS = EnumSet.of(
-        HttpHeader.CONTENT_LENGTH,
-        HttpHeader.CONTENT_TYPE,
-        HttpHeader.DATE,
-        HttpHeader.ETAG,
-        HttpHeader.LOCATION,
-        HttpHeader.SERVER
-    );
-
     private HttpClient httpClient;
     private String proxyToServerHost;
     private String viaHost;
@@ -355,7 +346,7 @@ public abstract class ProxyHandler extends Handler.Abstract
             if (headersToRemove != null && headersToRemove.contains(clientToProxyRequestField.getLowerCaseName()))
                 continue;
 
-            proxyToServerRequest.headers(headers -> headers.add(clientToProxyRequestField));
+            proxyToServerRequest.headers(headers -> headers.put(clientToProxyRequestField));
         }
     }
 
@@ -697,12 +688,7 @@ public abstract class ProxyHandler extends Handler.Abstract
                 HttpField newField = filterServerToProxyResponseField(serverToProxyResponseField);
                 if (newField == null)
                     continue;
-                // Use put() for single-value headers to avoid duplicates when both
-                // the proxy and backend server add these headers.
-                if (SINGLE_VALUE_HEADERS.contains(newField.getHeader()))
-                    proxyToClientResponse.getHeaders().put(newField);
-                else
-                    proxyToClientResponse.getHeaders().add(newField);
+                proxyToClientResponse.getHeaders().put(newField);
             }
             if (LOG.isDebugEnabled())
             {

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -689,7 +689,13 @@ public abstract class ProxyHandler extends Handler.Abstract
                 HttpField newField = filterServerToProxyResponseField(serverToProxyResponseField);
                 if (newField == null)
                     continue;
-                proxyToClientResponse.getHeaders().add(newField);
+                // Use put() for single-value headers to avoid duplicates when both
+                // the proxy and backend server add these headers.
+                HttpHeader header = newField.getHeader();
+                if (header == HttpHeader.SERVER || header == HttpHeader.DATE)
+                    proxyToClientResponse.getHeaders().put(newField);
+                else
+                    proxyToClientResponse.getHeaders().add(newField);
             }
             if (LOG.isDebugEnabled())
             {

--- a/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
+++ b/jetty-core/jetty-proxy/src/main/java/org/eclipse/jetty/proxy/ProxyHandler.java
@@ -89,6 +89,14 @@ public abstract class ProxyHandler extends Handler.Abstract
         HttpHeader.TRAILER,
         HttpHeader.UPGRADE
     );
+    private static final EnumSet<HttpHeader> SINGLE_VALUE_HEADERS = EnumSet.of(
+        HttpHeader.CONTENT_LENGTH,
+        HttpHeader.CONTENT_TYPE,
+        HttpHeader.DATE,
+        HttpHeader.ETAG,
+        HttpHeader.LOCATION,
+        HttpHeader.SERVER
+    );
 
     private HttpClient httpClient;
     private String proxyToServerHost;
@@ -691,8 +699,7 @@ public abstract class ProxyHandler extends Handler.Abstract
                     continue;
                 // Use put() for single-value headers to avoid duplicates when both
                 // the proxy and backend server add these headers.
-                HttpHeader header = newField.getHeader();
-                if (header == HttpHeader.SERVER || header == HttpHeader.DATE)
+                if (SINGLE_VALUE_HEADERS.contains(newField.getHeader()))
                     proxyToClientResponse.getHeaders().put(newField);
                 else
                     proxyToClientResponse.getHeaders().add(newField);

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AbstractProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AbstractProxyTest.java
@@ -70,8 +70,8 @@ public class AbstractProxyTest
         QueuedThreadPool proxyPool = new QueuedThreadPool();
         proxyPool.setName("proxy");
         proxy = new Server(proxyPool);
-        proxyHttpConfig.setSendDateHeader(false);
-        proxyHttpConfig.setSendServerVersion(false);
+        // Note: Individual tests can configure proxyHttpConfig.setSendDateHeader()
+        // and proxyHttpConfig.setSendServerVersion() before calling startProxy().
         proxyConnector = new ServerConnector(proxy, 1, 1, new HttpConnectionFactory(proxyHttpConfig), new HTTP2CServerConnectionFactory(proxyHttpConfig));
         proxy.addConnector(proxyConnector);
         proxy.setHandler(handler);

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AbstractProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/AbstractProxyTest.java
@@ -70,8 +70,6 @@ public class AbstractProxyTest
         QueuedThreadPool proxyPool = new QueuedThreadPool();
         proxyPool.setName("proxy");
         proxy = new Server(proxyPool);
-        // Note: Individual tests can configure proxyHttpConfig.setSendDateHeader()
-        // and proxyHttpConfig.setSendServerVersion() before calling startProxy().
         proxyConnector = new ServerConnector(proxy, 1, 1, new HttpConnectionFactory(proxyHttpConfig), new HTTP2CServerConnectionFactory(proxyHttpConfig));
         proxy.addConnector(proxyConnector);
         proxy.setHandler(handler);

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -59,12 +59,33 @@ public class ReverseProxyTest extends AbstractProxyTest
         );
     }
 
+    public static Stream<Arguments> httpVersionsThreadPoolsAndHeaders()
+    {
+        return Stream.of(
+            // Without server headers on proxy (original behavior)
+            Arguments.of(HttpVersion.HTTP_1_1, false, false),
+            Arguments.of(HttpVersion.HTTP_1_1, true, false),
+            Arguments.of(HttpVersion.HTTP_2, false, false),
+            Arguments.of(HttpVersion.HTTP_2, true, false),
+            // With server headers enabled on both backend and proxy (tests issue #13961 fix)
+            Arguments.of(HttpVersion.HTTP_1_1, false, true),
+            Arguments.of(HttpVersion.HTTP_1_1, true, true),
+            Arguments.of(HttpVersion.HTTP_2, false, true),
+            Arguments.of(HttpVersion.HTTP_2, true, true)
+        );
+    }
+
     @ParameterizedTest
-    @MethodSource("httpVersionsAndThreadPools")
-    public void testSimple(HttpVersion httpVersion, boolean useServerThreadPool) throws Exception
+    @MethodSource("httpVersionsThreadPoolsAndHeaders")
+    public void testSimple(HttpVersion httpVersion, boolean useServerThreadPool, boolean sendServerHeaders) throws Exception
     {
         String clientContent = "hello";
         String serverContent = "world";
+
+        // Enable headers on backend server (default, but explicit for clarity).
+        serverHttpConfig.setSendServerVersion(true);
+        serverHttpConfig.setSendDateHeader(true);
+
         startServer(new Handler.Abstract()
         {
             @Override
@@ -76,6 +97,10 @@ public class ReverseProxyTest extends AbstractProxyTest
                 return true;
             }
         });
+
+        // Configure proxy headers based on parameter.
+        proxyHttpConfig.setSendServerVersion(sendServerHeaders);
+        proxyHttpConfig.setSendDateHeader(sendServerHeaders);
 
         ProxyHandler.Reverse proxyHandler = new ProxyHandler.Reverse(clientToProxyRequest ->
             HttpURI.build(clientToProxyRequest.getHttpURI()).port(serverConnector.getLocalPort()))
@@ -105,6 +130,12 @@ public class ReverseProxyTest extends AbstractProxyTest
             .timeout(5, TimeUnit.SECONDS)
             .send();
         assertEquals(serverContent, response.getContentAsString());
+
+        // Verify no duplicate headers (issue #13961).
+        assertTrue(response.getHeaders().getValuesList("Server").size() <= 1,
+            "Should have at most one Server header");
+        assertTrue(response.getHeaders().getValuesList("Date").size() <= 1,
+            "Should have at most one Date header");
     }
 
     @ParameterizedTest

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -82,7 +82,6 @@ public class ReverseProxyTest extends AbstractProxyTest
         String clientContent = "hello";
         String serverContent = "world";
 
-        // Enable headers on backend server (default, but explicit for clarity).
         serverHttpConfig.setSendServerVersion(true);
         serverHttpConfig.setSendDateHeader(true);
 
@@ -98,7 +97,6 @@ public class ReverseProxyTest extends AbstractProxyTest
             }
         });
 
-        // Configure proxy headers based on parameter.
         proxyHttpConfig.setSendServerVersion(sendServerHeaders);
         proxyHttpConfig.setSendDateHeader(sendServerHeaders);
 
@@ -131,7 +129,6 @@ public class ReverseProxyTest extends AbstractProxyTest
             .send();
         assertEquals(serverContent, response.getContentAsString());
 
-        // Verify no duplicate headers.
         assertTrue(response.getHeaders().getValuesList("Server").size() <= 1,
             "Should have at most one Server header");
         assertTrue(response.getHeaders().getValuesList("Date").size() <= 1,

--- a/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
+++ b/jetty-core/jetty-proxy/src/test/java/org/eclipse/jetty/proxy/ReverseProxyTest.java
@@ -62,12 +62,12 @@ public class ReverseProxyTest extends AbstractProxyTest
     public static Stream<Arguments> httpVersionsThreadPoolsAndHeaders()
     {
         return Stream.of(
-            // Without server headers on proxy (original behavior)
+            // Without server headers on proxy
             Arguments.of(HttpVersion.HTTP_1_1, false, false),
             Arguments.of(HttpVersion.HTTP_1_1, true, false),
             Arguments.of(HttpVersion.HTTP_2, false, false),
             Arguments.of(HttpVersion.HTTP_2, true, false),
-            // With server headers enabled on both backend and proxy (tests issue #13961 fix)
+            // With server headers enabled on both backend and proxy
             Arguments.of(HttpVersion.HTTP_1_1, false, true),
             Arguments.of(HttpVersion.HTTP_1_1, true, true),
             Arguments.of(HttpVersion.HTTP_2, false, true),
@@ -131,7 +131,7 @@ public class ReverseProxyTest extends AbstractProxyTest
             .send();
         assertEquals(serverContent, response.getContentAsString());
 
-        // Verify no duplicate headers (issue #13961).
+        // Verify no duplicate headers.
         assertTrue(response.getHeaders().getValuesList("Server").size() <= 1,
             "Should have at most one Server header");
         assertTrue(response.getHeaders().getValuesList("Date").size() <= 1,


### PR DESCRIPTION
Fixes #13961                                                                                                                                
Related to #577                                                                                                                             
                                                                                                                                              
When both the backend server and proxy have `sendServerVersion` and `sendDateHeader` enabled (the defaults), `ProxyHandler` produces RFC-violating responses with duplicate `Server` and `Date` headers, because `add()` appends without checking for existing values.           
                                                                                                                                              
The fix uses `put()` instead of `add()` when copying headers in both `copyRequestHeaders()` and `ProxyResponseListener.onHeaders()`. In the default configuration the proxy will override what the backend sent; disabling those headers on the proxy will relay the backend's values to the client.
