### PR TITLE
Issue #11765 - Introduce EventSourceHandler for Server-Sent Events in jetty-core

### DIFF
--- a/documentation/jetty/modules/programming-guide/nav.adoc
+++ b/documentation/jetty/modules/programming-guide/nav.adoc
@@ -27,6 +27,7 @@
 ** xref:server/session.adoc[]
 ** xref:server/deploy.adoc[]
 ** xref:server/websocket.adoc[]
+** xref:server/server-sent-events.adoc[]
 ** xref:server/fastcgi.adoc[]
 ** xref:server/io-arch.adoc[]
 ** xref:server/threads.adoc[]

--- a/documentation/jetty/modules/programming-guide/pages/server/server-sent-events.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/server-sent-events.adoc
@@ -1,0 +1,267 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+= Server-Sent Events
+
+Server-Sent Events (SSE) is a web technology that enables servers to push data to clients over a standard HTTP connection.
+SSE uses the `text/event-stream` content type and provides a unidirectional communication channel from server to client.
+
+== When to Use SSE
+
+SSE is ideal for:
+
+* Real-time notifications and alerts
+* Live feeds (news, social media, stock prices)
+* Server-side progress updates
+* Any scenario where the server needs to push updates to the client
+
+=== SSE vs WebSocket
+
+[cols="1,1,1"]
+|===
+| Feature | SSE | WebSocket
+
+| Direction
+| Unidirectional (server to client)
+| Bidirectional
+
+| Protocol
+| HTTP
+| WebSocket (upgrade from HTTP)
+
+| Reconnection
+| Automatic browser reconnection
+| Manual reconnection required
+
+| Data format
+| Text-based
+| Text or binary
+
+| Browser support
+| Native `EventSource` API
+| Native `WebSocket` API
+|===
+
+Choose SSE when you only need server-to-client communication.
+Choose WebSocket when you need bidirectional communication.
+
+== Using EventSourceHandler in Jetty Core
+
+The `EventSourceHandler` class provides SSE support in Jetty Core applications without requiring the Servlet API.
+
+=== Basic Usage
+
+[,java]
+----
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.handler.EventSourceHandler;
+
+Server server = new Server();
+ServerConnector connector = new ServerConnector(server);
+connector.setPort(8080);
+server.addConnector(connector);
+
+EventSourceHandler eventSourceHandler = new EventSourceHandler()
+{
+    @Override
+    protected EventSource newEventSource(Request request)
+    {
+        return new EventSource()
+        {
+            private Emitter emitter;
+
+            @Override
+            public void onOpen(Emitter emitter)
+            {
+                this.emitter = emitter;
+                // Store emitter for later use to send events
+            }
+
+            @Override
+            public void onClose()
+            {
+                // Clean up resources when connection closes
+            }
+        };
+    }
+};
+
+server.setHandler(eventSourceHandler);
+server.start();
+----
+
+=== Sending Events
+
+The `Emitter` interface provides methods to send data to the client:
+
+[,java]
+----
+// Send a data-only event
+emitter.data("Hello, World!");
+// Client receives: data: Hello, World!
+
+// Send a named event with data
+emitter.event("notification", "You have a new message");
+// Client receives:
+// event: notification
+// data: You have a new message
+
+// Send a comment (not dispatched as an event, useful for keep-alive)
+emitter.comment("keep-alive");
+// Client receives: : keep-alive
+
+// Close the connection
+emitter.close();
+----
+
+=== Multiline Data
+
+When sending multiline data, each line is prefixed with `data:`:
+
+[,java]
+----
+emitter.data("line1\nline2\nline3");
+// Client receives:
+// data: line1
+// data: line2
+// data: line3
+----
+
+=== Configuration
+
+The `EventSourceHandler` supports configuration of the heartbeat period:
+
+[,java]
+----
+EventSourceHandler handler = new EventSourceHandler()
+{
+    @Override
+    protected EventSource newEventSource(Request request)
+    {
+        // ...
+    }
+};
+
+// Set heartbeat period (default is 10 seconds)
+handler.setHeartBeatPeriod(Duration.ofSeconds(30));
+----
+
+The heartbeat is a periodic newline sent to detect disconnected clients.
+When a client disconnects, the heartbeat write will fail, triggering the `onClose()` callback.
+
+=== Returning null from newEventSource
+
+If `newEventSource()` returns `null`, the handler responds with HTTP 503 Service Unavailable:
+
+[,java]
+----
+@Override
+protected EventSource newEventSource(Request request)
+{
+    // Check if SSE is currently available
+    if (!isServiceAvailable())
+    {
+        return null; // Returns 503 to client
+    }
+    return new EventSource() { /* ... */ };
+}
+----
+
+=== Request Filtering
+
+The `EventSourceHandler` only handles:
+
+* `GET` requests
+* Requests with `Accept: text/event-stream` header
+
+Other requests pass through to the next handler in the chain.
+
+== Client-Side Example
+
+Here's how a browser client connects to an SSE endpoint:
+
+[,javascript]
+----
+const eventSource = new EventSource('/events');
+
+// Handle default (unnamed) events
+eventSource.onmessage = function(event) {
+    console.log('Data:', event.data);
+};
+
+// Handle named events
+eventSource.addEventListener('notification', function(event) {
+    console.log('Notification:', event.data);
+});
+
+// Handle connection errors
+eventSource.onerror = function(event) {
+    console.error('Connection error');
+};
+
+// Close connection when done
+eventSource.close();
+----
+
+== EventSourceServlet for Servlet Applications
+
+For servlet-based applications, Jetty provides `EventSourceServlet` in the EE modules (`jetty-ee9-servlets`, `jetty-ee10-servlets`, `jetty-ee11-servlets`).
+
+[,java]
+----
+import org.eclipse.jetty.ee10.servlets.EventSourceServlet;
+import org.eclipse.jetty.ee10.servlets.EventSource;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class MyEventSourceServlet extends EventSourceServlet
+{
+    @Override
+    protected EventSource newEventSource(HttpServletRequest request)
+    {
+        return new EventSource()
+        {
+            @Override
+            public void onOpen(Emitter emitter) throws IOException
+            {
+                emitter.data("connected");
+            }
+
+            @Override
+            public void onClose()
+            {
+            }
+        };
+    }
+}
+----
+
+The servlet can be configured with an init parameter:
+
+[,xml]
+----
+<servlet>
+    <servlet-name>events</servlet-name>
+    <servlet-class>com.example.MyEventSourceServlet</servlet-class>
+    <init-param>
+        <param-name>heartBeatPeriod</param-name>
+        <param-value>30</param-value> <!-- seconds -->
+    </init-param>
+</servlet>
+----
+
+== Thread Safety
+
+The `Emitter` interface is thread-safe.
+Multiple threads can safely call `data()`, `event()`, `comment()`, and `close()` concurrently.

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MimeTypes.java
@@ -124,6 +124,9 @@ public class MimeTypes
         TEXT_XML_8859_1("text/xml;charset=iso-8859-1", TEXT_XML),
         TEXT_XML_UTF_8("text/xml;charset=utf-8", TEXT_XML),
 
+        TEXT_EVENT_STREAM("text/event-stream"),
+        TEXT_EVENT_STREAM_UTF_8("text/event-stream;charset=utf-8", TEXT_EVENT_STREAM),
+
         TEXT_JSON("text/json", StandardCharsets.UTF_8),
         TEXT_JSON_8859_1("text/json;charset=iso-8859-1", TEXT_JSON),
         TEXT_JSON_UTF_8("text/json;charset=utf-8", TEXT_JSON),

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
@@ -120,16 +120,7 @@ public abstract class EventSourceHandler extends Handler.Abstract
             return false;
 
         List<String> accepts = request.getHeaders().getValuesList(HttpHeader.ACCEPT);
-        boolean acceptsEventStream = false;
-        for (String accept : accepts)
-        {
-            if (accept.contains(MimeTypes.Type.TEXT_EVENT_STREAM.asString()))
-            {
-                acceptsEventStream = true;
-                break;
-            }
-        }
-        if (!acceptsEventStream)
+        if (accepts.stream().noneMatch(accept -> accept.contains(MimeTypes.Type.TEXT_EVENT_STREAM.asString())))
             return false;
 
         EventSource eventSource = newEventSource(request);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
@@ -1,0 +1,411 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+
+import org.eclipse.jetty.http.HttpField;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ExceptionUtil;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>A {@link Handler} that implements the
+ * <a href="https://html.spec.whatwg.org/multipage/server-sent-events.html">Server-Sent Events</a> protocol,
+ * also known as "event source".</p>
+ * <p>This handler must be subclassed to implement abstract method {@link #newEventSource(Request)}
+ * to return an instance of {@link EventSource} that allows applications to be notified of events
+ * and to emit events.</p>
+ * <p>Server-Sent Events is a unidirectional protocol: the server can push data to the client,
+ * but the client cannot send data to the server. For bidirectional communication, consider
+ * using WebSocket instead.</p>
+ * <p>The protocol uses the {@code text/event-stream} content type, and supports the following
+ * fields: {@code event:}, {@code data:}, {@code id:}, and {@code retry:}. This implementation
+ * supports {@code event:}, {@code data:}, and comments (lines starting with {@code :}).</p>
+ * <p>Example usage:</p>
+ * <pre>{@code
+ * EventSourceHandler eventSourceHandler = new EventSourceHandler()
+ * {
+ *     @Override
+ *     protected EventSource newEventSource(Request request)
+ *     {
+ *         return new EventSource()
+ *         {
+ *             @Override
+ *             public void onOpen(Emitter emitter) throws IOException
+ *             {
+ *                 emitter.data("connected");
+ *             }
+ *
+ *             @Override
+ *             public void onClose()
+ *             {
+ *             }
+ *         };
+ *     }
+ * };
+ * }</pre>
+ *
+ * @see EventSource
+ */
+public abstract class EventSourceHandler extends Handler.Abstract
+{
+    private static final Logger LOG = LoggerFactory.getLogger(EventSourceHandler.class);
+    private static final byte[] CRLF = new byte[]{'\r', '\n'};
+    private static final byte[] CRLF_CRLF = new byte[]{'\r', '\n', '\r', '\n'};
+    private static final byte[] EVENT_FIELD = "event: ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] DATA_FIELD = "data: ".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] COMMENT_FIELD = ": ".getBytes(StandardCharsets.UTF_8);
+
+    private Duration heartBeatPeriod = Duration.ofSeconds(10);
+
+    /**
+     * @return the heartbeat period
+     */
+    public Duration getHeartBeatPeriod()
+    {
+        return heartBeatPeriod;
+    }
+
+    /**
+     * <p>Sets the heartbeat period.</p>
+     * <p>The heartbeat is a newline written to the response to detect
+     * when the client has closed the connection.</p>
+     *
+     * @param heartBeatPeriod the heartbeat period
+     */
+    public void setHeartBeatPeriod(Duration heartBeatPeriod)
+    {
+        this.heartBeatPeriod = heartBeatPeriod;
+    }
+
+    @Override
+    public InvocationType getInvocationType()
+    {
+        return InvocationType.BLOCKING;
+    }
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) throws Exception
+    {
+        if (!HttpMethod.GET.is(request.getMethod()))
+            return false;
+
+        List<String> accepts = request.getHeaders().getValuesList(HttpHeader.ACCEPT);
+        boolean acceptsEventStream = false;
+        for (String accept : accepts)
+        {
+            if (accept.contains("text/event-stream"))
+            {
+                acceptsEventStream = true;
+                break;
+            }
+        }
+        if (!acceptsEventStream)
+            return false;
+
+        EventSource eventSource = newEventSource(request);
+        if (eventSource == null)
+        {
+            Response.writeError(request, response, callback, HttpStatus.SERVICE_UNAVAILABLE_503);
+            return true;
+        }
+
+        respond(response);
+        Scheduler scheduler = request.getComponents().getScheduler();
+        EventSourceEmitter emitter = new EventSourceEmitter(eventSource, response, callback, scheduler);
+        emitter.scheduleHeartBeat();
+        open(eventSource, emitter);
+        return true;
+    }
+
+    /**
+     * <p>Creates a new {@link EventSource} for the given request.</p>
+     * <p>Subclasses must implement this method to return an {@link EventSource} instance
+     * that will be used to handle the event source connection.</p>
+     *
+     * @param request the HTTP request
+     * @return a new {@link EventSource} instance, or {@code null} to reject the request with a 503 status
+     */
+    protected abstract EventSource newEventSource(Request request);
+
+    /**
+     * <p>Writes the response headers for the event source connection.</p>
+     * <p>Subclasses may override this method to customize the response headers.</p>
+     *
+     * @param response the HTTP response
+     */
+    protected void respond(Response response)
+    {
+        response.setStatus(HttpStatus.OK_200);
+        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/event-stream;charset=utf-8");
+        response.getHeaders().put(HttpHeader.CACHE_CONTROL, "no-cache");
+        response.getHeaders().put(HttpHeader.CONNECTION, "close");
+    }
+
+    /**
+     * <p>Opens the event source connection.</p>
+     * <p>Subclasses may override this method to perform custom actions when
+     * the event source connection is opened.</p>
+     *
+     * @param eventSource the event source
+     * @param emitter the emitter
+     * @throws IOException if an I/O error occurs
+     */
+    protected void open(EventSource eventSource, Emitter emitter) throws IOException
+    {
+        eventSource.onOpen(emitter);
+    }
+
+    /**
+     * <p>The passive half of an event source connection.</p>
+     * <p>{@link EventSource} allows applications to be notified of events happening on the connection:
+     * the opening of the connection via {@link #onOpen(Emitter)}, and the closing of the connection
+     * via {@link #onClose()}.</p>
+     *
+     * @see Emitter
+     */
+    public interface EventSource
+    {
+        /**
+         * <p>Callback method invoked when an event source connection is opened.</p>
+         *
+         * @param emitter the {@link Emitter} instance that allows to operate on the connection
+         * @throws IOException if the implementation throws such exception
+         */
+        void onOpen(Emitter emitter) throws IOException;
+
+        /**
+         * <p>Callback method invoked when an event source connection is closed.</p>
+         */
+        void onClose();
+    }
+
+    /**
+     * <p>The active half of an event source connection.</p>
+     * <p>{@link Emitter} allows applications to operate on the connection by sending events,
+     * data, or comments, or by closing the connection.</p>
+     * <p>{@link Emitter} instances are fully thread-safe and can be used from multiple threads.</p>
+     *
+     * @see EventSource
+     */
+    public interface Emitter
+    {
+        /**
+         * <p>Sends a named event with data to the client.</p>
+         * <p>When invoked as: {@code event("foo", "bar")}, the client will receive:</p>
+         * <pre>
+         * event: foo
+         * data: bar
+         * </pre>
+         *
+         * @param name the event name
+         * @param data the data to be sent
+         * @throws IOException if an I/O error occurs
+         * @see #data(String)
+         */
+        void event(String name, String data) throws IOException;
+
+        /**
+         * <p>Sends a default event with data to the client.</p>
+         * <p>When invoked as: {@code data("baz")}, the client will receive:</p>
+         * <pre>
+         * data: baz
+         * </pre>
+         * <p>When invoked as: {@code data("foo\r\nbar\rbaz\nbax")}, the client will receive:</p>
+         * <pre>
+         * data: foo
+         * data: bar
+         * data: baz
+         * data: bax
+         * </pre>
+         *
+         * @param data the data to be sent
+         * @throws IOException if an I/O error occurs
+         */
+        void data(String data) throws IOException;
+
+        /**
+         * <p>Sends a comment to the client.</p>
+         * <p>When invoked as: {@code comment("foo")}, the client will receive:</p>
+         * <pre>
+         * : foo
+         * </pre>
+         *
+         * @param comment the comment to send
+         * @throws IOException if an I/O error occurs
+         */
+        void comment(String comment) throws IOException;
+
+        /**
+         * <p>Closes this event source connection.</p>
+         */
+        void close();
+    }
+
+    private class EventSourceEmitter implements Emitter, Runnable
+    {
+        private final AutoLock lock = new AutoLock();
+        private final EventSource eventSource;
+        private final OutputStream outputStream;
+        private final Callback callback;
+        private final Scheduler scheduler;
+        private Scheduler.Task heartBeat;
+        private boolean closed;
+
+        private EventSourceEmitter(EventSource eventSource, Response response, Callback callback, Scheduler scheduler) throws IOException
+        {
+            this.eventSource = eventSource;
+            this.outputStream = Content.Sink.asOutputStream(response);
+            this.callback = callback;
+            this.scheduler = scheduler;
+            // Flush to commit the response headers
+            outputStream.flush();
+        }
+
+        @Override
+        public void event(String name, String data) throws IOException
+        {
+            try (AutoLock l = lock.lock())
+            {
+                if (closed)
+                    throw new IOException("closed");
+                outputStream.write(EVENT_FIELD);
+                outputStream.write(name.getBytes(StandardCharsets.UTF_8));
+                outputStream.write(CRLF);
+                lockedData(data);
+            }
+        }
+
+        @Override
+        public void data(String data) throws IOException
+        {
+            try (AutoLock l = lock.lock())
+            {
+                if (closed)
+                    throw new IOException("closed");
+                lockedData(data);
+            }
+        }
+
+        private void lockedData(String data) throws IOException
+        {
+            assert lock.isHeldByCurrentThread();
+
+            BufferedReader reader = new BufferedReader(new StringReader(data));
+            String line;
+            while ((line = reader.readLine()) != null)
+            {
+                outputStream.write(DATA_FIELD);
+                outputStream.write(line.getBytes(StandardCharsets.UTF_8));
+                outputStream.write(CRLF);
+            }
+            outputStream.write(CRLF);
+            outputStream.flush();
+        }
+
+        @Override
+        public void comment(String comment) throws IOException
+        {
+            try (AutoLock l = lock.lock())
+            {
+                if (closed)
+                    throw new IOException("closed");
+                outputStream.write(COMMENT_FIELD);
+                outputStream.write(comment.getBytes(StandardCharsets.UTF_8));
+                outputStream.write(CRLF_CRLF);
+                outputStream.flush();
+            }
+        }
+
+        @Override
+        public void run()
+        {
+            // If the other peer closes the connection, the first
+            // flush() should generate a TCP reset that is detected
+            // on the second flush()
+            try (AutoLock l = lock.lock())
+            {
+                if (closed)
+                    return;
+                outputStream.write('\r');
+                outputStream.flush();
+                outputStream.write('\n');
+                outputStream.flush();
+
+                // We could write, reschedule heartbeat
+                scheduleHeartBeat();
+            }
+            catch (Throwable x)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Heartbeat failed", x);
+
+                IO.close(this::close);
+
+                try
+                {
+                    // The other peer closed the connection
+                    eventSource.onClose();
+                }
+                catch (Throwable t)
+                {
+                    ExceptionUtil.addSuppressedIfNotAssociated(x, t);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("EventSource.onClose() failed", x);
+                }
+            }
+        }
+
+        private void scheduleHeartBeat()
+        {
+            try (AutoLock l = lock.lock())
+            {
+                if (!closed)
+                    heartBeat = scheduler.schedule(this, heartBeatPeriod);
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            try (AutoLock l = lock.lock())
+            {
+                if (closed)
+                    return;
+                closed = true;
+                if (heartBeat != null)
+                    heartBeat.cancel();
+            }
+            callback.succeeded();
+        }
+    }
+}

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventSourceHandler.java
@@ -21,10 +21,10 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.List;
 
-import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
@@ -123,7 +123,7 @@ public abstract class EventSourceHandler extends Handler.Abstract
         boolean acceptsEventStream = false;
         for (String accept : accepts)
         {
-            if (accept.contains("text/event-stream"))
+            if (accept.contains(MimeTypes.Type.TEXT_EVENT_STREAM.asString()))
             {
                 acceptsEventStream = true;
                 break;
@@ -166,7 +166,7 @@ public abstract class EventSourceHandler extends Handler.Abstract
     protected void respond(Response response)
     {
         response.setStatus(HttpStatus.OK_200);
-        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/event-stream;charset=utf-8");
+        response.getHeaders().put(MimeTypes.Type.TEXT_EVENT_STREAM_UTF_8.getContentTypeField());
         response.getHeaders().put(HttpHeader.CACHE_CONTROL, "no-cache");
         response.getHeaders().put(HttpHeader.CONNECTION, "close");
     }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventSourceHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventSourceHandlerTest.java
@@ -1,0 +1,560 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class EventSourceHandlerTest
+{
+    private Server server;
+    private ServerConnector connector;
+
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        server = new Server();
+        connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+    }
+
+    @AfterEach
+    public void stopServer() throws Exception
+    {
+        if (server != null)
+            server.stop();
+    }
+
+    private void startServer(EventSourceHandler handler) throws Exception
+    {
+        server.setHandler(handler);
+        server.start();
+    }
+
+    @Test
+    public void testBasicFunctionality() throws Exception
+    {
+        AtomicReference<EventSourceHandler.Emitter> emitterRef = new AtomicReference<>();
+        CountDownLatch emitterLatch = new CountDownLatch(1);
+        CountDownLatch closeLatch = new CountDownLatch(1);
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            {
+                setHeartBeatPeriod(Duration.ofSeconds(2));
+            }
+
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitterRef.set(emitter);
+                        emitterLatch.countDown();
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                        closeLatch.countDown();
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            assertTrue(emitterLatch.await(1, TimeUnit.SECONDS));
+            EventSourceHandler.Emitter emitter = emitterRef.get();
+            assertNotNull(emitter);
+
+            String data = "foo";
+            emitter.data(data);
+
+            String line = reader.readLine();
+            String received = "";
+            while (line != null)
+            {
+                received += line;
+                if (line.isEmpty())
+                    break;
+                line = reader.readLine();
+            }
+
+            assertEquals("data: " + data, received);
+
+            socket.close();
+            assertTrue(closeLatch.await(6, TimeUnit.SECONDS));
+        }
+    }
+
+    @Test
+    public void testServerSideClose() throws Exception
+    {
+        AtomicReference<EventSourceHandler.Emitter> emitterRef = new AtomicReference<>();
+        CountDownLatch emitterLatch = new CountDownLatch(1);
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitterRef.set(emitter);
+                        emitterLatch.countDown();
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            assertTrue(emitterLatch.await(1, TimeUnit.SECONDS));
+            EventSourceHandler.Emitter emitter = emitterRef.get();
+            assertNotNull(emitter);
+
+            String comment = "foo";
+            emitter.comment(comment);
+
+            String line = reader.readLine();
+            String received = "";
+            while (line != null)
+            {
+                received += line;
+                if (line.isEmpty())
+                    break;
+                line = reader.readLine();
+            }
+
+            assertEquals(": " + comment, received);
+
+            emitter.close();
+
+            line = reader.readLine();
+            assertNull(line);
+        }
+    }
+
+    @Test
+    public void testEncoding() throws Exception
+    {
+        // The EURO symbol
+        String data = "%E2%82%AC";
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitter.data(data);
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            String line = reader.readLine();
+            String received = "";
+            while (line != null)
+            {
+                received += line;
+                if (line.isEmpty())
+                    break;
+                line = reader.readLine();
+            }
+
+            assertEquals("data: " + data, received);
+        }
+    }
+
+    @Test
+    public void testMultiLineData() throws Exception
+    {
+        String data1 = "data1";
+        String data2 = "data2";
+        String data3 = "data3";
+        String data4 = "data4";
+        String data = data1 + "\r\n" + data2 + "\r" + data3 + "\n" + data4;
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitter.data(data);
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            String line1 = reader.readLine();
+            assertEquals("data: " + data1, line1);
+            String line2 = reader.readLine();
+            assertEquals("data: " + data2, line2);
+            String line3 = reader.readLine();
+            assertEquals("data: " + data3, line3);
+            String line4 = reader.readLine();
+            assertEquals("data: " + data4, line4);
+            String line5 = reader.readLine();
+            assertEquals(0, line5.length());
+        }
+    }
+
+    @Test
+    public void testNamedEvent() throws Exception
+    {
+        String name = "event1";
+        String data = "data2";
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitter.event(name, data);
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            String line1 = reader.readLine();
+            assertEquals("event: " + name, line1);
+            String line2 = reader.readLine();
+            assertEquals("data: " + data, line2);
+            String line3 = reader.readLine();
+            assertEquals(0, line3.length());
+        }
+    }
+
+    @Test
+    public void testHeartBeat() throws Exception
+    {
+        AtomicReference<EventSourceHandler.Emitter> emitterRef = new AtomicReference<>();
+        CountDownLatch emitterLatch = new CountDownLatch(1);
+
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            {
+                setHeartBeatPeriod(Duration.ofSeconds(1));
+            }
+
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter) throws IOException
+                    {
+                        emitterRef.set(emitter);
+                        emitterLatch.countDown();
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+            BufferedReader reader = readAndDiscardHTTPResponse(socket);
+
+            assertTrue(emitterLatch.await(1, TimeUnit.SECONDS));
+            EventSourceHandler.Emitter emitter = emitterRef.get();
+            assertNotNull(emitter);
+
+            // Wait for heartbeat (empty line)
+            long start = System.nanoTime();
+            String line = reader.readLine();
+            long elapsed = System.nanoTime() - start;
+            // Should receive heartbeat within about 1 second
+            assertTrue(elapsed >= Duration.ofMillis(500).toNanos(), "Heartbeat received too quickly");
+            assertEquals("", line);
+
+            emitter.close();
+        }
+    }
+
+    @Test
+    public void testNullEventSourceReturns503() throws Exception
+    {
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return null;
+            }
+        };
+
+        startServer(handler);
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            writeHTTPRequest(socket);
+
+            InputStream input = socket.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+            String line = reader.readLine();
+            assertTrue(line.contains("503"));
+        }
+    }
+
+    @Test
+    public void testNonGetRequestNotHandled() throws Exception
+    {
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter)
+                    {
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        // Wrap with a fallback handler that returns 404
+        ContextHandler contextHandler = new ContextHandler("/");
+        contextHandler.setHandler(new Handler.Sequence(handler, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(404);
+                callback.succeeded();
+                return true;
+            }
+        }));
+
+        server.setHandler(contextHandler);
+        server.start();
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            int serverPort = socket.getPort();
+            OutputStream output = socket.getOutputStream();
+
+            String request = "POST /eventsource HTTP/1.1\r\n" +
+                "Host: localhost:" + serverPort + "\r\n" +
+                "Accept: text/event-stream\r\n" +
+                "\r\n";
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            InputStream input = socket.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+            String line = reader.readLine();
+            assertTrue(line.contains("404"));
+        }
+    }
+
+    @Test
+    public void testMissingAcceptHeaderNotHandled() throws Exception
+    {
+        EventSourceHandler handler = new EventSourceHandler()
+        {
+            @Override
+            protected EventSource newEventSource(Request request)
+            {
+                return new EventSource()
+                {
+                    @Override
+                    public void onOpen(Emitter emitter)
+                    {
+                    }
+
+                    @Override
+                    public void onClose()
+                    {
+                    }
+                };
+            }
+        };
+
+        // Wrap with a fallback handler that returns 404
+        ContextHandler contextHandler = new ContextHandler("/");
+        contextHandler.setHandler(new Handler.Sequence(handler, new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(404);
+                callback.succeeded();
+                return true;
+            }
+        }));
+
+        server.setHandler(contextHandler);
+        server.start();
+
+        try (Socket socket = new Socket("localhost", connector.getLocalPort()))
+        {
+            int serverPort = socket.getPort();
+            OutputStream output = socket.getOutputStream();
+
+            // Request without Accept: text/event-stream header
+            String request = "GET /eventsource HTTP/1.1\r\n" +
+                "Host: localhost:" + serverPort + "\r\n" +
+                "\r\n";
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            InputStream input = socket.getInputStream();
+            BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+            String line = reader.readLine();
+            assertTrue(line.contains("404"));
+        }
+    }
+
+    private void writeHTTPRequest(Socket socket) throws IOException
+    {
+        int serverPort = socket.getPort();
+        OutputStream output = socket.getOutputStream();
+
+        String handshake = "GET /eventsource HTTP/1.1\r\n" +
+            "Host: localhost:" + serverPort + "\r\n" +
+            "Accept: text/event-stream\r\n" +
+            "\r\n";
+        output.write(handshake.getBytes(StandardCharsets.UTF_8));
+        output.flush();
+    }
+
+    private BufferedReader readAndDiscardHTTPResponse(Socket socket) throws IOException
+    {
+        // Read and discard the HTTP response headers
+        InputStream input = socket.getInputStream();
+        BufferedReader reader = new BufferedReader(new InputStreamReader(input, StandardCharsets.UTF_8));
+        String line = reader.readLine();
+        while (line != null)
+        {
+            if (line.isEmpty())
+                break;
+            line = reader.readLine();
+        }
+        // Now we can parse the event-source stream
+        return reader;
+    }
+}


### PR DESCRIPTION
Closes #11765                                                                                                                                                                  
                                                                                                                                                                                 
This PR adds `EventSourceHandler` to `jetty-core/jetty-server` for SSE support without Servlet API dependencies.                                                        
                                                                                                                                                                                 
- Abstract handler with `newEventSource(Request)` factory method                                                                                                               
- `EventSource` interface with `onOpen(Emitter)` and `onClose()` callbacks                                                                                                     
- `Emitter` with `event()`, `data()`, `comment()`, `close()` methods                                                                                               
- Configurable heartbeat period for connection keep-alive                                                                                                                      
- Documentation in programming guide                    