### PR TITLE
Issue #14401 - Add ACME (Let's Encrypt) certificate management module

### DIFF
--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.1.6-SNAPSHOT</version>
+    <version>12.1.7-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-acme</artifactId>
   <name>Core :: ACME</name>

--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.1.10-SNAPSHOT</version>
+    <version>12.1.11-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-acme</artifactId>
   <name>Core :: ACME</name>

--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.1.7-SNAPSHOT</version>
+    <version>12.1.10-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-acme</artifactId>
   <name>Core :: ACME</name>

--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.eclipse.jetty</groupId>
+    <artifactId>jetty-core</artifactId>
+    <version>12.1.6-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-acme</artifactId>
+  <name>Core :: ACME</name>
+  <description>Jetty ACME (Let's Encrypt) Certificate Management</description>
+
+  <properties>
+    <bundle-symbolic-name>${project.groupId}.acme</bundle-symbolic-name>
+    <spotbugs.onlyAnalyze>org.eclipse.jetty.acme.*</spotbugs.onlyAnalyze>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-util-ajax</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-http-tools</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-slf4j-impl</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -19,11 +19,11 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-server</artifactId>
+      <artifactId>jetty-client</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
+      <artifactId>jetty-server</artifactId>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
@@ -44,13 +44,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
+      <groupId>org.eclipse.jetty.toolchain</groupId>
+      <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/jetty-core/jetty-acme/pom.xml
+++ b/jetty-core/jetty-acme/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.eclipse.jetty</groupId>
     <artifactId>jetty-core</artifactId>
-    <version>12.1.11-SNAPSHOT</version>
+    <version>12.1.13-SNAPSHOT</version>
   </parent>
   <artifactId>jetty-acme</artifactId>
   <name>Core :: ACME</name>

--- a/jetty-core/jetty-acme/src/main/config/etc/jetty-acme-init.xml
+++ b/jetty-core/jetty-acme/src/main/config/etc/jetty-acme-init.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
+<!-- ============================================================= -->
+<!-- Initialize ACME keystore before SSL context loads             -->
+<!-- This XML runs BEFORE ssl-context to ensure keystore exists    -->
+<!-- ============================================================= -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- Ensure keystore exists (creates self-signed cert if missing) -->
+  <Call class="org.eclipse.jetty.acme.AcmeKeyStoreManager" name="ensureKeyStoreExists">
+    <Arg><Property name="jetty.base"/></Arg>
+    <Arg><Property name="jetty.acme.keystorePath" default="etc/keystore.p12"/></Arg>
+    <Arg><Property name="jetty.acme.keystorePassword" default="changeit"/></Arg>
+    <Arg><Property name="jetty.acme.domains" default=""/></Arg>
+  </Call>
+
+</Configure>

--- a/jetty-core/jetty-acme/src/main/config/etc/jetty-acme-init.xml
+++ b/jetty-core/jetty-acme/src/main/config/etc/jetty-acme-init.xml
@@ -11,7 +11,7 @@
   <Call class="org.eclipse.jetty.acme.AcmeKeyStoreManager" name="ensureKeyStoreExists">
     <Arg><Property name="jetty.base"/></Arg>
     <Arg><Property name="jetty.acme.keystorePath" default="etc/keystore.p12"/></Arg>
-    <Arg><Property name="jetty.acme.keystorePassword" default="changeit"/></Arg>
+    <Arg><Property name="jetty.acme.keystorePassword" default="storepwd"/></Arg>
     <Arg><Property name="jetty.acme.domains" default=""/></Arg>
   </Call>
 

--- a/jetty-core/jetty-acme/src/main/config/etc/jetty-acme.xml
+++ b/jetty-core/jetty-acme/src/main/config/etc/jetty-acme.xml
@@ -27,7 +27,7 @@
       <Property name="jetty.acme.keystorePath" default="etc/keystore.p12"/>
     </Set>
     <Set name="keystorePassword">
-      <Property name="jetty.acme.keystorePassword" default="changeit"/>
+      <Property name="jetty.acme.keystorePassword" default="storepwd"/>
     </Set>
     <Set name="renewalThresholdDays">
       <Property name="jetty.acme.renewalThresholdDays" default="30"/>

--- a/jetty-core/jetty-acme/src/main/config/etc/jetty-acme.xml
+++ b/jetty-core/jetty-acme/src/main/config/etc/jetty-acme.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
+<!-- ============================================================= -->
+<!-- Configure ACME (Let's Encrypt) certificate management         -->
+<!-- ============================================================= -->
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+
+  <!-- ACME Configuration -->
+  <New id="AcmeConfiguration" class="org.eclipse.jetty.acme.AcmeConfiguration">
+    <Set name="dryRun">
+      <Property name="jetty.acme.dryRun" default="true"/>
+    </Set>
+    <Set name="directoryUrl">
+      <Property name="jetty.acme.directoryUrl" default="https://acme-staging-v02.api.letsencrypt.org/directory"/>
+    </Set>
+    <Set name="domains">
+      <Property name="jetty.acme.domains" default=""/>
+    </Set>
+    <Set name="accountEmail">
+      <Property name="jetty.acme.accountEmail"/>
+    </Set>
+    <Set name="accountKeyPath">
+      <Property name="jetty.acme.accountKeyPath" default="acme/account.key"/>
+    </Set>
+    <Set name="keystorePath">
+      <Property name="jetty.acme.keystorePath" default="etc/keystore.p12"/>
+    </Set>
+    <Set name="keystorePassword">
+      <Property name="jetty.acme.keystorePassword" default="changeit"/>
+    </Set>
+    <Set name="renewalThresholdDays">
+      <Property name="jetty.acme.renewalThresholdDays" default="30"/>
+    </Set>
+    <Set name="checkIntervalSeconds">
+      <Property name="jetty.acme.checkIntervalSeconds" default="86400"/>
+    </Set>
+    <Set name="termsOfServiceAgreed">
+      <Property name="jetty.acme.termsOfServiceAgreed" default="false"/>
+    </Set>
+  </New>
+
+  <!-- ACME Challenge Handler - serves /.well-known/acme-challenge/ -->
+  <New id="AcmeChallengeHandler" class="org.eclipse.jetty.acme.AcmeChallengeHandler"/>
+
+  <!-- Insert challenge handler at the front of the handler chain -->
+  <Call name="insertHandler">
+    <Arg><Ref refid="AcmeChallengeHandler"/></Arg>
+  </Call>
+
+  <!-- ACME Certificate Manager -->
+  <Call name="addBean">
+    <Arg>
+      <New class="org.eclipse.jetty.acme.AcmeCertificateManager">
+        <Arg><Ref refid="AcmeConfiguration"/></Arg>
+        <Arg><Ref refid="sslContextFactory"/></Arg>
+        <Arg><Ref refid="AcmeChallengeHandler"/></Arg>
+        <Call name="setServer">
+          <Arg><Ref refid="Server"/></Arg>
+        </Call>
+      </New>
+    </Arg>
+  </Call>
+
+</Configure>

--- a/jetty-core/jetty-acme/src/main/config/modules/acme-init.mod
+++ b/jetty-core/jetty-acme/src/main/config/modules/acme-init.mod
@@ -1,0 +1,21 @@
+[description]
+Initializes ACME keystore before SSL context loads.
+This module is used internally by the acme module.
+
+[tags]
+ssl
+security
+acme
+internal
+
+[depend]
+server
+
+[before]
+ssl-context
+
+[lib]
+lib/jetty-acme-${jetty.version}.jar
+
+[xml]
+etc/jetty-acme-init.xml

--- a/jetty-core/jetty-acme/src/main/config/modules/acme.mod
+++ b/jetty-core/jetty-acme/src/main/config/modules/acme.mod
@@ -9,6 +9,7 @@ security
 acme
 
 [depend]
+acme-init
 ssl-context
 server
 client

--- a/jetty-core/jetty-acme/src/main/config/modules/acme.mod
+++ b/jetty-core/jetty-acme/src/main/config/modules/acme.mod
@@ -23,8 +23,8 @@ etc/jetty-acme.xml
 [ini]
 # Set ssl-context properties to use the same keystore as ACME
 jetty.sslContext.keyStorePath?=etc/keystore.p12
-jetty.sslContext.keyStorePassword?=changeit
-jetty.sslContext.keyManagerPassword?=changeit
+jetty.sslContext.keyStorePassword?=storepwd
+jetty.sslContext.keyManagerPassword?=storepwd
 
 [ini-template]
 # tag::documentation[]
@@ -52,7 +52,7 @@ jetty.sslContext.keyManagerPassword?=changeit
 
 ## Keystore path and password
 # jetty.acme.keystorePath=etc/keystore.p12
-# jetty.acme.keystorePassword=changeit
+# jetty.acme.keystorePassword=storepwd
 
 ## Days before expiry to trigger renewal (default 30)
 # jetty.acme.renewalThresholdDays=30

--- a/jetty-core/jetty-acme/src/main/config/modules/acme.mod
+++ b/jetty-core/jetty-acme/src/main/config/modules/acme.mod
@@ -20,6 +20,12 @@ lib/jetty-acme-${jetty.version}.jar
 [xml]
 etc/jetty-acme.xml
 
+[ini]
+# Set ssl-context properties to use the same keystore as ACME
+jetty.sslContext.keyStorePath?=etc/keystore.p12
+jetty.sslContext.keyStorePassword?=changeit
+jetty.sslContext.keyManagerPassword?=changeit
+
 [ini-template]
 # tag::documentation[]
 ### ACME Certificate Management Configuration

--- a/jetty-core/jetty-acme/src/main/config/modules/acme.mod
+++ b/jetty-core/jetty-acme/src/main/config/modules/acme.mod
@@ -1,0 +1,59 @@
+[description]
+Enables ACME (Let's Encrypt) automatic certificate management.
+Obtains and renews TLS certificates automatically using Jetty HttpClient.
+Supports HTTP-01 challenges for domain validation.
+
+[tags]
+ssl
+security
+acme
+
+[depend]
+ssl-context
+server
+client
+
+[lib]
+lib/jetty-acme-${jetty.version}.jar
+
+[xml]
+etc/jetty-acme.xml
+
+[ini-template]
+# tag::documentation[]
+### ACME Certificate Management Configuration
+
+## Dry run mode - generates self-signed cert, no ACME calls
+## Default: true (SAFE - must explicitly disable for production)
+# jetty.acme.dryRun=true
+
+## ACME provider directory URL
+## Production: https://acme-v02.api.letsencrypt.org/directory
+## Staging (default): https://acme-staging-v02.api.letsencrypt.org/directory
+# jetty.acme.directoryUrl=https://acme-staging-v02.api.letsencrypt.org/directory
+
+## Comma-separated domain names for certificate
+## REQUIRED for production use
+# jetty.acme.domains=example.com,www.example.com
+
+## Contact email for ACME account
+## REQUIRED for production use
+# jetty.acme.accountEmail=admin@example.com
+
+## Path to store account key (relative to JETTY_BASE)
+# jetty.acme.accountKeyPath=acme/account.key
+
+## Keystore path and password
+# jetty.acme.keystorePath=etc/keystore.p12
+# jetty.acme.keystorePassword=changeit
+
+## Days before expiry to trigger renewal (default 30)
+# jetty.acme.renewalThresholdDays=30
+
+## Renewal check interval in seconds (default 86400 = 24 hours)
+# jetty.acme.checkIntervalSeconds=86400
+
+## Terms of service agreement
+## REQUIRED for production use - must be set to true
+# jetty.acme.termsOfServiceAgreed=false
+# end::documentation[]

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
@@ -1,0 +1,544 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.ManagedOperation;
+import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.eclipse.jetty.util.thread.AutoLock;
+import org.eclipse.jetty.util.thread.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Main orchestrator for ACME certificate management.</p>
+ * <p>This component manages the complete lifecycle of TLS certificates:</p>
+ * <ul>
+ *   <li>Initial certificate acquisition</li>
+ *   <li>Periodic renewal checks</li>
+ *   <li>Challenge response handling</li>
+ *   <li>Hot-reload of renewed certificates</li>
+ * </ul>
+ *
+ * <p>The manager supports dry-run mode for testing without contacting
+ * the ACME server. In dry-run mode, self-signed certificates are
+ * generated instead.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * AcmeConfiguration config = new AcmeConfiguration();
+ * config.setDomains("example.com");
+ * config.setAccountEmail("admin@example.com");
+ * config.setTermsOfServiceAgreed(true);
+ * config.setDryRun(false);
+ *
+ * AcmeChallengeHandler challengeHandler = new AcmeChallengeHandler();
+ * server.insertHandler(challengeHandler);
+ *
+ * AcmeCertificateManager manager = new AcmeCertificateManager(
+ *     config, sslContextFactory, challengeHandler);
+ * server.addBean(manager);
+ * </pre>
+ */
+@ManagedObject("ACME Certificate Manager")
+public class AcmeCertificateManager extends AbstractLifeCycle
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AcmeCertificateManager.class);
+    private static final int DRY_RUN_VALIDITY_DAYS = 90;
+
+    private final AutoLock lock = new AutoLock();
+    private final AcmeConfiguration config;
+    private final SslContextFactory.Server sslContextFactory;
+    private final AcmeChallengeHandler challengeHandler;
+
+    private Server server;
+    private HttpClient httpClient;
+    private AcmeKeyStoreManager keyStoreManager;
+    private Scheduler scheduler;
+    private Scheduler.Task renewalTask;
+    private boolean ownHttpClient;
+    private KeyPair accountKeyPair;
+    private KeyPair domainKeyPair;
+
+    /**
+     * Creates a new ACME certificate manager.
+     *
+     * @param config the ACME configuration
+     * @param sslContextFactory the SSL context factory to update with certificates
+     * @param challengeHandler the challenge handler for HTTP-01 challenges
+     */
+    public AcmeCertificateManager(AcmeConfiguration config, SslContextFactory.Server sslContextFactory,
+                                   AcmeChallengeHandler challengeHandler)
+    {
+        this.config = Objects.requireNonNull(config, "config");
+        this.sslContextFactory = Objects.requireNonNull(sslContextFactory, "sslContextFactory");
+        this.challengeHandler = Objects.requireNonNull(challengeHandler, "challengeHandler");
+    }
+
+    /**
+     * Sets the Server for accessing shared resources.
+     *
+     * @param server the server
+     */
+    public void setServer(Server server)
+    {
+        this.server = server;
+    }
+
+    /**
+     * @return the configuration
+     */
+    @ManagedAttribute("ACME Configuration")
+    public AcmeConfiguration getConfiguration()
+    {
+        return config;
+    }
+
+    @Override
+    protected void doStart() throws Exception
+    {
+        if (!config.isDryRun())
+            config.validate();
+
+        // Get base path from server
+        Path basePath = Path.of(".");
+        if (server != null)
+        {
+            Object jettyBase = server.getAttribute("jetty.base");
+            if (jettyBase != null)
+                basePath = Path.of(jettyBase.toString());
+        }
+
+        keyStoreManager = new AcmeKeyStoreManager(basePath);
+
+        // Load or generate account key
+        accountKeyPair = keyStoreManager.loadOrGenerateAccountKey(config.getAccountKeyPath());
+
+        if (config.isDryRun())
+        {
+            LOG.info("ACME dry-run mode enabled - generating self-signed certificate");
+            generateDryRunCertificate();
+        }
+        else
+        {
+            // Create HTTP client for ACME requests
+            setupHttpClient();
+
+            // Check if we need a new certificate
+            checkAndRenewIfNeeded();
+        }
+
+        // Schedule periodic renewal checks
+        scheduleRenewalCheck();
+
+        super.doStart();
+    }
+
+    @Override
+    protected void doStop() throws Exception
+    {
+        try (AutoLock l = lock.lock())
+        {
+            if (renewalTask != null)
+            {
+                renewalTask.cancel();
+                renewalTask = null;
+            }
+
+            if (ownHttpClient && httpClient != null)
+            {
+                httpClient.stop();
+                httpClient = null;
+            }
+        }
+
+        super.doStop();
+    }
+
+    /**
+     * Forces an immediate certificate renewal check.
+     *
+     * @throws AcmeException if renewal fails
+     */
+    @ManagedOperation(value = "Force certificate renewal check", impact = "ACTION")
+    public void forceRenewalCheck() throws AcmeException
+    {
+        if (config.isDryRun())
+        {
+            LOG.info("Dry-run mode: regenerating self-signed certificate");
+            generateDryRunCertificate();
+        }
+        else
+        {
+            checkAndRenewIfNeeded();
+        }
+    }
+
+    /**
+     * @return true if a valid certificate is installed
+     */
+    @ManagedAttribute("Certificate valid")
+    public boolean isCertificateValid()
+    {
+        try
+        {
+            X509Certificate cert = keyStoreManager.loadCertificate(
+                config.getKeystorePath(), config.getKeystorePassword());
+            return cert != null && !needsRenewal(cert);
+        }
+        catch (Exception e)
+        {
+            return false;
+        }
+    }
+
+    /**
+     * @return days until certificate expires, or -1 if no certificate
+     */
+    @ManagedAttribute("Days until certificate expires")
+    public long getDaysUntilExpiry()
+    {
+        try
+        {
+            X509Certificate cert = keyStoreManager.loadCertificate(
+                config.getKeystorePath(), config.getKeystorePassword());
+            if (cert == null)
+                return -1;
+
+            Instant expiry = cert.getNotAfter().toInstant();
+            return ChronoUnit.DAYS.between(Instant.now(), expiry);
+        }
+        catch (Exception e)
+        {
+            return -1;
+        }
+    }
+
+    private void setupHttpClient() throws Exception
+    {
+        if (server != null)
+        {
+            // Try to find an existing HttpClient bean
+            httpClient = server.getBean(HttpClient.class);
+        }
+
+        if (httpClient == null)
+        {
+            httpClient = new HttpClient();
+            httpClient.start();
+            ownHttpClient = true;
+        }
+    }
+
+    private void checkAndRenewIfNeeded() throws AcmeException
+    {
+        try
+        {
+            X509Certificate currentCert = keyStoreManager.loadCertificate(
+                config.getKeystorePath(), config.getKeystorePassword());
+
+            if (currentCert == null || needsRenewal(currentCert))
+            {
+                LOG.info("Certificate renewal needed, starting ACME flow");
+                obtainNewCertificate();
+            }
+            else
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Certificate is valid, no renewal needed");
+            }
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Certificate check failed", e);
+        }
+    }
+
+    private boolean needsRenewal(X509Certificate cert)
+    {
+        Instant expiry = cert.getNotAfter().toInstant();
+        Instant threshold = Instant.now().plus(config.getRenewalThresholdDays(), ChronoUnit.DAYS);
+        return expiry.isBefore(threshold);
+    }
+
+    private void obtainNewCertificate() throws AcmeException
+    {
+        AcmeClient acmeClient = new AcmeClient(httpClient, accountKeyPair, config.getDirectoryUrl());
+
+        try
+        {
+            // Step 1: Fetch directory
+            LOG.info("Fetching ACME directory from {}", config.getDirectoryUrl());
+            acmeClient.fetchDirectory();
+
+            // Step 2: Create/find account
+            LOG.info("Creating/finding ACME account");
+            acmeClient.createAccount(config.getAccountEmail(), config.isTermsOfServiceAgreed());
+
+            // Step 3: Create order
+            List<String> domains = config.getDomains();
+            LOG.info("Creating order for domains: {}", domains);
+            Map<String, Object> order = acmeClient.createOrder(domains);
+
+            String orderUrl = (String)order.get("_location");
+            String finalizeUrl = (String)order.get("finalize");
+            Object[] authUrls = (Object[])order.get("authorizations");
+
+            // Step 4: Complete authorizations
+            for (Object authUrlObj : authUrls)
+            {
+                String authUrl = (String)authUrlObj;
+                completeAuthorization(acmeClient, authUrl);
+            }
+
+            // Step 5: Generate domain key pair and CSR
+            domainKeyPair = keyStoreManager.generateDomainKeyPair();
+            byte[] csr = keyStoreManager.generateCSR(domainKeyPair, domains);
+
+            // Step 6: Finalize order
+            LOG.info("Finalizing order");
+            acmeClient.finalizeOrder(finalizeUrl, csr);
+
+            // Step 7: Poll for order completion
+            Map<String, Object> finalOrder = acmeClient.pollOrderStatus(orderUrl);
+
+            // Step 8: Download certificate
+            String certUrl = (String)finalOrder.get("certificate");
+            LOG.info("Downloading certificate from {}", certUrl);
+            List<X509Certificate> certificates = acmeClient.downloadCertificate(certUrl);
+
+            // Step 9: Store certificate
+            LOG.info("Storing certificate chain ({} certificates)", certificates.size());
+            keyStoreManager.storeCertificates(
+                config.getKeystorePath(),
+                config.getKeystorePassword(),
+                domainKeyPair.getPrivate(),
+                certificates
+            );
+
+            // Step 10: Reload SSL context
+            reloadSslContext();
+
+            LOG.info("Certificate successfully obtained and installed");
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to obtain certificate", e);
+        }
+    }
+
+    private void completeAuthorization(AcmeClient acmeClient, String authUrl) throws AcmeException
+    {
+        Map<String, Object> auth = acmeClient.getAuthorization(authUrl);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> identifier = (Map<String, Object>)auth.get("identifier");
+        String domain = (String)identifier.get("value");
+
+        Object[] challenges = (Object[])auth.get("challenges");
+
+        // Find HTTP-01 challenge
+        Map<String, Object> httpChallenge = null;
+        for (Object challengeObj : challenges)
+        {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> challenge = (Map<String, Object>)challengeObj;
+            if ("http-01".equals(challenge.get("type")))
+            {
+                httpChallenge = challenge;
+                break;
+            }
+        }
+
+        if (httpChallenge == null)
+            throw new AcmeException("No HTTP-01 challenge available for domain: " + domain);
+
+        String token = (String)httpChallenge.get("token");
+        String challengeUrl = (String)httpChallenge.get("url");
+
+        // Compute key authorization
+        String keyAuthorization = acmeClient.computeKeyAuthorization(token);
+
+        // Register challenge with handler
+        LOG.info("Setting up HTTP-01 challenge for domain: {}", domain);
+        challengeHandler.addChallenge(token, keyAuthorization);
+
+        try
+        {
+            // Respond to challenge
+            acmeClient.respondToChallenge(challengeUrl);
+
+            // Poll for completion
+            acmeClient.pollChallengeStatus(challengeUrl);
+
+            LOG.info("Challenge completed for domain: {}", domain);
+        }
+        finally
+        {
+            // Clean up challenge
+            challengeHandler.removeChallenge(token);
+        }
+    }
+
+    private void generateDryRunCertificate() throws AcmeException
+    {
+        List<String> domains = config.getDomains();
+        if (domains.isEmpty())
+        {
+            domains = Collections.singletonList("localhost");
+        }
+
+        // Generate domain key pair
+        domainKeyPair = keyStoreManager.generateDomainKeyPair();
+
+        // Generate self-signed certificate
+        X509Certificate cert = keyStoreManager.generateSelfSignedCertificate(
+            domainKeyPair, domains, DRY_RUN_VALIDITY_DAYS);
+
+        // Store certificate
+        keyStoreManager.storeCertificates(
+            config.getKeystorePath(),
+            config.getKeystorePassword(),
+            domainKeyPair.getPrivate(),
+            Collections.singletonList(cert)
+        );
+
+        // Reload SSL context
+        reloadSslContext();
+
+        LOG.info("Dry-run self-signed certificate installed for domains: {}", domains);
+    }
+
+    private void reloadSslContext()
+    {
+        try
+        {
+            Path keystorePath = config.getKeystorePath();
+            if (!keystorePath.isAbsolute() && server != null)
+            {
+                Object jettyBase = server.getAttribute("jetty.base");
+                if (jettyBase != null)
+                    keystorePath = Path.of(jettyBase.toString()).resolve(keystorePath);
+            }
+
+            String keystorePathStr = keystorePath.toString();
+
+            sslContextFactory.reload(scf ->
+            {
+                scf.setKeyStorePath(keystorePathStr);
+                scf.setKeyStorePassword(config.getKeystorePassword());
+            });
+
+            LOG.info("SSL context reloaded with new certificate");
+        }
+        catch (Exception e)
+        {
+            LOG.warn("Failed to reload SSL context", e);
+        }
+    }
+
+    private void scheduleRenewalCheck()
+    {
+        try (AutoLock l = lock.lock())
+        {
+            if (server != null)
+            {
+                scheduler = server.getScheduler();
+            }
+
+            if (scheduler == null || !scheduler.isStarted())
+            {
+                LOG.debug("No scheduler available, renewal checks will not be scheduled");
+                return;
+            }
+
+            long intervalMs = config.getCheckIntervalSeconds() * 1000;
+
+            renewalTask = scheduler.schedule(new RenewalRunner(), intervalMs, TimeUnit.MILLISECONDS);
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Scheduled renewal check in {} seconds", config.getCheckIntervalSeconds());
+        }
+    }
+
+    private class RenewalRunner implements Runnable
+    {
+        @Override
+        public void run()
+        {
+            try
+            {
+                if (isStopping() || isStopped())
+                    return;
+
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Running scheduled renewal check");
+
+                if (config.isDryRun())
+                {
+                    X509Certificate cert = keyStoreManager.loadCertificate(
+                        config.getKeystorePath(), config.getKeystorePassword());
+                    if (cert == null || needsRenewal(cert))
+                    {
+                        LOG.info("Dry-run certificate needs renewal");
+                        generateDryRunCertificate();
+                    }
+                }
+                else
+                {
+                    checkAndRenewIfNeeded();
+                }
+            }
+            catch (Exception e)
+            {
+                LOG.warn("Certificate renewal check failed", e);
+            }
+            finally
+            {
+                // Reschedule
+                try (AutoLock l = lock.lock())
+                {
+                    if (scheduler != null && scheduler.isRunning() && isRunning())
+                    {
+                        long intervalMs = config.getCheckIntervalSeconds() * 1000;
+                        renewalTask = scheduler.schedule(this, intervalMs, TimeUnit.MILLISECONDS);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
@@ -72,19 +72,19 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     private static final Logger LOG = LoggerFactory.getLogger(AcmeCertificateManager.class);
     private static final int DRY_RUN_VALIDITY_DAYS = 90;
 
-    private final AutoLock lock = new AutoLock();
-    private final AcmeConfiguration config;
-    private final SslContextFactory.Server sslContextFactory;
-    private final AcmeChallengeHandler challengeHandler;
+    private final AutoLock _lock = new AutoLock();
+    private final AcmeConfiguration _config;
+    private final SslContextFactory.Server _sslContextFactory;
+    private final AcmeChallengeHandler _challengeHandler;
 
-    private Server server;
-    private HttpClient httpClient;
-    private AcmeKeyStoreManager keyStoreManager;
-    private Scheduler scheduler;
-    private Scheduler.Task renewalTask;
-    private boolean ownHttpClient;
-    private KeyPair accountKeyPair;
-    private KeyPair domainKeyPair;
+    private Server _server;
+    private HttpClient _httpClient;
+    private AcmeKeyStoreManager _keyStoreManager;
+    private Scheduler _scheduler;
+    private Scheduler.Task _renewalTask;
+    private boolean _ownHttpClient;
+    private KeyPair _accountKeyPair;
+    private KeyPair _domainKeyPair;
 
     /**
      * Creates a new ACME certificate manager.
@@ -96,9 +96,9 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     public AcmeCertificateManager(AcmeConfiguration config, SslContextFactory.Server sslContextFactory,
                                    AcmeChallengeHandler challengeHandler)
     {
-        this.config = Objects.requireNonNull(config, "config");
-        this.sslContextFactory = Objects.requireNonNull(sslContextFactory, "sslContextFactory");
-        this.challengeHandler = Objects.requireNonNull(challengeHandler, "challengeHandler");
+        _config = Objects.requireNonNull(config, "config");
+        _sslContextFactory = Objects.requireNonNull(sslContextFactory, "sslContextFactory");
+        _challengeHandler = Objects.requireNonNull(challengeHandler, "challengeHandler");
     }
 
     /**
@@ -108,7 +108,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
      */
     public void setServer(Server server)
     {
-        this.server = server;
+        _server = server;
     }
 
     /**
@@ -117,30 +117,30 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     @ManagedAttribute("ACME Configuration")
     public AcmeConfiguration getConfiguration()
     {
-        return config;
+        return _config;
     }
 
     @Override
     protected void doStart() throws Exception
     {
-        if (!config.isDryRun())
-            config.validate();
+        if (!_config.isDryRun())
+            _config.validate();
 
         // Get base path from server
         Path basePath = Path.of(".");
-        if (server != null)
+        if (_server != null)
         {
-            Object jettyBase = server.getAttribute("jetty.base");
+            Object jettyBase = _server.getAttribute("jetty.base");
             if (jettyBase != null)
                 basePath = Path.of(jettyBase.toString());
         }
 
-        keyStoreManager = new AcmeKeyStoreManager(basePath);
+        _keyStoreManager = new AcmeKeyStoreManager(basePath);
 
         // Load or generate account key
-        accountKeyPair = keyStoreManager.loadOrGenerateAccountKey(config.getAccountKeyPath());
+        _accountKeyPair = _keyStoreManager.loadOrGenerateAccountKey(_config.getAccountKeyPath());
 
-        if (config.isDryRun())
+        if (_config.isDryRun())
         {
             LOG.info("ACME dry-run mode enabled - generating self-signed certificate");
             generateDryRunCertificate();
@@ -163,18 +163,18 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     @Override
     protected void doStop() throws Exception
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock l = _lock.lock())
         {
-            if (renewalTask != null)
+            if (_renewalTask != null)
             {
-                renewalTask.cancel();
-                renewalTask = null;
+                _renewalTask.cancel();
+                _renewalTask = null;
             }
 
-            if (ownHttpClient && httpClient != null)
+            if (_ownHttpClient && _httpClient != null)
             {
-                httpClient.stop();
-                httpClient = null;
+                _httpClient.stop();
+                _httpClient = null;
             }
         }
 
@@ -189,7 +189,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     @ManagedOperation(value = "Force certificate renewal check", impact = "ACTION")
     public void forceRenewalCheck() throws AcmeException
     {
-        if (config.isDryRun())
+        if (_config.isDryRun())
         {
             LOG.info("Dry-run mode: regenerating self-signed certificate");
             generateDryRunCertificate();
@@ -208,8 +208,8 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     {
         try
         {
-            X509Certificate cert = keyStoreManager.loadCertificate(
-                config.getKeystorePath(), config.getKeystorePassword());
+            X509Certificate cert = _keyStoreManager.loadCertificate(
+                _config.getKeystorePath(), _config.getKeystorePassword());
             return cert != null && !needsRenewal(cert);
         }
         catch (Exception e)
@@ -226,8 +226,8 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     {
         try
         {
-            X509Certificate cert = keyStoreManager.loadCertificate(
-                config.getKeystorePath(), config.getKeystorePassword());
+            X509Certificate cert = _keyStoreManager.loadCertificate(
+                _config.getKeystorePath(), _config.getKeystorePassword());
             if (cert == null)
                 return -1;
 
@@ -242,17 +242,17 @@ public class AcmeCertificateManager extends AbstractLifeCycle
 
     private void setupHttpClient() throws Exception
     {
-        if (server != null)
+        if (_server != null)
         {
             // Try to find an existing HttpClient bean
-            httpClient = server.getBean(HttpClient.class);
+            _httpClient = _server.getBean(HttpClient.class);
         }
 
-        if (httpClient == null)
+        if (_httpClient == null)
         {
-            httpClient = new HttpClient();
-            httpClient.start();
-            ownHttpClient = true;
+            _httpClient = new HttpClient();
+            _httpClient.start();
+            _ownHttpClient = true;
         }
     }
 
@@ -260,8 +260,8 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     {
         try
         {
-            X509Certificate currentCert = keyStoreManager.loadCertificate(
-                config.getKeystorePath(), config.getKeystorePassword());
+            X509Certificate currentCert = _keyStoreManager.loadCertificate(
+                _config.getKeystorePath(), _config.getKeystorePassword());
 
             if (currentCert == null || needsRenewal(currentCert))
             {
@@ -287,26 +287,26 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     private boolean needsRenewal(X509Certificate cert)
     {
         Instant expiry = cert.getNotAfter().toInstant();
-        Instant threshold = Instant.now().plus(config.getRenewalThresholdDays(), ChronoUnit.DAYS);
+        Instant threshold = Instant.now().plus(_config.getRenewalThresholdDays(), ChronoUnit.DAYS);
         return expiry.isBefore(threshold);
     }
 
     private void obtainNewCertificate() throws AcmeException
     {
-        AcmeClient acmeClient = new AcmeClient(httpClient, accountKeyPair, config.getDirectoryUrl());
+        AcmeClient acmeClient = new AcmeClient(_httpClient, _accountKeyPair, _config.getDirectoryUrl());
 
         try
         {
             // Step 1: Fetch directory
-            LOG.info("Fetching ACME directory from {}", config.getDirectoryUrl());
+            LOG.info("Fetching ACME directory from {}", _config.getDirectoryUrl());
             acmeClient.fetchDirectory();
 
             // Step 2: Create/find account
             LOG.info("Creating/finding ACME account");
-            acmeClient.createAccount(config.getAccountEmail(), config.isTermsOfServiceAgreed());
+            acmeClient.createAccount(_config.getAccountEmail(), _config.isTermsOfServiceAgreed());
 
             // Step 3: Create order
-            List<String> domains = config.getDomains();
+            List<String> domains = _config.getDomains();
             LOG.info("Creating order for domains: {}", domains);
             Map<String, Object> order = acmeClient.createOrder(domains);
 
@@ -322,8 +322,8 @@ public class AcmeCertificateManager extends AbstractLifeCycle
             }
 
             // Step 5: Generate domain key pair and CSR
-            domainKeyPair = keyStoreManager.generateDomainKeyPair();
-            byte[] csr = keyStoreManager.generateCSR(domainKeyPair, domains);
+            _domainKeyPair = _keyStoreManager.generateDomainKeyPair();
+            byte[] csr = _keyStoreManager.generateCSR(_domainKeyPair, domains);
 
             // Step 6: Finalize order
             LOG.info("Finalizing order");
@@ -339,10 +339,10 @@ public class AcmeCertificateManager extends AbstractLifeCycle
 
             // Step 9: Store certificate
             LOG.info("Storing certificate chain ({} certificates)", certificates.size());
-            keyStoreManager.storeCertificates(
-                config.getKeystorePath(),
-                config.getKeystorePassword(),
-                domainKeyPair.getPrivate(),
+            _keyStoreManager.storeCertificates(
+                _config.getKeystorePath(),
+                _config.getKeystorePassword(),
+                _domainKeyPair.getPrivate(),
                 certificates
             );
 
@@ -395,7 +395,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
 
         // Register challenge with handler
         LOG.info("Setting up HTTP-01 challenge for domain: {}", domain);
-        challengeHandler.addChallenge(token, keyAuthorization);
+        _challengeHandler.addChallenge(token, keyAuthorization);
 
         try
         {
@@ -410,30 +410,30 @@ public class AcmeCertificateManager extends AbstractLifeCycle
         finally
         {
             // Clean up challenge
-            challengeHandler.removeChallenge(token);
+            _challengeHandler.removeChallenge(token);
         }
     }
 
     private void generateDryRunCertificate() throws AcmeException
     {
-        List<String> domains = config.getDomains();
+        List<String> domains = _config.getDomains();
         if (domains.isEmpty())
         {
             domains = Collections.singletonList("localhost");
         }
 
         // Generate domain key pair
-        domainKeyPair = keyStoreManager.generateDomainKeyPair();
+        _domainKeyPair = _keyStoreManager.generateDomainKeyPair();
 
         // Generate self-signed certificate
-        X509Certificate cert = keyStoreManager.generateSelfSignedCertificate(
-            domainKeyPair, domains, DRY_RUN_VALIDITY_DAYS);
+        X509Certificate cert = _keyStoreManager.generateSelfSignedCertificate(
+            _domainKeyPair, domains, DRY_RUN_VALIDITY_DAYS);
 
         // Store certificate
-        keyStoreManager.storeCertificates(
-            config.getKeystorePath(),
-            config.getKeystorePassword(),
-            domainKeyPair.getPrivate(),
+        _keyStoreManager.storeCertificates(
+            _config.getKeystorePath(),
+            _config.getKeystorePassword(),
+            _domainKeyPair.getPrivate(),
             Collections.singletonList(cert)
         );
 
@@ -447,20 +447,20 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     {
         try
         {
-            Path keystorePath = config.getKeystorePath();
-            if (!keystorePath.isAbsolute() && server != null)
+            Path keystorePath = _config.getKeystorePath();
+            if (!keystorePath.isAbsolute() && _server != null)
             {
-                Object jettyBase = server.getAttribute("jetty.base");
+                Object jettyBase = _server.getAttribute("jetty.base");
                 if (jettyBase != null)
                     keystorePath = Path.of(jettyBase.toString()).resolve(keystorePath);
             }
 
             String keystorePathStr = keystorePath.toString();
 
-            sslContextFactory.reload(scf ->
+            _sslContextFactory.reload(scf ->
             {
                 scf.setKeyStorePath(keystorePathStr);
-                scf.setKeyStorePassword(config.getKeystorePassword());
+                scf.setKeyStorePassword(_config.getKeystorePassword());
             });
 
             LOG.info("SSL context reloaded with new certificate");
@@ -473,25 +473,25 @@ public class AcmeCertificateManager extends AbstractLifeCycle
 
     private void scheduleRenewalCheck()
     {
-        try (AutoLock l = lock.lock())
+        try (AutoLock l = _lock.lock())
         {
-            if (server != null)
+            if (_server != null)
             {
-                scheduler = server.getScheduler();
+                _scheduler = _server.getScheduler();
             }
 
-            if (scheduler == null || !scheduler.isStarted())
+            if (_scheduler == null || !_scheduler.isStarted())
             {
                 LOG.debug("No scheduler available, renewal checks will not be scheduled");
                 return;
             }
 
-            long intervalMs = config.getCheckIntervalSeconds() * 1000;
+            long intervalMs = _config.getCheckIntervalSeconds() * 1000;
 
-            renewalTask = scheduler.schedule(new RenewalRunner(), intervalMs, TimeUnit.MILLISECONDS);
+            _renewalTask = _scheduler.schedule(new RenewalRunner(), intervalMs, TimeUnit.MILLISECONDS);
 
             if (LOG.isDebugEnabled())
-                LOG.debug("Scheduled renewal check in {} seconds", config.getCheckIntervalSeconds());
+                LOG.debug("Scheduled renewal check in {} seconds", _config.getCheckIntervalSeconds());
         }
     }
 
@@ -508,10 +508,10 @@ public class AcmeCertificateManager extends AbstractLifeCycle
                 if (LOG.isDebugEnabled())
                     LOG.debug("Running scheduled renewal check");
 
-                if (config.isDryRun())
+                if (_config.isDryRun())
                 {
-                    X509Certificate cert = keyStoreManager.loadCertificate(
-                        config.getKeystorePath(), config.getKeystorePassword());
+                    X509Certificate cert = _keyStoreManager.loadCertificate(
+                        _config.getKeystorePath(), _config.getKeystorePassword());
                     if (cert == null || needsRenewal(cert))
                     {
                         LOG.info("Dry-run certificate needs renewal");
@@ -530,12 +530,12 @@ public class AcmeCertificateManager extends AbstractLifeCycle
             finally
             {
                 // Reschedule
-                try (AutoLock l = lock.lock())
+                try (AutoLock l = _lock.lock())
                 {
-                    if (scheduler != null && scheduler.isRunning() && isRunning())
+                    if (_scheduler != null && _scheduler.isRunning() && isRunning())
                     {
-                        long intervalMs = config.getCheckIntervalSeconds() * 1000;
-                        renewalTask = scheduler.schedule(this, intervalMs, TimeUnit.MILLISECONDS);
+                        long intervalMs = _config.getCheckIntervalSeconds() * 1000;
+                        _renewalTask = _scheduler.schedule(this, intervalMs, TimeUnit.MILLISECONDS);
                     }
                 }
             }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.acme;
 import java.nio.file.Path;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -73,20 +74,20 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     private static final int DRY_RUN_VALIDITY_DAYS = 90;
 
     /**
-     * Exponential backoff intervals in seconds for renewal failures.
+     * Exponential backoff intervals for renewal failures.
      * Starts at 1 minute, escalates up to 6 hours.
      */
-    private static final long[] BACKOFF_INTERVALS_SECONDS = {
-        60,       // 1 minute
-        120,      // 2 minutes
-        300,      // 5 minutes
-        600,      // 10 minutes
-        1200,     // 20 minutes
-        1800,     // 30 minutes
-        3600,     // 1 hour
-        7200,     // 2 hours
-        10800,    // 3 hours
-        21600     // 6 hours (max)
+    private static final Duration[] BACKOFF_INTERVALS = {
+        Duration.ofMinutes(1),
+        Duration.ofMinutes(2),
+        Duration.ofMinutes(5),
+        Duration.ofMinutes(10),
+        Duration.ofMinutes(20),
+        Duration.ofMinutes(30),
+        Duration.ofHours(1),
+        Duration.ofHours(2),
+        Duration.ofHours(3),
+        Duration.ofHours(6)
     };
 
     private final AutoLock _lock = new AutoLock();
@@ -504,12 +505,12 @@ public class AcmeCertificateManager extends AbstractLifeCycle
                 return;
             }
 
-            long intervalMs = _config.getCheckIntervalSeconds() * 1000;
+            long intervalMs = _config.getCheckInterval().toMillis();
 
             _renewalTask = _scheduler.schedule(new RenewalRunner(), intervalMs, TimeUnit.MILLISECONDS);
 
             if (LOG.isDebugEnabled())
-                LOG.debug("Scheduled renewal check in {} seconds", _config.getCheckIntervalSeconds());
+                LOG.debug("Scheduled renewal check in {} seconds", _config.getCheckInterval().toSeconds());
         }
     }
 
@@ -569,7 +570,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
                         if (success)
                         {
                             _consecutiveFailures = 0;
-                            intervalMs = _config.getCheckIntervalSeconds() * 1000;
+                            intervalMs = _config.getCheckInterval().toMillis();
                         }
                         else
                         {
@@ -593,9 +594,9 @@ public class AcmeCertificateManager extends AbstractLifeCycle
      */
     private long getBackoffIntervalMs(int failureCount)
     {
-        int index = Math.min(failureCount - 1, BACKOFF_INTERVALS_SECONDS.length - 1);
+        int index = Math.min(failureCount - 1, BACKOFF_INTERVALS.length - 1);
         if (index < 0)
             index = 0;
-        return BACKOFF_INTERVALS_SECONDS[index] * 1000;
+        return BACKOFF_INTERVALS[index].toMillis();
     }
 }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeCertificateManager.java
@@ -72,6 +72,23 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     private static final Logger LOG = LoggerFactory.getLogger(AcmeCertificateManager.class);
     private static final int DRY_RUN_VALIDITY_DAYS = 90;
 
+    /**
+     * Exponential backoff intervals in seconds for renewal failures.
+     * Starts at 1 minute, escalates up to 6 hours.
+     */
+    private static final long[] BACKOFF_INTERVALS_SECONDS = {
+        60,       // 1 minute
+        120,      // 2 minutes
+        300,      // 5 minutes
+        600,      // 10 minutes
+        1200,     // 20 minutes
+        1800,     // 30 minutes
+        3600,     // 1 hour
+        7200,     // 2 hours
+        10800,    // 3 hours
+        21600     // 6 hours (max)
+    };
+
     private final AutoLock _lock = new AutoLock();
     private final AcmeConfiguration _config;
     private final SslContextFactory.Server _sslContextFactory;
@@ -85,6 +102,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
     private boolean _ownHttpClient;
     private KeyPair _accountKeyPair;
     private KeyPair _domainKeyPair;
+    private int _consecutiveFailures;
 
     /**
      * Creates a new ACME certificate manager.
@@ -500,6 +518,7 @@ public class AcmeCertificateManager extends AbstractLifeCycle
         @Override
         public void run()
         {
+            boolean success = false;
             try
             {
                 if (isStopping() || isStopped())
@@ -522,6 +541,18 @@ public class AcmeCertificateManager extends AbstractLifeCycle
                 {
                     checkAndRenewIfNeeded();
                 }
+                success = true;
+            }
+            catch (AcmeException e)
+            {
+                if (e.isRateLimited())
+                {
+                    LOG.warn("ACME rate limit exceeded, will retry with backoff: {}", e.getMessage());
+                }
+                else
+                {
+                    LOG.warn("Certificate renewal check failed", e);
+                }
             }
             catch (Exception e)
             {
@@ -529,16 +560,42 @@ public class AcmeCertificateManager extends AbstractLifeCycle
             }
             finally
             {
-                // Reschedule
+                // Reschedule with backoff on failure
                 try (AutoLock l = _lock.lock())
                 {
                     if (_scheduler != null && _scheduler.isRunning() && isRunning())
                     {
-                        long intervalMs = _config.getCheckIntervalSeconds() * 1000;
+                        long intervalMs;
+                        if (success)
+                        {
+                            _consecutiveFailures = 0;
+                            intervalMs = _config.getCheckIntervalSeconds() * 1000;
+                        }
+                        else
+                        {
+                            _consecutiveFailures++;
+                            intervalMs = getBackoffIntervalMs(_consecutiveFailures);
+                            LOG.info("Scheduling next renewal attempt in {} seconds (failure #{})",
+                                intervalMs / 1000, _consecutiveFailures);
+                        }
                         _renewalTask = _scheduler.schedule(this, intervalMs, TimeUnit.MILLISECONDS);
                     }
                 }
             }
         }
+    }
+
+    /**
+     * Calculates the backoff interval based on the number of consecutive failures.
+     *
+     * @param failureCount the number of consecutive failures
+     * @return the backoff interval in milliseconds
+     */
+    private long getBackoffIntervalMs(int failureCount)
+    {
+        int index = Math.min(failureCount - 1, BACKOFF_INTERVALS_SECONDS.length - 1);
+        if (index < 0)
+            index = 0;
+        return BACKOFF_INTERVALS_SECONDS[index] * 1000;
     }
 }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
@@ -59,7 +59,7 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
      */
     public static final String CHALLENGE_PATH_PREFIX = "/.well-known/acme-challenge/";
 
-    private final ConcurrentMap<String, String> challenges = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> _challenges = new ConcurrentHashMap<>();
 
     /**
      * Creates a new ACME challenge handler.
@@ -83,7 +83,7 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
         if (token.isEmpty())
             return false;
 
-        String keyAuthorization = challenges.get(token);
+        String keyAuthorization = _challenges.get(token);
 
         if (keyAuthorization == null)
         {
@@ -119,7 +119,7 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
         if (LOG.isDebugEnabled())
             LOG.debug("Adding challenge: token={}", token);
 
-        challenges.put(token, keyAuthorization);
+        _challenges.put(token, keyAuthorization);
     }
 
     /**
@@ -133,7 +133,7 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
         if (LOG.isDebugEnabled())
             LOG.debug("Removing challenge: token={}", token);
 
-        challenges.remove(token);
+        _challenges.remove(token);
     }
 
     /**
@@ -142,7 +142,7 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
     @ManagedAttribute("Number of pending challenges")
     public int getPendingChallengeCount()
     {
-        return challenges.size();
+        return _challenges.size();
     }
 
     /**
@@ -154,6 +154,6 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
         if (LOG.isDebugEnabled())
             LOG.debug("Clearing all challenges");
 
-        challenges.clear();
+        _challenges.clear();
     }
 }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * </pre>
  */
 @ManagedObject("ACME Challenge Handler")
-public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
+public class AcmeChallengeHandler extends Handler.Wrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(AcmeChallengeHandler.class);
 
@@ -66,22 +66,33 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
      */
     public AcmeChallengeHandler()
     {
+        this(null);
+    }
+
+    /**
+     * Creates a new ACME challenge handler wrapping the given handler.
+     *
+     * @param handler the handler to wrap
+     */
+    public AcmeChallengeHandler(Handler handler)
+    {
+        super(handler);
     }
 
     @Override
-    public boolean handle(Request request, Response response, Callback callback)
+    public boolean handle(Request request, Response response, Callback callback) throws Exception
     {
         String path = request.getHttpURI().getPath();
 
         // Only handle requests to the challenge path
         if (!path.startsWith(CHALLENGE_PATH_PREFIX))
-            return false;
+            return super.handle(request, response, callback);
 
         String token = path.substring(CHALLENGE_PATH_PREFIX.length());
 
         // Ignore empty tokens
         if (token.isEmpty())
-            return false;
+            return super.handle(request, response, callback);
 
         String keyAuthorization = _challenges.get(token);
 
@@ -89,7 +100,10 @@ public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Challenge not found for token: {}", token);
-            return false;
+
+            // Return 404 for challenge URLs with unknown tokens
+            Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
+            return true;
         }
 
         if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeChallengeHandler.java
@@ -1,0 +1,159 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+import org.eclipse.jetty.util.annotation.ManagedOperation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Handler for ACME HTTP-01 challenges.</p>
+ * <p>This handler serves challenge responses at the well-known path
+ * {@code /.well-known/acme-challenge/{token}}. It should be installed
+ * early in the handler chain to intercept challenge requests before
+ * other handlers.</p>
+ *
+ * <p>The handler stores pending challenges in memory and serves
+ * the key authorization when the ACME server validates the domain.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * AcmeChallengeHandler challengeHandler = new AcmeChallengeHandler();
+ * server.insertHandler(challengeHandler);
+ *
+ * // Later, when setting up a challenge:
+ * challengeHandler.addChallenge(token, keyAuthorization);
+ * </pre>
+ */
+@ManagedObject("ACME Challenge Handler")
+public class AcmeChallengeHandler extends Handler.Abstract.NonBlocking
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AcmeChallengeHandler.class);
+
+    /**
+     * The well-known path prefix for ACME challenges.
+     */
+    public static final String CHALLENGE_PATH_PREFIX = "/.well-known/acme-challenge/";
+
+    private final ConcurrentMap<String, String> challenges = new ConcurrentHashMap<>();
+
+    /**
+     * Creates a new ACME challenge handler.
+     */
+    public AcmeChallengeHandler()
+    {
+    }
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback)
+    {
+        String path = request.getHttpURI().getPath();
+
+        // Only handle requests to the challenge path
+        if (!path.startsWith(CHALLENGE_PATH_PREFIX))
+            return false;
+
+        String token = path.substring(CHALLENGE_PATH_PREFIX.length());
+
+        // Ignore empty tokens
+        if (token.isEmpty())
+            return false;
+
+        String keyAuthorization = challenges.get(token);
+
+        if (keyAuthorization == null)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Challenge not found for token: {}", token);
+            return false;
+        }
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Serving challenge response for token: {}", token);
+
+        // Serve the key authorization
+        response.setStatus(HttpStatus.OK_200);
+        response.getHeaders().put(HttpHeader.CONTENT_TYPE, "text/plain; charset=utf-8");
+        response.getHeaders().put(HttpHeader.CACHE_CONTROL, "no-store");
+
+        byte[] content = keyAuthorization.getBytes(StandardCharsets.US_ASCII);
+        response.getHeaders().put(HttpHeader.CONTENT_LENGTH, content.length);
+
+        response.write(true, ByteBuffer.wrap(content), callback);
+        return true;
+    }
+
+    /**
+     * Adds a challenge for the ACME server to validate.
+     *
+     * @param token the challenge token
+     * @param keyAuthorization the key authorization to serve
+     */
+    @ManagedOperation(value = "Add a challenge", impact = "ACTION")
+    public void addChallenge(String token, String keyAuthorization)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Adding challenge: token={}", token);
+
+        challenges.put(token, keyAuthorization);
+    }
+
+    /**
+     * Removes a challenge after it has been completed or is no longer needed.
+     *
+     * @param token the challenge token to remove
+     */
+    @ManagedOperation(value = "Remove a challenge", impact = "ACTION")
+    public void removeChallenge(String token)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Removing challenge: token={}", token);
+
+        challenges.remove(token);
+    }
+
+    /**
+     * @return the number of pending challenges
+     */
+    @ManagedAttribute("Number of pending challenges")
+    public int getPendingChallengeCount()
+    {
+        return challenges.size();
+    }
+
+    /**
+     * Clears all pending challenges.
+     */
+    @ManagedOperation(value = "Clear all challenges", impact = "ACTION")
+    public void clearChallenges()
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Clearing all challenges");
+
+        challenges.clear();
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
@@ -56,13 +56,13 @@ public class AcmeClient
     private static final int MAX_POLL_ATTEMPTS = 30;
     private static final long POLL_DELAY_MS = 2000;
 
-    private final HttpClient httpClient;
-    private final JSON json;
-    private final AcmeJwsSigner signer;
-    private final String directoryUrl;
+    private final HttpClient _httpClient;
+    private final JSON _json;
+    private final AcmeJwsSigner _signer;
+    private final String _directoryUrl;
 
-    private Map<String, Object> directory;
-    private String lastNonce;
+    private Map<String, Object> _directory;
+    private String _lastNonce;
 
     /**
      * Creates a new ACME client.
@@ -73,10 +73,10 @@ public class AcmeClient
      */
     public AcmeClient(HttpClient httpClient, KeyPair accountKeyPair, String directoryUrl)
     {
-        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
-        this.directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
-        this.json = new JSON();
-        this.signer = new AcmeJwsSigner(accountKeyPair, json);
+        _httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        _directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
+        _json = new JSON();
+        _signer = new AcmeJwsSigner(accountKeyPair, _json);
     }
 
     /**
@@ -89,9 +89,9 @@ public class AcmeClient
         try
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Fetching ACME directory from {}", directoryUrl);
+                LOG.debug("Fetching ACME directory from {}", _directoryUrl);
 
-            ContentResponse response = httpClient.GET(directoryUrl);
+            ContentResponse response = _httpClient.GET(_directoryUrl);
 
             if (response.getStatus() != HttpStatus.OK_200)
             {
@@ -99,11 +99,11 @@ public class AcmeClient
             }
 
             @SuppressWarnings("unchecked")
-            Map<String, Object> result = (Map<String, Object>)json.fromJSON(response.getContentAsString());
-            directory = result;
+            Map<String, Object> result = (Map<String, Object>)_json.fromJSON(response.getContentAsString());
+            _directory = result;
 
             if (LOG.isDebugEnabled())
-                LOG.debug("Directory endpoints: {}", directory.keySet());
+                LOG.debug("Directory endpoints: {}", _directory.keySet());
         }
         catch (AcmeException e)
         {
@@ -126,7 +126,7 @@ public class AcmeClient
         try
         {
             String newNonceUrl = getEndpoint("newNonce");
-            ContentResponse response = httpClient.newRequest(newNonceUrl)
+            ContentResponse response = _httpClient.newRequest(newNonceUrl)
                 .method(HttpMethod.HEAD)
                 .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
                 .send();
@@ -135,7 +135,7 @@ public class AcmeClient
             if (nonce == null)
                 throw new AcmeException("No Replay-Nonce header in response");
 
-            lastNonce = nonce;
+            _lastNonce = nonce;
             return nonce;
         }
         catch (AcmeException e)
@@ -172,7 +172,7 @@ public class AcmeClient
         if (accountUrl == null)
             throw new AcmeException("No Location header in account response");
 
-        signer.setAccountUrl(accountUrl);
+        _signer.setAccountUrl(accountUrl);
 
         if (LOG.isDebugEnabled())
             LOG.debug("Account URL: {}", accountUrl);
@@ -351,9 +351,9 @@ public class AcmeClient
         {
             ensureNonce();
 
-            String jwsBody = signer.sign(null, lastNonce, certificateUrl);
+            String jwsBody = _signer.sign(null, _lastNonce, certificateUrl);
 
-            Request request = httpClient.newRequest(certificateUrl)
+            Request request = _httpClient.newRequest(certificateUrl)
                 .method(HttpMethod.POST)
                 .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
                 .headers(headers -> headers.put(HttpHeader.ACCEPT, PEM_CHAIN_CONTENT_TYPE))
@@ -361,7 +361,7 @@ public class AcmeClient
                 .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
             ContentResponse response = request.send();
-            lastNonce = response.getHeaders().get("Replay-Nonce");
+            _lastNonce = response.getHeaders().get("Replay-Nonce");
 
             if (response.getStatus() != HttpStatus.OK_200)
             {
@@ -390,7 +390,7 @@ public class AcmeClient
      */
     public String computeKeyAuthorization(String token) throws AcmeException
     {
-        return signer.computeKeyAuthorization(token);
+        return _signer.computeKeyAuthorization(token);
     }
 
     private Map<String, Object> signedPost(String url, Object payload, boolean expectLocation) throws AcmeException
@@ -399,9 +399,9 @@ public class AcmeClient
         {
             ensureNonce();
 
-            String jwsBody = signer.sign(payload, lastNonce, url);
+            String jwsBody = _signer.sign(payload, _lastNonce, url);
 
-            Request request = httpClient.newRequest(url)
+            Request request = _httpClient.newRequest(url)
                 .method(HttpMethod.POST)
                 .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
                 .body(new StringRequestContent(JOSE_JSON_CONTENT_TYPE, jwsBody))
@@ -412,7 +412,7 @@ public class AcmeClient
             // Always capture the new nonce
             String nonce = response.getHeaders().get("Replay-Nonce");
             if (nonce != null)
-                lastNonce = nonce;
+                _lastNonce = nonce;
 
             int status = response.getStatus();
             String content = response.getContentAsString();
@@ -424,7 +424,7 @@ public class AcmeClient
             if (status >= 400)
             {
                 @SuppressWarnings("unchecked")
-                Map<String, Object> error = (Map<String, Object>)json.fromJSON(content);
+                Map<String, Object> error = (Map<String, Object>)_json.fromJSON(content);
                 String type = (String)error.get("type");
                 String detail = (String)error.get("detail");
                 throw new AcmeException(detail != null ? detail : "ACME error", type, status);
@@ -433,7 +433,7 @@ public class AcmeClient
             // Parse response
             @SuppressWarnings("unchecked")
             Map<String, Object> result = content.isEmpty() ? new LinkedHashMap<>()
-                : (Map<String, Object>)json.fromJSON(content);
+                : (Map<String, Object>)_json.fromJSON(content);
 
             // Store location if present
             String location = response.getHeaders().get("Location");
@@ -454,16 +454,16 @@ public class AcmeClient
 
     private void ensureNonce() throws AcmeException
     {
-        if (lastNonce == null)
+        if (_lastNonce == null)
             fetchNonce();
     }
 
     private String getEndpoint(String name) throws AcmeException
     {
-        if (directory == null)
+        if (_directory == null)
             throw new AcmeException("Directory not fetched");
 
-        String endpoint = (String)directory.get(name);
+        String endpoint = (String)_directory.get(name);
         if (endpoint == null)
             throw new AcmeException("No endpoint for: " + name);
 

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -52,9 +53,9 @@ public class AcmeClient
     private static final Logger LOG = LoggerFactory.getLogger(AcmeClient.class);
     private static final String JOSE_JSON_CONTENT_TYPE = "application/jose+json";
     private static final String PEM_CHAIN_CONTENT_TYPE = "application/pem-certificate-chain";
-    private static final long REQUEST_TIMEOUT_MS = 30000;
+    private static final Duration REQUEST_TIMEOUT = Duration.ofSeconds(30);
     private static final int MAX_POLL_ATTEMPTS = 30;
-    private static final long POLL_DELAY_MS = 2000;
+    private static final Duration POLL_DELAY = Duration.ofSeconds(2);
     private static final int MAX_NONCE_RETRY_ATTEMPTS = 5;
 
     private final HttpClient _httpClient;
@@ -129,7 +130,7 @@ public class AcmeClient
             String newNonceUrl = getEndpoint("newNonce");
             ContentResponse response = _httpClient.newRequest(newNonceUrl)
                 .method(HttpMethod.HEAD)
-                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .timeout(REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)
                 .send();
 
             String nonce = response.getHeaders().get("Replay-Nonce");
@@ -267,7 +268,7 @@ public class AcmeClient
 
             try
             {
-                Thread.sleep(POLL_DELAY_MS);
+                Thread.sleep(POLL_DELAY.toMillis());
             }
             catch (InterruptedException e)
             {
@@ -309,7 +310,7 @@ public class AcmeClient
 
             try
             {
-                Thread.sleep(POLL_DELAY_MS);
+                Thread.sleep(POLL_DELAY.toMillis());
             }
             catch (InterruptedException e)
             {
@@ -359,7 +360,7 @@ public class AcmeClient
                 .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
                 .headers(headers -> headers.put(HttpHeader.ACCEPT, PEM_CHAIN_CONTENT_TYPE))
                 .body(new StringRequestContent(JOSE_JSON_CONTENT_TYPE, jwsBody))
-                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                .timeout(REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
             ContentResponse response = request.send();
             _lastNonce = response.getHeaders().get("Replay-Nonce");
@@ -434,7 +435,7 @@ public class AcmeClient
                 .method(HttpMethod.POST)
                 .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
                 .body(new StringRequestContent(JOSE_JSON_CONTENT_TYPE, jwsBody))
-                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+                .timeout(REQUEST_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
 
             ContentResponse response = request.send();
 

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
@@ -55,6 +55,7 @@ public class AcmeClient
     private static final long REQUEST_TIMEOUT_MS = 30000;
     private static final int MAX_POLL_ATTEMPTS = 30;
     private static final long POLL_DELAY_MS = 2000;
+    private static final int MAX_NONCE_RETRY_ATTEMPTS = 5;
 
     private final HttpClient _httpClient;
     private final JSON _json;
@@ -395,6 +396,34 @@ public class AcmeClient
 
     private Map<String, Object> signedPost(String url, Object payload, boolean expectLocation) throws AcmeException
     {
+        for (int attempt = 0; attempt < MAX_NONCE_RETRY_ATTEMPTS; attempt++)
+        {
+            try
+            {
+                return doSignedPost(url, payload);
+            }
+            catch (AcmeException e)
+            {
+                // Retry on badNonce errors (nonce expired or invalid)
+                if (e.isBadNonce() && attempt < MAX_NONCE_RETRY_ATTEMPTS - 1)
+                {
+                    LOG.debug("BadNonce error, retrying (attempt {}/{})", attempt + 1, MAX_NONCE_RETRY_ATTEMPTS);
+                    _lastNonce = null; // Force fresh nonce on retry
+                    continue;
+                }
+                // Log rate limit warnings
+                if (e.isRateLimited())
+                {
+                    LOG.warn("ACME rate limit exceeded: {}", e.getMessage());
+                }
+                throw e;
+            }
+        }
+        throw new AcmeException("Max nonce retry attempts exceeded");
+    }
+
+    private Map<String, Object> doSignedPost(String url, Object payload) throws AcmeException
+    {
         try
         {
             ensureNonce();
@@ -427,7 +456,8 @@ public class AcmeClient
                 Map<String, Object> error = (Map<String, Object>)_json.fromJSON(content);
                 String type = (String)error.get("type");
                 String detail = (String)error.get("detail");
-                throw new AcmeException(detail != null ? detail : "ACME error", type, status);
+                String retryAfter = response.getHeaders().get("Retry-After");
+                throw new AcmeException(detail != null ? detail : "ACME error", type, status, retryAfter);
             }
 
             // Parse response

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeClient.java
@@ -1,0 +1,493 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyPair;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.StringRequestContent;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.util.ajax.JSON;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>ACME protocol client implementation using Jetty HttpClient.</p>
+ * <p>Implements RFC 8555 (ACME) protocol operations including:</p>
+ * <ul>
+ *   <li>Directory discovery</li>
+ *   <li>Account registration</li>
+ *   <li>Order creation and finalization</li>
+ *   <li>HTTP-01 challenge handling</li>
+ *   <li>Certificate retrieval</li>
+ * </ul>
+ */
+public class AcmeClient
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AcmeClient.class);
+    private static final String JOSE_JSON_CONTENT_TYPE = "application/jose+json";
+    private static final String PEM_CHAIN_CONTENT_TYPE = "application/pem-certificate-chain";
+    private static final long REQUEST_TIMEOUT_MS = 30000;
+    private static final int MAX_POLL_ATTEMPTS = 30;
+    private static final long POLL_DELAY_MS = 2000;
+
+    private final HttpClient httpClient;
+    private final JSON json;
+    private final AcmeJwsSigner signer;
+    private final String directoryUrl;
+
+    private Map<String, Object> directory;
+    private String lastNonce;
+
+    /**
+     * Creates a new ACME client.
+     *
+     * @param httpClient the HTTP client to use for requests
+     * @param accountKeyPair the account key pair for signing
+     * @param directoryUrl the ACME directory URL
+     */
+    public AcmeClient(HttpClient httpClient, KeyPair accountKeyPair, String directoryUrl)
+    {
+        this.httpClient = Objects.requireNonNull(httpClient, "httpClient");
+        this.directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
+        this.json = new JSON();
+        this.signer = new AcmeJwsSigner(accountKeyPair, json);
+    }
+
+    /**
+     * Fetches the ACME directory to discover endpoint URLs.
+     *
+     * @throws AcmeException if the directory cannot be fetched
+     */
+    public void fetchDirectory() throws AcmeException
+    {
+        try
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Fetching ACME directory from {}", directoryUrl);
+
+            ContentResponse response = httpClient.GET(directoryUrl);
+
+            if (response.getStatus() != HttpStatus.OK_200)
+            {
+                throw new AcmeException("Failed to fetch directory: HTTP " + response.getStatus());
+            }
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> result = (Map<String, Object>)json.fromJSON(response.getContentAsString());
+            directory = result;
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Directory endpoints: {}", directory.keySet());
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to fetch directory", e);
+        }
+    }
+
+    /**
+     * Fetches a fresh nonce from the ACME server.
+     *
+     * @return the nonce value
+     * @throws AcmeException if the nonce cannot be fetched
+     */
+    public String fetchNonce() throws AcmeException
+    {
+        try
+        {
+            String newNonceUrl = getEndpoint("newNonce");
+            ContentResponse response = httpClient.newRequest(newNonceUrl)
+                .method(HttpMethod.HEAD)
+                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+                .send();
+
+            String nonce = response.getHeaders().get("Replay-Nonce");
+            if (nonce == null)
+                throw new AcmeException("No Replay-Nonce header in response");
+
+            lastNonce = nonce;
+            return nonce;
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to fetch nonce", e);
+        }
+    }
+
+    /**
+     * Creates a new account or finds an existing one.
+     *
+     * @param email the contact email address
+     * @param termsOfServiceAgreed whether the terms of service are agreed to
+     * @return the account URL
+     * @throws AcmeException if account creation fails
+     */
+    public String createAccount(String email, boolean termsOfServiceAgreed) throws AcmeException
+    {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("termsOfServiceAgreed", termsOfServiceAgreed);
+
+        if (email != null && !email.isEmpty())
+        {
+            payload.put("contact", new Object[]{"mailto:" + email});
+        }
+
+        Map<String, Object> response = signedPost(getEndpoint("newAccount"), payload, true);
+
+        String accountUrl = (String)response.get("_location");
+        if (accountUrl == null)
+            throw new AcmeException("No Location header in account response");
+
+        signer.setAccountUrl(accountUrl);
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Account URL: {}", accountUrl);
+
+        return accountUrl;
+    }
+
+    /**
+     * Creates a new order for the specified domains.
+     *
+     * @param domains the domain names to include in the certificate
+     * @return the order response containing authorization URLs
+     * @throws AcmeException if order creation fails
+     */
+    public Map<String, Object> createOrder(List<String> domains) throws AcmeException
+    {
+        List<Map<String, String>> identifiers = new ArrayList<>();
+        for (String domain : domains)
+        {
+            Map<String, String> identifier = new LinkedHashMap<>();
+            identifier.put("type", "dns");
+            identifier.put("value", domain);
+            identifiers.add(identifier);
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("identifiers", identifiers.toArray());
+
+        Map<String, Object> response = signedPost(getEndpoint("newOrder"), payload, true);
+
+        if (LOG.isDebugEnabled())
+            LOG.debug("Order created: {}", response.get("_location"));
+
+        return response;
+    }
+
+    /**
+     * Fetches an authorization and its challenges.
+     *
+     * @param authorizationUrl the authorization URL
+     * @return the authorization response containing challenges
+     * @throws AcmeException if fetching fails
+     */
+    public Map<String, Object> getAuthorization(String authorizationUrl) throws AcmeException
+    {
+        // POST-as-GET (empty payload)
+        return signedPost(authorizationUrl, null, false);
+    }
+
+    /**
+     * Responds to a challenge to indicate readiness.
+     *
+     * @param challengeUrl the challenge URL
+     * @return the challenge response
+     * @throws AcmeException if the challenge response fails
+     */
+    public Map<String, Object> respondToChallenge(String challengeUrl) throws AcmeException
+    {
+        // Empty object payload to trigger validation
+        Map<String, Object> payload = new LinkedHashMap<>();
+        return signedPost(challengeUrl, payload, false);
+    }
+
+    /**
+     * Polls for challenge completion.
+     *
+     * @param challengeUrl the challenge URL to poll
+     * @return the final challenge status
+     * @throws AcmeException if polling fails or times out
+     */
+    public Map<String, Object> pollChallengeStatus(String challengeUrl) throws AcmeException
+    {
+        for (int i = 0; i < MAX_POLL_ATTEMPTS; i++)
+        {
+            Map<String, Object> challenge = signedPost(challengeUrl, null, false);
+            String status = (String)challenge.get("status");
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Challenge status: {}", status);
+
+            if ("valid".equals(status))
+                return challenge;
+
+            if ("invalid".equals(status))
+            {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> error = (Map<String, Object>)challenge.get("error");
+                String errorDetail = error != null ? (String)error.get("detail") : "Unknown error";
+                throw new AcmeException("Challenge failed: " + errorDetail);
+            }
+
+            try
+            {
+                Thread.sleep(POLL_DELAY_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                throw new AcmeException("Polling interrupted", e);
+            }
+        }
+
+        throw new AcmeException("Challenge polling timed out");
+    }
+
+    /**
+     * Polls for order completion.
+     *
+     * @param orderUrl the order URL to poll
+     * @return the final order status
+     * @throws AcmeException if polling fails or times out
+     */
+    public Map<String, Object> pollOrderStatus(String orderUrl) throws AcmeException
+    {
+        for (int i = 0; i < MAX_POLL_ATTEMPTS; i++)
+        {
+            Map<String, Object> order = signedPost(orderUrl, null, false);
+            String status = (String)order.get("status");
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Order status: {}", status);
+
+            if ("valid".equals(status))
+                return order;
+
+            if ("invalid".equals(status))
+            {
+                throw new AcmeException("Order failed");
+            }
+
+            if ("ready".equals(status))
+                return order;
+
+            try
+            {
+                Thread.sleep(POLL_DELAY_MS);
+            }
+            catch (InterruptedException e)
+            {
+                Thread.currentThread().interrupt();
+                throw new AcmeException("Polling interrupted", e);
+            }
+        }
+
+        throw new AcmeException("Order polling timed out");
+    }
+
+    /**
+     * Finalizes an order with a CSR.
+     *
+     * @param finalizeUrl the finalize URL from the order
+     * @param csrDer the DER-encoded CSR
+     * @return the finalize response
+     * @throws AcmeException if finalization fails
+     */
+    public Map<String, Object> finalizeOrder(String finalizeUrl, byte[] csrDer) throws AcmeException
+    {
+        String csrB64 = java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(csrDer);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("csr", csrB64);
+
+        return signedPost(finalizeUrl, payload, false);
+    }
+
+    /**
+     * Downloads the certificate chain.
+     *
+     * @param certificateUrl the certificate URL from the order
+     * @return the list of certificates in the chain
+     * @throws AcmeException if download fails
+     */
+    public List<X509Certificate> downloadCertificate(String certificateUrl) throws AcmeException
+    {
+        try
+        {
+            ensureNonce();
+
+            String jwsBody = signer.sign(null, lastNonce, certificateUrl);
+
+            Request request = httpClient.newRequest(certificateUrl)
+                .method(HttpMethod.POST)
+                .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
+                .headers(headers -> headers.put(HttpHeader.ACCEPT, PEM_CHAIN_CONTENT_TYPE))
+                .body(new StringRequestContent(JOSE_JSON_CONTENT_TYPE, jwsBody))
+                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+            ContentResponse response = request.send();
+            lastNonce = response.getHeaders().get("Replay-Nonce");
+
+            if (response.getStatus() != HttpStatus.OK_200)
+            {
+                throw new AcmeException("Failed to download certificate: HTTP " + response.getStatus());
+            }
+
+            String pemChain = response.getContentAsString();
+            return parsePemChain(pemChain);
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to download certificate", e);
+        }
+    }
+
+    /**
+     * Computes the key authorization for an HTTP-01 challenge.
+     *
+     * @param token the challenge token
+     * @return the key authorization string
+     * @throws AcmeException if computation fails
+     */
+    public String computeKeyAuthorization(String token) throws AcmeException
+    {
+        return signer.computeKeyAuthorization(token);
+    }
+
+    private Map<String, Object> signedPost(String url, Object payload, boolean expectLocation) throws AcmeException
+    {
+        try
+        {
+            ensureNonce();
+
+            String jwsBody = signer.sign(payload, lastNonce, url);
+
+            Request request = httpClient.newRequest(url)
+                .method(HttpMethod.POST)
+                .headers(headers -> headers.put(HttpHeader.CONTENT_TYPE, JOSE_JSON_CONTENT_TYPE))
+                .body(new StringRequestContent(JOSE_JSON_CONTENT_TYPE, jwsBody))
+                .timeout(REQUEST_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+            ContentResponse response = request.send();
+
+            // Always capture the new nonce
+            String nonce = response.getHeaders().get("Replay-Nonce");
+            if (nonce != null)
+                lastNonce = nonce;
+
+            int status = response.getStatus();
+            String content = response.getContentAsString();
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("POST {} -> {} {}", url, status, content.length() > 200 ? content.substring(0, 200) + "..." : content);
+
+            // Check for error response
+            if (status >= 400)
+            {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> error = (Map<String, Object>)json.fromJSON(content);
+                String type = (String)error.get("type");
+                String detail = (String)error.get("detail");
+                throw new AcmeException(detail != null ? detail : "ACME error", type, status);
+            }
+
+            // Parse response
+            @SuppressWarnings("unchecked")
+            Map<String, Object> result = content.isEmpty() ? new LinkedHashMap<>()
+                : (Map<String, Object>)json.fromJSON(content);
+
+            // Store location if present
+            String location = response.getHeaders().get("Location");
+            if (location != null)
+                result.put("_location", location);
+
+            return result;
+        }
+        catch (AcmeException e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to POST to " + url, e);
+        }
+    }
+
+    private void ensureNonce() throws AcmeException
+    {
+        if (lastNonce == null)
+            fetchNonce();
+    }
+
+    private String getEndpoint(String name) throws AcmeException
+    {
+        if (directory == null)
+            throw new AcmeException("Directory not fetched");
+
+        String endpoint = (String)directory.get(name);
+        if (endpoint == null)
+            throw new AcmeException("No endpoint for: " + name);
+
+        return endpoint;
+    }
+
+    private List<X509Certificate> parsePemChain(String pemChain) throws Exception
+    {
+        List<X509Certificate> certificates = new ArrayList<>();
+        CertificateFactory cf = CertificateFactory.getInstance("X.509");
+
+        // Split PEM chain by certificate boundaries
+        String[] pems = pemChain.split("(?=-----BEGIN CERTIFICATE-----)");
+        for (String pem : pems)
+        {
+            pem = pem.trim();
+            if (pem.isEmpty())
+                continue;
+
+            ByteArrayInputStream bis = new ByteArrayInputStream(pem.getBytes(StandardCharsets.UTF_8));
+            X509Certificate cert = (X509Certificate)cf.generateCertificate(bis);
+            certificates.add(cert);
+        }
+
+        return certificates;
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.acme;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -59,7 +60,7 @@ public class AcmeConfiguration
     private Path _keystorePath = Path.of("etc/keystore.p12");
     private String _keystorePassword = "changeit";
     private int _renewalThresholdDays = 30;
-    private long _checkIntervalSeconds = 86400;
+    private Duration _checkInterval = Duration.ofDays(1);
     private boolean _termsOfServiceAgreed = false;
 
     /**
@@ -265,22 +266,33 @@ public class AcmeConfiguration
     }
 
     /**
-     * @return the renewal check interval in seconds
+     * @return the renewal check interval
      */
-    @ManagedAttribute("Renewal check interval in seconds")
-    public long getCheckIntervalSeconds()
+    @ManagedAttribute("Renewal check interval")
+    public Duration getCheckInterval()
     {
-        return _checkIntervalSeconds;
+        return _checkInterval;
     }
 
     /**
      * Sets how often to check if certificates need renewal.
      *
+     * @param checkInterval the check interval
+     */
+    public void setCheckInterval(Duration checkInterval)
+    {
+        _checkInterval = Objects.requireNonNull(checkInterval, "checkInterval");
+    }
+
+    /**
+     * Sets how often to check if certificates need renewal.
+     * This method is provided for XML configuration compatibility.
+     *
      * @param checkIntervalSeconds the interval in seconds
      */
     public void setCheckIntervalSeconds(long checkIntervalSeconds)
     {
-        _checkIntervalSeconds = checkIntervalSeconds;
+        _checkInterval = Duration.ofSeconds(checkIntervalSeconds);
     }
 
     /**

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
@@ -51,16 +51,16 @@ public class AcmeConfiguration
      */
     public static final String LETSENCRYPT_STAGING_URL = "https://acme-staging-v02.api.letsencrypt.org/directory";
 
-    private boolean dryRun = true;
-    private String directoryUrl = LETSENCRYPT_STAGING_URL;
-    private List<String> domains = new ArrayList<>();
-    private String accountEmail;
-    private Path accountKeyPath = Path.of("acme/account.key");
-    private Path keystorePath = Path.of("etc/keystore.p12");
-    private String keystorePassword = "changeit";
-    private int renewalThresholdDays = 30;
-    private long checkIntervalSeconds = 86400;
-    private boolean termsOfServiceAgreed = false;
+    private boolean _dryRun = true;
+    private String _directoryUrl = LETSENCRYPT_STAGING_URL;
+    private List<String> _domains = new ArrayList<>();
+    private String _accountEmail;
+    private Path _accountKeyPath = Path.of("acme/account.key");
+    private Path _keystorePath = Path.of("etc/keystore.p12");
+    private String _keystorePassword = "changeit";
+    private int _renewalThresholdDays = 30;
+    private long _checkIntervalSeconds = 86400;
+    private boolean _termsOfServiceAgreed = false;
 
     /**
      * Creates a new AcmeConfiguration with default settings.
@@ -75,7 +75,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Dry run mode - simulates certificate flow without contacting ACME")
     public boolean isDryRun()
     {
-        return dryRun;
+        return _dryRun;
     }
 
     /**
@@ -86,7 +86,7 @@ public class AcmeConfiguration
      */
     public void setDryRun(boolean dryRun)
     {
-        this.dryRun = dryRun;
+        _dryRun = dryRun;
     }
 
     /**
@@ -95,7 +95,7 @@ public class AcmeConfiguration
     @ManagedAttribute("ACME directory URL")
     public String getDirectoryUrl()
     {
-        return directoryUrl;
+        return _directoryUrl;
     }
 
     /**
@@ -106,7 +106,7 @@ public class AcmeConfiguration
      */
     public void setDirectoryUrl(String directoryUrl)
     {
-        this.directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
+        _directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
     }
 
     /**
@@ -115,7 +115,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Domain names for the certificate")
     public List<String> getDomains()
     {
-        return Collections.unmodifiableList(domains);
+        return Collections.unmodifiableList(_domains);
     }
 
     /**
@@ -125,7 +125,7 @@ public class AcmeConfiguration
      */
     public void setDomains(List<String> domains)
     {
-        this.domains = new ArrayList<>(Objects.requireNonNull(domains, "domains"));
+        _domains = new ArrayList<>(Objects.requireNonNull(domains, "domains"));
     }
 
     /**
@@ -135,14 +135,14 @@ public class AcmeConfiguration
      */
     public void setDomains(String domains)
     {
-        this.domains.clear();
+        _domains.clear();
         if (StringUtil.isNotBlank(domains))
         {
             for (String domain : StringUtil.csvSplit(domains))
             {
                 String trimmed = domain.trim();
                 if (!trimmed.isEmpty())
-                    this.domains.add(trimmed);
+                    _domains.add(trimmed);
             }
         }
     }
@@ -153,7 +153,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Contact email for ACME account")
     public String getAccountEmail()
     {
-        return accountEmail;
+        return _accountEmail;
     }
 
     /**
@@ -163,7 +163,7 @@ public class AcmeConfiguration
      */
     public void setAccountEmail(String accountEmail)
     {
-        this.accountEmail = accountEmail;
+        _accountEmail = accountEmail;
     }
 
     /**
@@ -172,7 +172,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Path to store account key")
     public Path getAccountKeyPath()
     {
-        return accountKeyPath;
+        return _accountKeyPath;
     }
 
     /**
@@ -182,7 +182,7 @@ public class AcmeConfiguration
      */
     public void setAccountKeyPath(Path accountKeyPath)
     {
-        this.accountKeyPath = Objects.requireNonNull(accountKeyPath, "accountKeyPath");
+        _accountKeyPath = Objects.requireNonNull(accountKeyPath, "accountKeyPath");
     }
 
     /**
@@ -193,7 +193,7 @@ public class AcmeConfiguration
     public void setAccountKeyPath(String accountKeyPath)
     {
         if (StringUtil.isNotBlank(accountKeyPath))
-            this.accountKeyPath = Path.of(accountKeyPath);
+            _accountKeyPath = Path.of(accountKeyPath);
     }
 
     /**
@@ -202,7 +202,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Keystore path")
     public Path getKeystorePath()
     {
-        return keystorePath;
+        return _keystorePath;
     }
 
     /**
@@ -212,7 +212,7 @@ public class AcmeConfiguration
      */
     public void setKeystorePath(Path keystorePath)
     {
-        this.keystorePath = Objects.requireNonNull(keystorePath, "keystorePath");
+        _keystorePath = Objects.requireNonNull(keystorePath, "keystorePath");
     }
 
     /**
@@ -223,7 +223,7 @@ public class AcmeConfiguration
     public void setKeystorePath(String keystorePath)
     {
         if (StringUtil.isNotBlank(keystorePath))
-            this.keystorePath = Path.of(keystorePath);
+            _keystorePath = Path.of(keystorePath);
     }
 
     /**
@@ -232,7 +232,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Keystore password")
     public String getKeystorePassword()
     {
-        return keystorePassword;
+        return _keystorePassword;
     }
 
     /**
@@ -242,7 +242,7 @@ public class AcmeConfiguration
      */
     public void setKeystorePassword(String keystorePassword)
     {
-        this.keystorePassword = keystorePassword;
+        _keystorePassword = keystorePassword;
     }
 
     /**
@@ -251,7 +251,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Days before expiry to trigger renewal")
     public int getRenewalThresholdDays()
     {
-        return renewalThresholdDays;
+        return _renewalThresholdDays;
     }
 
     /**
@@ -261,7 +261,7 @@ public class AcmeConfiguration
      */
     public void setRenewalThresholdDays(int renewalThresholdDays)
     {
-        this.renewalThresholdDays = renewalThresholdDays;
+        _renewalThresholdDays = renewalThresholdDays;
     }
 
     /**
@@ -270,7 +270,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Renewal check interval in seconds")
     public long getCheckIntervalSeconds()
     {
-        return checkIntervalSeconds;
+        return _checkIntervalSeconds;
     }
 
     /**
@@ -280,7 +280,7 @@ public class AcmeConfiguration
      */
     public void setCheckIntervalSeconds(long checkIntervalSeconds)
     {
-        this.checkIntervalSeconds = checkIntervalSeconds;
+        _checkIntervalSeconds = checkIntervalSeconds;
     }
 
     /**
@@ -289,7 +289,7 @@ public class AcmeConfiguration
     @ManagedAttribute("Terms of service agreement")
     public boolean isTermsOfServiceAgreed()
     {
-        return termsOfServiceAgreed;
+        return _termsOfServiceAgreed;
     }
 
     /**
@@ -300,7 +300,7 @@ public class AcmeConfiguration
      */
     public void setTermsOfServiceAgreed(boolean termsOfServiceAgreed)
     {
-        this.termsOfServiceAgreed = termsOfServiceAgreed;
+        _termsOfServiceAgreed = termsOfServiceAgreed;
     }
 
     /**
@@ -310,14 +310,14 @@ public class AcmeConfiguration
      */
     public void validate()
     {
-        if (dryRun)
+        if (_dryRun)
             return;
 
-        if (domains.isEmpty())
+        if (_domains.isEmpty())
             throw new IllegalStateException("At least one domain must be configured");
-        if (StringUtil.isBlank(accountEmail))
+        if (StringUtil.isBlank(_accountEmail))
             throw new IllegalStateException("Account email must be configured");
-        if (!termsOfServiceAgreed)
+        if (!_termsOfServiceAgreed)
             throw new IllegalStateException("Terms of service must be agreed to for production use");
     }
 
@@ -327,9 +327,9 @@ public class AcmeConfiguration
         return String.format("%s@%x{dryRun=%b,directoryUrl=%s,domains=%s,accountEmail=%s}",
             getClass().getSimpleName(),
             hashCode(),
-            dryRun,
-            directoryUrl,
-            domains,
-            accountEmail);
+            _dryRun,
+            _directoryUrl,
+            _domains,
+            _accountEmail);
     }
 }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
@@ -1,0 +1,335 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
+
+/**
+ * <p>Configuration holder for ACME certificate management.</p>
+ * <p>This class stores all settings required for ACME protocol operations,
+ * including the ACME directory URL, domain names, account information,
+ * and keystore paths.</p>
+ *
+ * <h2>Example Configuration</h2>
+ * <pre>
+ * AcmeConfiguration config = new AcmeConfiguration();
+ * config.setDomains("example.com,www.example.com");
+ * config.setAccountEmail("admin@example.com");
+ * config.setTermsOfServiceAgreed(true);
+ * config.setDryRun(false);
+ * </pre>
+ */
+@ManagedObject("ACME Configuration")
+public class AcmeConfiguration
+{
+    /**
+     * Let's Encrypt production directory URL.
+     */
+    public static final String LETSENCRYPT_PRODUCTION_URL = "https://acme-v02.api.letsencrypt.org/directory";
+
+    /**
+     * Let's Encrypt staging directory URL (for testing).
+     */
+    public static final String LETSENCRYPT_STAGING_URL = "https://acme-staging-v02.api.letsencrypt.org/directory";
+
+    private boolean dryRun = true;
+    private String directoryUrl = LETSENCRYPT_STAGING_URL;
+    private List<String> domains = new ArrayList<>();
+    private String accountEmail;
+    private Path accountKeyPath = Path.of("acme/account.key");
+    private Path keystorePath = Path.of("etc/keystore.p12");
+    private String keystorePassword = "changeit";
+    private int renewalThresholdDays = 30;
+    private long checkIntervalSeconds = 86400;
+    private boolean termsOfServiceAgreed = false;
+
+    /**
+     * Creates a new AcmeConfiguration with default settings.
+     */
+    public AcmeConfiguration()
+    {
+    }
+
+    /**
+     * @return true if dry-run mode is enabled (no real ACME calls)
+     */
+    @ManagedAttribute("Dry run mode - simulates certificate flow without contacting ACME")
+    public boolean isDryRun()
+    {
+        return dryRun;
+    }
+
+    /**
+     * Sets dry-run mode. When enabled, the manager generates self-signed
+     * certificates instead of contacting the ACME server.
+     *
+     * @param dryRun true to enable dry-run mode
+     */
+    public void setDryRun(boolean dryRun)
+    {
+        this.dryRun = dryRun;
+    }
+
+    /**
+     * @return the ACME directory URL
+     */
+    @ManagedAttribute("ACME directory URL")
+    public String getDirectoryUrl()
+    {
+        return directoryUrl;
+    }
+
+    /**
+     * Sets the ACME directory URL. Use {@link #LETSENCRYPT_STAGING_URL}
+     * for testing or {@link #LETSENCRYPT_PRODUCTION_URL} for production.
+     *
+     * @param directoryUrl the ACME directory URL
+     */
+    public void setDirectoryUrl(String directoryUrl)
+    {
+        this.directoryUrl = Objects.requireNonNull(directoryUrl, "directoryUrl");
+    }
+
+    /**
+     * @return the list of domain names for the certificate
+     */
+    @ManagedAttribute("Domain names for the certificate")
+    public List<String> getDomains()
+    {
+        return Collections.unmodifiableList(domains);
+    }
+
+    /**
+     * Sets the domain names for the certificate.
+     *
+     * @param domains the list of domain names
+     */
+    public void setDomains(List<String> domains)
+    {
+        this.domains = new ArrayList<>(Objects.requireNonNull(domains, "domains"));
+    }
+
+    /**
+     * Sets the domain names from a comma-separated string.
+     *
+     * @param domains comma-separated domain names
+     */
+    public void setDomains(String domains)
+    {
+        this.domains.clear();
+        if (StringUtil.isNotBlank(domains))
+        {
+            for (String domain : StringUtil.csvSplit(domains))
+            {
+                String trimmed = domain.trim();
+                if (!trimmed.isEmpty())
+                    this.domains.add(trimmed);
+            }
+        }
+    }
+
+    /**
+     * @return the account email address
+     */
+    @ManagedAttribute("Contact email for ACME account")
+    public String getAccountEmail()
+    {
+        return accountEmail;
+    }
+
+    /**
+     * Sets the account email address for ACME registration.
+     *
+     * @param accountEmail the email address
+     */
+    public void setAccountEmail(String accountEmail)
+    {
+        this.accountEmail = accountEmail;
+    }
+
+    /**
+     * @return the path to the account key file
+     */
+    @ManagedAttribute("Path to store account key")
+    public Path getAccountKeyPath()
+    {
+        return accountKeyPath;
+    }
+
+    /**
+     * Sets the path where the ACME account private key will be stored.
+     *
+     * @param accountKeyPath the path to the account key file
+     */
+    public void setAccountKeyPath(Path accountKeyPath)
+    {
+        this.accountKeyPath = Objects.requireNonNull(accountKeyPath, "accountKeyPath");
+    }
+
+    /**
+     * Sets the account key path from a string.
+     *
+     * @param accountKeyPath the path string
+     */
+    public void setAccountKeyPath(String accountKeyPath)
+    {
+        if (StringUtil.isNotBlank(accountKeyPath))
+            this.accountKeyPath = Path.of(accountKeyPath);
+    }
+
+    /**
+     * @return the keystore path
+     */
+    @ManagedAttribute("Keystore path")
+    public Path getKeystorePath()
+    {
+        return keystorePath;
+    }
+
+    /**
+     * Sets the path to the keystore where certificates will be stored.
+     *
+     * @param keystorePath the keystore path
+     */
+    public void setKeystorePath(Path keystorePath)
+    {
+        this.keystorePath = Objects.requireNonNull(keystorePath, "keystorePath");
+    }
+
+    /**
+     * Sets the keystore path from a string.
+     *
+     * @param keystorePath the path string
+     */
+    public void setKeystorePath(String keystorePath)
+    {
+        if (StringUtil.isNotBlank(keystorePath))
+            this.keystorePath = Path.of(keystorePath);
+    }
+
+    /**
+     * @return the keystore password
+     */
+    @ManagedAttribute("Keystore password")
+    public String getKeystorePassword()
+    {
+        return keystorePassword;
+    }
+
+    /**
+     * Sets the keystore password.
+     *
+     * @param keystorePassword the password
+     */
+    public void setKeystorePassword(String keystorePassword)
+    {
+        this.keystorePassword = keystorePassword;
+    }
+
+    /**
+     * @return days before expiry to trigger renewal
+     */
+    @ManagedAttribute("Days before expiry to trigger renewal")
+    public int getRenewalThresholdDays()
+    {
+        return renewalThresholdDays;
+    }
+
+    /**
+     * Sets the number of days before certificate expiry to trigger renewal.
+     *
+     * @param renewalThresholdDays the renewal threshold in days
+     */
+    public void setRenewalThresholdDays(int renewalThresholdDays)
+    {
+        this.renewalThresholdDays = renewalThresholdDays;
+    }
+
+    /**
+     * @return the renewal check interval in seconds
+     */
+    @ManagedAttribute("Renewal check interval in seconds")
+    public long getCheckIntervalSeconds()
+    {
+        return checkIntervalSeconds;
+    }
+
+    /**
+     * Sets how often to check if certificates need renewal.
+     *
+     * @param checkIntervalSeconds the interval in seconds
+     */
+    public void setCheckIntervalSeconds(long checkIntervalSeconds)
+    {
+        this.checkIntervalSeconds = checkIntervalSeconds;
+    }
+
+    /**
+     * @return true if the ACME terms of service have been agreed to
+     */
+    @ManagedAttribute("Terms of service agreement")
+    public boolean isTermsOfServiceAgreed()
+    {
+        return termsOfServiceAgreed;
+    }
+
+    /**
+     * Sets whether the ACME terms of service have been agreed to.
+     * This must be true for production use.
+     *
+     * @param termsOfServiceAgreed true if terms are agreed
+     */
+    public void setTermsOfServiceAgreed(boolean termsOfServiceAgreed)
+    {
+        this.termsOfServiceAgreed = termsOfServiceAgreed;
+    }
+
+    /**
+     * Validates this configuration.
+     *
+     * @throws IllegalStateException if the configuration is invalid
+     */
+    public void validate()
+    {
+        if (dryRun)
+            return;
+
+        if (domains.isEmpty())
+            throw new IllegalStateException("At least one domain must be configured");
+        if (StringUtil.isBlank(accountEmail))
+            throw new IllegalStateException("Account email must be configured");
+        if (!termsOfServiceAgreed)
+            throw new IllegalStateException("Terms of service must be agreed to for production use");
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s@%x{dryRun=%b,directoryUrl=%s,domains=%s,accountEmail=%s}",
+            getClass().getSimpleName(),
+            hashCode(),
+            dryRun,
+            directoryUrl,
+            domains,
+            accountEmail);
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeConfiguration.java
@@ -58,7 +58,7 @@ public class AcmeConfiguration
     private String _accountEmail;
     private Path _accountKeyPath = Path.of("acme/account.key");
     private Path _keystorePath = Path.of("etc/keystore.p12");
-    private String _keystorePassword = "changeit";
+    private String _keystorePassword = "storepwd";
     private int _renewalThresholdDays = 30;
     private Duration _checkInterval = Duration.ofDays(1);
     private boolean _termsOfServiceAgreed = false;

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeException.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeException.java
@@ -20,8 +20,19 @@ package org.eclipse.jetty.acme;
  */
 public class AcmeException extends Exception
 {
+    /**
+     * ACME error type for bad nonce errors.
+     */
+    public static final String BAD_NONCE = "urn:ietf:params:acme:error:badNonce";
+
+    /**
+     * ACME error type for rate limit errors.
+     */
+    public static final String RATE_LIMITED = "urn:ietf:params:acme:error:rateLimited";
+
     private final String type;
     private final int statusCode;
+    private final String retryAfter;
 
     /**
      * Creates a new AcmeException with a message.
@@ -30,7 +41,7 @@ public class AcmeException extends Exception
      */
     public AcmeException(String message)
     {
-        this(message, null, 0, null);
+        this(message, null, 0, null, null);
     }
 
     /**
@@ -41,7 +52,7 @@ public class AcmeException extends Exception
      */
     public AcmeException(String message, Throwable cause)
     {
-        this(message, null, 0, cause);
+        this(message, null, 0, null, cause);
     }
 
     /**
@@ -53,7 +64,20 @@ public class AcmeException extends Exception
      */
     public AcmeException(String message, String type, int statusCode)
     {
-        this(message, type, statusCode, null);
+        this(message, type, statusCode, null, null);
+    }
+
+    /**
+     * Creates a new AcmeException with ACME error details and Retry-After.
+     *
+     * @param message the error message
+     * @param type the ACME error type URN
+     * @param statusCode the HTTP status code
+     * @param retryAfter the Retry-After header value, or null
+     */
+    public AcmeException(String message, String type, int statusCode, String retryAfter)
+    {
+        this(message, type, statusCode, retryAfter, null);
     }
 
     /**
@@ -62,13 +86,15 @@ public class AcmeException extends Exception
      * @param message the error message
      * @param type the ACME error type URN
      * @param statusCode the HTTP status code
+     * @param retryAfter the Retry-After header value, or null
      * @param cause the underlying cause
      */
-    public AcmeException(String message, String type, int statusCode, Throwable cause)
+    public AcmeException(String message, String type, int statusCode, String retryAfter, Throwable cause)
     {
         super(message, cause);
         this.type = type;
         this.statusCode = statusCode;
+        this.retryAfter = retryAfter;
     }
 
     /**
@@ -87,6 +113,30 @@ public class AcmeException extends Exception
         return statusCode;
     }
 
+    /**
+     * @return the Retry-After header value from the ACME server, or null if not present
+     */
+    public String getRetryAfter()
+    {
+        return retryAfter;
+    }
+
+    /**
+     * @return true if this is a badNonce error that can be retried with a fresh nonce
+     */
+    public boolean isBadNonce()
+    {
+        return BAD_NONCE.equals(type);
+    }
+
+    /**
+     * @return true if this is a rate limit error
+     */
+    public boolean isRateLimited()
+    {
+        return RATE_LIMITED.equals(type) || statusCode == 429;
+    }
+
     @Override
     public String toString()
     {
@@ -96,6 +146,8 @@ public class AcmeException extends Exception
             sb.append(" [type=").append(type).append("]");
         if (statusCode > 0)
             sb.append(" [status=").append(statusCode).append("]");
+        if (retryAfter != null)
+            sb.append(" [retryAfter=").append(retryAfter).append("]");
         return sb.toString();
     }
 }

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeException.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeException.java
@@ -1,0 +1,101 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+/**
+ * <p>Exception thrown when ACME protocol operations fail.</p>
+ * <p>This exception wraps errors from ACME server responses,
+ * network failures, or invalid protocol states.</p>
+ */
+public class AcmeException extends Exception
+{
+    private final String type;
+    private final int statusCode;
+
+    /**
+     * Creates a new AcmeException with a message.
+     *
+     * @param message the error message
+     */
+    public AcmeException(String message)
+    {
+        this(message, null, 0, null);
+    }
+
+    /**
+     * Creates a new AcmeException with a message and cause.
+     *
+     * @param message the error message
+     * @param cause the underlying cause
+     */
+    public AcmeException(String message, Throwable cause)
+    {
+        this(message, null, 0, cause);
+    }
+
+    /**
+     * Creates a new AcmeException with ACME error details.
+     *
+     * @param message the error message
+     * @param type the ACME error type URN (e.g., "urn:ietf:params:acme:error:malformed")
+     * @param statusCode the HTTP status code from the ACME server
+     */
+    public AcmeException(String message, String type, int statusCode)
+    {
+        this(message, type, statusCode, null);
+    }
+
+    /**
+     * Creates a new AcmeException with full details.
+     *
+     * @param message the error message
+     * @param type the ACME error type URN
+     * @param statusCode the HTTP status code
+     * @param cause the underlying cause
+     */
+    public AcmeException(String message, String type, int statusCode, Throwable cause)
+    {
+        super(message, cause);
+        this.type = type;
+        this.statusCode = statusCode;
+    }
+
+    /**
+     * @return the ACME error type URN, or null if not an ACME protocol error
+     */
+    public String getType()
+    {
+        return type;
+    }
+
+    /**
+     * @return the HTTP status code from the ACME server, or 0 if not applicable
+     */
+    public int getStatusCode()
+    {
+        return statusCode;
+    }
+
+    @Override
+    public String toString()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass().getName()).append(": ").append(getMessage());
+        if (type != null)
+            sb.append(" [type=").append(type).append("]");
+        if (statusCode > 0)
+            sb.append(" [status=").append(statusCode).append("]");
+        return sb.toString();
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeJwsSigner.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeJwsSigner.java
@@ -1,0 +1,395 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.KeyPair;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.Signature;
+import java.security.SignatureException;
+import java.security.interfaces.ECPublicKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.ECParameterSpec;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.eclipse.jetty.util.ajax.JSON;
+
+/**
+ * <p>JWS (JSON Web Signature) signer for ACME protocol requests.</p>
+ * <p>All ACME requests (except directory and newNonce) must be signed
+ * using JWS with a Flattened JSON Serialization format.</p>
+ *
+ * <p>Supports RSA (RS256) and ECDSA (ES256, ES384) key algorithms.</p>
+ */
+public class AcmeJwsSigner
+{
+    private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
+
+    private final KeyPair accountKeyPair;
+    private final JSON json;
+    private String accountUrl;
+
+    /**
+     * Creates a new JWS signer with the given account key pair.
+     *
+     * @param accountKeyPair the key pair for signing
+     * @param json the JSON parser/generator
+     */
+    public AcmeJwsSigner(KeyPair accountKeyPair, JSON json)
+    {
+        this.accountKeyPair = Objects.requireNonNull(accountKeyPair, "accountKeyPair");
+        this.json = Objects.requireNonNull(json, "json");
+    }
+
+    /**
+     * Sets the account URL (kid) to use in JWS headers after account creation.
+     *
+     * @param accountUrl the account URL
+     */
+    public void setAccountUrl(String accountUrl)
+    {
+        this.accountUrl = accountUrl;
+    }
+
+    /**
+     * @return the account URL, or null if not yet set
+     */
+    public String getAccountUrl()
+    {
+        return accountUrl;
+    }
+
+    /**
+     * Signs a payload for an ACME request.
+     *
+     * @param payload the payload object (will be JSON encoded), or null for POST-as-GET
+     * @param nonce the replay nonce from the ACME server
+     * @param url the URL being requested
+     * @return the JWS JSON string
+     * @throws AcmeException if signing fails
+     */
+    public String sign(Object payload, String nonce, String url) throws AcmeException
+    {
+        try
+        {
+            // Build protected header
+            Map<String, Object> protectedHeader = new LinkedHashMap<>();
+            protectedHeader.put("alg", getAlgorithm());
+            protectedHeader.put("nonce", nonce);
+            protectedHeader.put("url", url);
+
+            // Use kid (account URL) if available, otherwise jwk (public key)
+            if (accountUrl != null)
+            {
+                protectedHeader.put("kid", accountUrl);
+            }
+            else
+            {
+                protectedHeader.put("jwk", getJwk());
+            }
+
+            // Encode protected header
+            String protectedJson = json.toJSON(protectedHeader);
+            String protectedB64 = base64UrlEncode(protectedJson.getBytes(StandardCharsets.UTF_8));
+
+            // Encode payload (empty string for POST-as-GET)
+            String payloadB64;
+            if (payload == null)
+            {
+                payloadB64 = "";
+            }
+            else
+            {
+                String payloadJson = json.toJSON(payload);
+                payloadB64 = base64UrlEncode(payloadJson.getBytes(StandardCharsets.UTF_8));
+            }
+
+            // Sign
+            String signingInput = protectedB64 + "." + payloadB64;
+            byte[] signatureBytes = computeSignature(signingInput.getBytes(StandardCharsets.UTF_8));
+            String signatureB64 = base64UrlEncode(signatureBytes);
+
+            // Build JWS JSON
+            Map<String, String> jwsMap = new LinkedHashMap<>();
+            jwsMap.put("protected", protectedB64);
+            jwsMap.put("payload", payloadB64);
+            jwsMap.put("signature", signatureB64);
+
+            return json.toJSON(jwsMap);
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to sign JWS", e);
+        }
+    }
+
+    /**
+     * Computes the key authorization for an HTTP-01 challenge.
+     * This is the token concatenated with the account key thumbprint.
+     *
+     * @param token the challenge token
+     * @return the key authorization string
+     * @throws AcmeException if computation fails
+     */
+    public String computeKeyAuthorization(String token) throws AcmeException
+    {
+        try
+        {
+            String thumbprint = computeThumbprint();
+            return token + "." + thumbprint;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to compute key authorization", e);
+        }
+    }
+
+    /**
+     * Computes the JWK thumbprint of the account public key.
+     *
+     * @return the base64url-encoded thumbprint
+     * @throws NoSuchAlgorithmException if SHA-256 is not available
+     */
+    public String computeThumbprint() throws NoSuchAlgorithmException
+    {
+        Map<String, Object> jwk = getJwk();
+
+        // Create canonical JWK JSON (keys in lexicographic order)
+        StringBuilder canonical = new StringBuilder("{");
+        PublicKey publicKey = accountKeyPair.getPublic();
+
+        if (publicKey instanceof RSAPublicKey)
+        {
+            // RSA: {"e":"...","kty":"RSA","n":"..."}
+            canonical.append("\"e\":\"").append(jwk.get("e")).append("\",");
+            canonical.append("\"kty\":\"RSA\",");
+            canonical.append("\"n\":\"").append(jwk.get("n")).append("\"");
+        }
+        else if (publicKey instanceof ECPublicKey)
+        {
+            // EC: {"crv":"...","kty":"EC","x":"...","y":"..."}
+            canonical.append("\"crv\":\"").append(jwk.get("crv")).append("\",");
+            canonical.append("\"kty\":\"EC\",");
+            canonical.append("\"x\":\"").append(jwk.get("x")).append("\",");
+            canonical.append("\"y\":\"").append(jwk.get("y")).append("\"");
+        }
+
+        canonical.append("}");
+
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(canonical.toString().getBytes(StandardCharsets.UTF_8));
+        return base64UrlEncode(hash);
+    }
+
+    /**
+     * Gets the JWK (JSON Web Key) representation of the account public key.
+     *
+     * @return the JWK as a map
+     */
+    public Map<String, Object> getJwk()
+    {
+        Map<String, Object> jwk = new LinkedHashMap<>();
+        PublicKey publicKey = accountKeyPair.getPublic();
+
+        if (publicKey instanceof RSAPublicKey rsaKey)
+        {
+            jwk.put("kty", "RSA");
+            jwk.put("e", base64UrlEncode(toUnsignedBytes(rsaKey.getPublicExponent())));
+            jwk.put("n", base64UrlEncode(toUnsignedBytes(rsaKey.getModulus())));
+        }
+        else if (publicKey instanceof ECPublicKey ecKey)
+        {
+            ECParameterSpec params = ecKey.getParams();
+            int fieldSize = params.getCurve().getField().getFieldSize();
+            String crv = getCurveName(fieldSize);
+
+            jwk.put("kty", "EC");
+            jwk.put("crv", crv);
+            jwk.put("x", base64UrlEncode(toFixedLengthBytes(ecKey.getW().getAffineX(), fieldSize)));
+            jwk.put("y", base64UrlEncode(toFixedLengthBytes(ecKey.getW().getAffineY(), fieldSize)));
+        }
+
+        return jwk;
+    }
+
+    private String getAlgorithm()
+    {
+        PublicKey publicKey = accountKeyPair.getPublic();
+        if (publicKey instanceof RSAPublicKey)
+        {
+            return "RS256";
+        }
+        else if (publicKey instanceof ECPublicKey ecKey)
+        {
+            int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+            return switch (fieldSize)
+            {
+                case 256 -> "ES256";
+                case 384 -> "ES384";
+                case 521 -> "ES512";
+                default -> throw new IllegalStateException("Unsupported EC key size: " + fieldSize);
+            };
+        }
+        throw new IllegalStateException("Unsupported key type: " + publicKey.getAlgorithm());
+    }
+
+    private byte[] computeSignature(byte[] data) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException
+    {
+        PublicKey publicKey = accountKeyPair.getPublic();
+        String algorithm;
+
+        if (publicKey instanceof RSAPublicKey)
+        {
+            algorithm = "SHA256withRSA";
+        }
+        else if (publicKey instanceof ECPublicKey ecKey)
+        {
+            int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+            algorithm = switch (fieldSize)
+            {
+                case 256 -> "SHA256withECDSA";
+                case 384 -> "SHA384withECDSA";
+                case 521 -> "SHA512withECDSA";
+                default -> throw new IllegalStateException("Unsupported EC key size: " + fieldSize);
+            };
+        }
+        else
+        {
+            throw new IllegalStateException("Unsupported key type: " + publicKey.getAlgorithm());
+        }
+
+        Signature sig = Signature.getInstance(algorithm);
+        sig.initSign(accountKeyPair.getPrivate());
+        sig.update(data);
+        byte[] signatureBytes = sig.sign();
+
+        // For ECDSA, convert from DER to R||S format as required by JWS
+        if (publicKey instanceof ECPublicKey ecKey)
+        {
+            int fieldSize = ecKey.getParams().getCurve().getField().getFieldSize();
+            signatureBytes = derToConcat(signatureBytes, (fieldSize + 7) / 8);
+        }
+
+        return signatureBytes;
+    }
+
+    private String getCurveName(int fieldSize)
+    {
+        return switch (fieldSize)
+        {
+            case 256 -> "P-256";
+            case 384 -> "P-384";
+            case 521 -> "P-521";
+            default -> throw new IllegalStateException("Unsupported EC curve size: " + fieldSize);
+        };
+    }
+
+    private static String base64UrlEncode(byte[] data)
+    {
+        return URL_ENCODER.encodeToString(data);
+    }
+
+    private static byte[] toUnsignedBytes(BigInteger value)
+    {
+        byte[] bytes = value.toByteArray();
+        // Remove leading zero byte if present (sign byte)
+        if (bytes.length > 1 && bytes[0] == 0)
+        {
+            byte[] result = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, result, 0, result.length);
+            return result;
+        }
+        return bytes;
+    }
+
+    private static byte[] toFixedLengthBytes(BigInteger value, int bitLength)
+    {
+        int byteLength = (bitLength + 7) / 8;
+        byte[] bytes = toUnsignedBytes(value);
+
+        if (bytes.length == byteLength)
+            return bytes;
+
+        byte[] result = new byte[byteLength];
+        if (bytes.length > byteLength)
+        {
+            System.arraycopy(bytes, bytes.length - byteLength, result, 0, byteLength);
+        }
+        else
+        {
+            System.arraycopy(bytes, 0, result, byteLength - bytes.length, bytes.length);
+        }
+        return result;
+    }
+
+    /**
+     * Converts ECDSA DER signature to R||S concatenated format.
+     */
+    private static byte[] derToConcat(byte[] derSignature, int componentLength)
+    {
+        // DER format: 0x30 [length] 0x02 [r-length] [r] 0x02 [s-length] [s]
+        int offset = 0;
+
+        // Skip SEQUENCE tag and length
+        if (derSignature[offset++] != 0x30)
+            throw new IllegalArgumentException("Invalid DER signature");
+
+        int sequenceLength = derSignature[offset++] & 0xFF;
+        if ((sequenceLength & 0x80) != 0)
+        {
+            // Long form length
+            int numLengthBytes = sequenceLength & 0x7F;
+            offset += numLengthBytes;
+        }
+
+        // Read R
+        if (derSignature[offset++] != 0x02)
+            throw new IllegalArgumentException("Invalid DER signature");
+
+        int rLength = derSignature[offset++] & 0xFF;
+        byte[] r = new byte[rLength];
+        System.arraycopy(derSignature, offset, r, 0, rLength);
+        offset += rLength;
+
+        // Read S
+        if (derSignature[offset++] != 0x02)
+            throw new IllegalArgumentException("Invalid DER signature");
+
+        int sLength = derSignature[offset++] & 0xFF;
+        byte[] s = new byte[sLength];
+        System.arraycopy(derSignature, offset, s, 0, sLength);
+
+        // Convert to fixed-length concatenated format
+        byte[] result = new byte[componentLength * 2];
+
+        // Copy R (skip leading zeros, pad if needed)
+        int rOffset = (r.length > componentLength) ? r.length - componentLength : 0;
+        int rCopyLen = Math.min(r.length, componentLength);
+        System.arraycopy(r, rOffset, result, componentLength - rCopyLen, rCopyLen);
+
+        // Copy S (skip leading zeros, pad if needed)
+        int sOffset = (s.length > componentLength) ? s.length - componentLength : 0;
+        int sCopyLen = Math.min(s.length, componentLength);
+        System.arraycopy(s, sOffset, result, componentLength * 2 - sCopyLen, sCopyLen);
+
+        return result;
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeJwsSigner.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeJwsSigner.java
@@ -43,9 +43,9 @@ public class AcmeJwsSigner
 {
     private static final Base64.Encoder URL_ENCODER = Base64.getUrlEncoder().withoutPadding();
 
-    private final KeyPair accountKeyPair;
-    private final JSON json;
-    private String accountUrl;
+    private final KeyPair _accountKeyPair;
+    private final JSON _json;
+    private String _accountUrl;
 
     /**
      * Creates a new JWS signer with the given account key pair.
@@ -55,8 +55,8 @@ public class AcmeJwsSigner
      */
     public AcmeJwsSigner(KeyPair accountKeyPair, JSON json)
     {
-        this.accountKeyPair = Objects.requireNonNull(accountKeyPair, "accountKeyPair");
-        this.json = Objects.requireNonNull(json, "json");
+        _accountKeyPair = Objects.requireNonNull(accountKeyPair, "accountKeyPair");
+        _json = Objects.requireNonNull(json, "json");
     }
 
     /**
@@ -66,7 +66,7 @@ public class AcmeJwsSigner
      */
     public void setAccountUrl(String accountUrl)
     {
-        this.accountUrl = accountUrl;
+        _accountUrl = accountUrl;
     }
 
     /**
@@ -74,7 +74,7 @@ public class AcmeJwsSigner
      */
     public String getAccountUrl()
     {
-        return accountUrl;
+        return _accountUrl;
     }
 
     /**
@@ -97,9 +97,9 @@ public class AcmeJwsSigner
             protectedHeader.put("url", url);
 
             // Use kid (account URL) if available, otherwise jwk (public key)
-            if (accountUrl != null)
+            if (_accountUrl != null)
             {
-                protectedHeader.put("kid", accountUrl);
+                protectedHeader.put("kid", _accountUrl);
             }
             else
             {
@@ -107,7 +107,7 @@ public class AcmeJwsSigner
             }
 
             // Encode protected header
-            String protectedJson = json.toJSON(protectedHeader);
+            String protectedJson = _json.toJSON(protectedHeader);
             String protectedB64 = base64UrlEncode(protectedJson.getBytes(StandardCharsets.UTF_8));
 
             // Encode payload (empty string for POST-as-GET)
@@ -118,7 +118,7 @@ public class AcmeJwsSigner
             }
             else
             {
-                String payloadJson = json.toJSON(payload);
+                String payloadJson = _json.toJSON(payload);
                 payloadB64 = base64UrlEncode(payloadJson.getBytes(StandardCharsets.UTF_8));
             }
 
@@ -133,7 +133,7 @@ public class AcmeJwsSigner
             jwsMap.put("payload", payloadB64);
             jwsMap.put("signature", signatureB64);
 
-            return json.toJSON(jwsMap);
+            return _json.toJSON(jwsMap);
         }
         catch (Exception e)
         {
@@ -174,7 +174,7 @@ public class AcmeJwsSigner
 
         // Create canonical JWK JSON (keys in lexicographic order)
         StringBuilder canonical = new StringBuilder("{");
-        PublicKey publicKey = accountKeyPair.getPublic();
+        PublicKey publicKey = _accountKeyPair.getPublic();
 
         if (publicKey instanceof RSAPublicKey)
         {
@@ -207,7 +207,7 @@ public class AcmeJwsSigner
     public Map<String, Object> getJwk()
     {
         Map<String, Object> jwk = new LinkedHashMap<>();
-        PublicKey publicKey = accountKeyPair.getPublic();
+        PublicKey publicKey = _accountKeyPair.getPublic();
 
         if (publicKey instanceof RSAPublicKey rsaKey)
         {
@@ -232,7 +232,7 @@ public class AcmeJwsSigner
 
     private String getAlgorithm()
     {
-        PublicKey publicKey = accountKeyPair.getPublic();
+        PublicKey publicKey = _accountKeyPair.getPublic();
         if (publicKey instanceof RSAPublicKey)
         {
             return "RS256";
@@ -253,7 +253,7 @@ public class AcmeJwsSigner
 
     private byte[] computeSignature(byte[] data) throws NoSuchAlgorithmException, InvalidKeyException, SignatureException
     {
-        PublicKey publicKey = accountKeyPair.getPublic();
+        PublicKey publicKey = _accountKeyPair.getPublic();
         String algorithm;
 
         if (publicKey instanceof RSAPublicKey)
@@ -277,7 +277,7 @@ public class AcmeJwsSigner
         }
 
         Signature sig = Signature.getInstance(algorithm);
-        sig.initSign(accountKeyPair.getPrivate());
+        sig.initSign(_accountKeyPair.getPrivate());
         sig.update(data);
         byte[] signatureBytes = sig.sign();
 

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
@@ -370,8 +370,14 @@ public class AcmeKeyStoreManager
     public static void ensureKeyStoreExists(String basePath, String keystorePath, String password, String domain)
         throws Exception
     {
-        Path base = Path.of(basePath);
-        Path keystore = base.resolve(keystorePath);
+        Path base = Path.of(basePath).toAbsolutePath().normalize();
+        Path keystore = base.resolve(keystorePath).normalize();
+
+        // Validate that the keystore path stays within the base directory
+        if (!keystore.startsWith(base))
+        {
+            throw new IllegalArgumentException("Keystore path escapes base directory: " + keystorePath);
+        }
 
         if (Files.exists(keystore))
         {
@@ -436,9 +442,25 @@ public class AcmeKeyStoreManager
 
     private Path resolvePath(Path path)
     {
+        Path resolved;
         if (path.isAbsolute())
-            return path;
-        return _basePath.resolve(path);
+        {
+            resolved = path.normalize();
+        }
+        else
+        {
+            resolved = _basePath.resolve(path).normalize();
+        }
+
+        // Validate that the resolved path stays within the base directory
+        Path normalizedBase = _basePath.toAbsolutePath().normalize();
+        Path normalizedResolved = resolved.toAbsolutePath().normalize();
+        if (!normalizedResolved.startsWith(normalizedBase))
+        {
+            throw new IllegalArgumentException("Path escapes base directory: " + path);
+        }
+
+        return resolved;
     }
 
     // ASN.1 DER encoding helpers

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
@@ -1,0 +1,584 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Signature;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateFactory;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPrivateCrtKey;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <p>Manages keystore operations for ACME certificate management.</p>
+ * <p>This class handles:</p>
+ * <ul>
+ *   <li>Account key pair generation and storage</li>
+ *   <li>Domain key pair generation</li>
+ *   <li>Certificate Signing Request (CSR) generation</li>
+ *   <li>Keystore creation and certificate storage</li>
+ *   <li>Self-signed certificate generation for dry-run mode</li>
+ * </ul>
+ *
+ * <p>This implementation uses only standard Java crypto APIs.</p>
+ */
+public class AcmeKeyStoreManager
+{
+    private static final Logger LOG = LoggerFactory.getLogger(AcmeKeyStoreManager.class);
+    private static final String RSA_ALGORITHM = "RSA";
+    private static final int RSA_KEY_SIZE = 2048;
+    private static final String SIGNATURE_ALGORITHM = "SHA256withRSA";
+    private static final String KEYSTORE_TYPE = "PKCS12";
+    private static final String DEFAULT_ALIAS = "jetty";
+
+    private final Path basePath;
+
+    /**
+     * Creates a new keystore manager.
+     *
+     * @param basePath the base path for resolving relative paths
+     */
+    public AcmeKeyStoreManager(Path basePath)
+    {
+        this.basePath = basePath != null ? basePath : Path.of(".");
+    }
+
+    /**
+     * Loads or generates an account key pair.
+     *
+     * @param accountKeyPath the path to the account key file
+     * @return the account key pair
+     * @throws AcmeException if loading or generation fails
+     */
+    public KeyPair loadOrGenerateAccountKey(Path accountKeyPath) throws AcmeException
+    {
+        Path resolvedPath = resolvePath(accountKeyPath);
+
+        try
+        {
+            if (Files.exists(resolvedPath))
+            {
+                return loadKeyPair(resolvedPath);
+            }
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Generating new account key pair at {}", resolvedPath);
+
+            KeyPair keyPair = generateKeyPair();
+            saveKeyPair(keyPair, resolvedPath);
+            return keyPair;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to load or generate account key", e);
+        }
+    }
+
+    /**
+     * Generates a new domain key pair.
+     *
+     * @return the generated key pair
+     * @throws AcmeException if generation fails
+     */
+    public KeyPair generateDomainKeyPair() throws AcmeException
+    {
+        try
+        {
+            return generateKeyPair();
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to generate domain key pair", e);
+        }
+    }
+
+    /**
+     * Generates a Certificate Signing Request (CSR) in DER format.
+     *
+     * @param keyPair the domain key pair
+     * @param domains the domain names to include
+     * @return the DER-encoded CSR
+     * @throws AcmeException if CSR generation fails
+     */
+    public byte[] generateCSR(KeyPair keyPair, List<String> domains) throws AcmeException
+    {
+        if (domains.isEmpty())
+            throw new AcmeException("At least one domain is required");
+
+        try
+        {
+            String primaryDomain = domains.get(0);
+
+            // Build CSR using DER encoding directly
+            ByteArrayOutputStream csrDer = new ByteArrayOutputStream();
+
+            // Build CertificationRequestInfo
+            ByteArrayOutputStream certReqInfo = new ByteArrayOutputStream();
+
+            // Version (INTEGER 0)
+            certReqInfo.write(new byte[]{0x02, 0x01, 0x00});
+
+            // Subject (CN=domain)
+            byte[] subjectDer = buildSubjectDN(primaryDomain);
+            certReqInfo.write(subjectDer);
+
+            // SubjectPublicKeyInfo
+            byte[] publicKeyInfo = keyPair.getPublic().getEncoded();
+            certReqInfo.write(publicKeyInfo);
+
+            // Attributes with SAN extension
+            byte[] attributes = buildCSRAttributes(domains);
+            certReqInfo.write(attributes);
+
+            byte[] certReqInfoBytes = certReqInfo.toByteArray();
+
+            // Sign the CertificationRequestInfo
+            Signature sig = Signature.getInstance(SIGNATURE_ALGORITHM);
+            sig.initSign(keyPair.getPrivate());
+            sig.update(wrapSequence(certReqInfoBytes));
+            byte[] signature = sig.sign();
+
+            // Build final CSR: SEQUENCE { certificationRequestInfo, signatureAlgorithm, signature }
+            ByteArrayOutputStream csr = new ByteArrayOutputStream();
+
+            // CertificationRequestInfo (as SEQUENCE)
+            csr.write(wrapSequence(certReqInfoBytes));
+
+            // SignatureAlgorithm (SHA256withRSA OID: 1.2.840.113549.1.1.11)
+            byte[] sigAlgId = new byte[]{
+                0x30, 0x0d,
+                // OID
+                0x06, 0x09, 0x2a, (byte)0x86, 0x48, (byte)0x86, (byte)0xf7, 0x0d, 0x01, 0x01, 0x0b,
+                // NULL parameters
+                0x05, 0x00
+            };
+            csr.write(sigAlgId);
+
+            // Signature (BIT STRING)
+            csr.write(wrapBitString(signature));
+
+            return wrapSequence(csr.toByteArray());
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to generate CSR", e);
+        }
+    }
+
+    /**
+     * Stores a certificate chain in the keystore.
+     *
+     * @param keystorePath the keystore path
+     * @param password the keystore password
+     * @param privateKey the private key
+     * @param certificates the certificate chain
+     * @throws AcmeException if storage fails
+     */
+    public void storeCertificates(Path keystorePath, String password, PrivateKey privateKey,
+                                  List<X509Certificate> certificates) throws AcmeException
+    {
+        Path resolvedPath = resolvePath(keystorePath);
+
+        try
+        {
+            // Ensure parent directories exist
+            Files.createDirectories(resolvedPath.getParent());
+
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+            keyStore.load(null, null);
+
+            // Convert list to array
+            Certificate[] chain = certificates.toArray(new Certificate[0]);
+
+            // Store private key with certificate chain
+            keyStore.setKeyEntry(DEFAULT_ALIAS, privateKey, password.toCharArray(), chain);
+
+            // Save keystore
+            try (OutputStream os = Files.newOutputStream(resolvedPath))
+            {
+                keyStore.store(os, password.toCharArray());
+            }
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("Stored certificate chain in {}", resolvedPath);
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to store certificates", e);
+        }
+    }
+
+    /**
+     * Loads the current certificate from the keystore.
+     *
+     * @param keystorePath the keystore path
+     * @param password the keystore password
+     * @return the certificate, or null if not found
+     * @throws AcmeException if loading fails
+     */
+    public X509Certificate loadCertificate(Path keystorePath, String password) throws AcmeException
+    {
+        Path resolvedPath = resolvePath(keystorePath);
+
+        if (!Files.exists(resolvedPath))
+            return null;
+
+        try
+        {
+            KeyStore keyStore = KeyStore.getInstance(KEYSTORE_TYPE);
+            keyStore.load(Files.newInputStream(resolvedPath), password.toCharArray());
+
+            Certificate cert = keyStore.getCertificate(DEFAULT_ALIAS);
+            if (cert instanceof X509Certificate x509)
+                return x509;
+
+            return null;
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to load certificate", e);
+        }
+    }
+
+    /**
+     * Generates a self-signed certificate for dry-run mode.
+     *
+     * @param keyPair the key pair to use
+     * @param domains the domain names
+     * @param validityDays the validity period in days
+     * @return the self-signed certificate
+     * @throws AcmeException if generation fails
+     */
+    public X509Certificate generateSelfSignedCertificate(KeyPair keyPair, List<String> domains, int validityDays)
+        throws AcmeException
+    {
+        if (domains.isEmpty())
+            throw new AcmeException("At least one domain is required");
+
+        try
+        {
+            String primaryDomain = domains.get(0);
+
+            Instant now = Instant.now();
+            Date notBefore = Date.from(now);
+            Date notAfter = Date.from(now.plus(validityDays, ChronoUnit.DAYS));
+
+            // Build TBSCertificate
+            ByteArrayOutputStream tbsCert = new ByteArrayOutputStream();
+
+            // Version [0] EXPLICIT INTEGER { v3(2) }
+            tbsCert.write(new byte[]{(byte)0xa0, 0x03, 0x02, 0x01, 0x02});
+
+            // Serial number
+            byte[] serialBytes = BigInteger.valueOf(now.toEpochMilli()).toByteArray();
+            tbsCert.write(wrapInteger(serialBytes));
+
+            // Signature algorithm (SHA256withRSA)
+            byte[] sigAlgId = new byte[]{
+                0x30, 0x0d,
+                0x06, 0x09, 0x2a, (byte)0x86, 0x48, (byte)0x86, (byte)0xf7, 0x0d, 0x01, 0x01, 0x0b,
+                0x05, 0x00
+            };
+            tbsCert.write(sigAlgId);
+
+            // Issuer (same as subject for self-signed)
+            byte[] subjectDer = buildSubjectDN(primaryDomain);
+            tbsCert.write(subjectDer);
+
+            // Validity
+            tbsCert.write(buildValidity(notBefore, notAfter));
+
+            // Subject
+            tbsCert.write(subjectDer);
+
+            // SubjectPublicKeyInfo
+            tbsCert.write(keyPair.getPublic().getEncoded());
+
+            // Extensions [3] (SAN)
+            byte[] extensions = buildCertExtensions(domains);
+            tbsCert.write(extensions);
+
+            byte[] tbsCertBytes = wrapSequence(tbsCert.toByteArray());
+
+            // Sign the TBSCertificate
+            Signature sig = Signature.getInstance(SIGNATURE_ALGORITHM);
+            sig.initSign(keyPair.getPrivate());
+            sig.update(tbsCertBytes);
+            byte[] signature = sig.sign();
+
+            // Build final certificate
+            ByteArrayOutputStream cert = new ByteArrayOutputStream();
+            cert.write(tbsCertBytes);
+            cert.write(sigAlgId);
+            cert.write(wrapBitString(signature));
+
+            byte[] certDer = wrapSequence(cert.toByteArray());
+
+            // Parse as X509Certificate
+            CertificateFactory cf = CertificateFactory.getInstance("X.509");
+            return (X509Certificate)cf.generateCertificate(new java.io.ByteArrayInputStream(certDer));
+        }
+        catch (Exception e)
+        {
+            throw new AcmeException("Failed to generate self-signed certificate", e);
+        }
+    }
+
+    private KeyPair generateKeyPair() throws Exception
+    {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(RSA_ALGORITHM);
+        keyGen.initialize(RSA_KEY_SIZE, new SecureRandom());
+        return keyGen.generateKeyPair();
+    }
+
+    private KeyPair loadKeyPair(Path path) throws Exception
+    {
+        byte[] keyBytes = Files.readAllBytes(path);
+
+        PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+        java.security.KeyFactory keyFactory = java.security.KeyFactory.getInstance(RSA_ALGORITHM);
+        PrivateKey privateKey = keyFactory.generatePrivate(keySpec);
+
+        // Derive public key from private key
+        RSAPrivateCrtKey rsaPrivateKey = (RSAPrivateCrtKey)privateKey;
+        RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(
+            rsaPrivateKey.getModulus(),
+            rsaPrivateKey.getPublicExponent()
+        );
+
+        PublicKey publicKey = keyFactory.generatePublic(publicKeySpec);
+
+        return new KeyPair(publicKey, privateKey);
+    }
+
+    private void saveKeyPair(KeyPair keyPair, Path path) throws IOException
+    {
+        Files.createDirectories(path.getParent());
+        byte[] keyBytes = keyPair.getPrivate().getEncoded();
+        Files.write(path, keyBytes);
+    }
+
+    private Path resolvePath(Path path)
+    {
+        if (path.isAbsolute())
+            return path;
+        return basePath.resolve(path);
+    }
+
+    // ASN.1 DER encoding helpers
+
+    private byte[] buildSubjectDN(String commonName) throws IOException
+    {
+        // CN attribute: OID 2.5.4.3
+        byte[] cnOid = new byte[]{0x06, 0x03, 0x55, 0x04, 0x03};
+        byte[] cnValue = wrapUtf8String(commonName);
+
+        ByteArrayOutputStream attrTypeValue = new ByteArrayOutputStream();
+        attrTypeValue.write(cnOid);
+        attrTypeValue.write(cnValue);
+
+        byte[] attrSeq = wrapSequence(attrTypeValue.toByteArray());
+        byte[] rdnSet = wrapSet(attrSeq);
+
+        return wrapSequence(rdnSet);
+    }
+
+    private byte[] buildCSRAttributes(List<String> domains) throws IOException
+    {
+        // Build SAN extension
+        ByteArrayOutputStream sanValues = new ByteArrayOutputStream();
+        for (String domain : domains)
+        {
+            // dNSName [2] IA5String
+            byte[] dnsName = domain.getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+            sanValues.write(0x82);
+            sanValues.write(encodeLength(dnsName.length));
+            sanValues.write(dnsName);
+        }
+        byte[] sanSeq = wrapSequence(sanValues.toByteArray());
+
+        // Extension: OID 2.5.29.17 (subjectAltName), not critical, value
+        byte[] sanOid = new byte[]{0x06, 0x03, 0x55, 0x1d, 0x11};
+        byte[] sanOctetString = wrapOctetString(sanSeq);
+
+        ByteArrayOutputStream ext = new ByteArrayOutputStream();
+        ext.write(sanOid);
+        ext.write(sanOctetString);
+        byte[] extSeq = wrapSequence(ext.toByteArray());
+        byte[] extensions = wrapSequence(extSeq);
+
+        // extensionRequest OID: 1.2.840.113549.1.9.14
+        byte[] extReqOid = new byte[]{0x06, 0x09, 0x2a, (byte)0x86, 0x48, (byte)0x86, (byte)0xf7, 0x0d, 0x01, 0x09, 0x0e};
+
+        ByteArrayOutputStream attr = new ByteArrayOutputStream();
+        attr.write(extReqOid);
+        attr.write(wrapSet(extensions));
+
+        byte[] attrSeq = wrapSequence(attr.toByteArray());
+
+        // Attributes [0] IMPLICIT
+        return wrapContextTag(0, attrSeq);
+    }
+
+    private byte[] buildValidity(Date notBefore, Date notAfter) throws IOException
+    {
+        java.text.SimpleDateFormat utcFormat = new java.text.SimpleDateFormat("yyMMddHHmmss'Z'");
+        utcFormat.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+
+        byte[] notBeforeBytes = wrapUtcTime(utcFormat.format(notBefore));
+        byte[] notAfterBytes = wrapUtcTime(utcFormat.format(notAfter));
+
+        ByteArrayOutputStream validity = new ByteArrayOutputStream();
+        validity.write(notBeforeBytes);
+        validity.write(notAfterBytes);
+
+        return wrapSequence(validity.toByteArray());
+    }
+
+    private byte[] buildCertExtensions(List<String> domains) throws IOException
+    {
+        // Basic Constraints: CA=false
+        byte[] bcOid = new byte[]{0x06, 0x03, 0x55, 0x1d, 0x13};
+        byte[] bcValue = wrapOctetString(wrapSequence(new byte[0]));
+
+        ByteArrayOutputStream bcExt = new ByteArrayOutputStream();
+        bcExt.write(bcOid);
+        bcExt.write(new byte[]{0x01, 0x01, (byte)0xff});
+        bcExt.write(bcValue);
+        byte[] bcExtSeq = wrapSequence(bcExt.toByteArray());
+
+        // Subject Alternative Name
+        ByteArrayOutputStream sanValues = new ByteArrayOutputStream();
+        for (String domain : domains)
+        {
+            byte[] dnsName = domain.getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+            sanValues.write(0x82);
+            sanValues.write(encodeLength(dnsName.length));
+            sanValues.write(dnsName);
+        }
+        byte[] sanSeq = wrapSequence(sanValues.toByteArray());
+
+        byte[] sanOid = new byte[]{0x06, 0x03, 0x55, 0x1d, 0x11};
+        byte[] sanOctetString = wrapOctetString(sanSeq);
+
+        ByteArrayOutputStream sanExt = new ByteArrayOutputStream();
+        sanExt.write(sanOid);
+        sanExt.write(sanOctetString);
+        byte[] sanExtSeq = wrapSequence(sanExt.toByteArray());
+
+        ByteArrayOutputStream allExts = new ByteArrayOutputStream();
+        allExts.write(bcExtSeq);
+        allExts.write(sanExtSeq);
+
+        byte[] extsSeq = wrapSequence(allExts.toByteArray());
+
+        // Extensions [3] EXPLICIT
+        return wrapContextTag(3, extsSeq);
+    }
+
+    private byte[] wrapSequence(byte[] content)
+    {
+        return wrapTag(0x30, content);
+    }
+
+    private byte[] wrapSet(byte[] content)
+    {
+        return wrapTag(0x31, content);
+    }
+
+    private byte[] wrapOctetString(byte[] content)
+    {
+        return wrapTag(0x04, content);
+    }
+
+    private byte[] wrapBitString(byte[] content)
+    {
+        // BIT STRING with 0 unused bits
+        byte[] result = new byte[content.length + 1];
+        result[0] = 0;
+        System.arraycopy(content, 0, result, 1, content.length);
+        return wrapTag(0x03, result);
+    }
+
+    private byte[] wrapInteger(byte[] content)
+    {
+        return wrapTag(0x02, content);
+    }
+
+    private byte[] wrapUtf8String(String s)
+    {
+        return wrapTag(0x0c, s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    private byte[] wrapUtcTime(String time)
+    {
+        return wrapTag(0x17, time.getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+    }
+
+    private byte[] wrapContextTag(int tagNumber, byte[] content)
+    {
+        return wrapTag(0xa0 | tagNumber, content);
+    }
+
+    private byte[] wrapTag(int tag, byte[] content)
+    {
+        byte[] lengthBytes = encodeLength(content.length);
+        byte[] result = new byte[1 + lengthBytes.length + content.length];
+        result[0] = (byte)tag;
+        System.arraycopy(lengthBytes, 0, result, 1, lengthBytes.length);
+        System.arraycopy(content, 0, result, 1 + lengthBytes.length, content.length);
+        return result;
+    }
+
+    private byte[] encodeLength(int length)
+    {
+        if (length < 128)
+        {
+            return new byte[]{(byte)length};
+        }
+        else if (length < 256)
+        {
+            return new byte[]{(byte)0x81, (byte)length};
+        }
+        else if (length < 65536)
+        {
+            return new byte[]{(byte)0x82, (byte)(length >> 8), (byte)length};
+        }
+        else
+        {
+            return new byte[]{(byte)0x83, (byte)(length >> 16), (byte)(length >> 8), (byte)length};
+        }
+    }
+}

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
@@ -63,7 +63,7 @@ public class AcmeKeyStoreManager
     private static final String KEYSTORE_TYPE = "PKCS12";
     private static final String DEFAULT_ALIAS = "jetty";
 
-    private final Path basePath;
+    private final Path _basePath;
 
     /**
      * Creates a new keystore manager.
@@ -72,7 +72,7 @@ public class AcmeKeyStoreManager
      */
     public AcmeKeyStoreManager(Path basePath)
     {
-        this.basePath = basePath != null ? basePath : Path.of(".");
+        _basePath = basePath != null ? basePath : Path.of(".");
     }
 
     /**
@@ -394,7 +394,7 @@ public class AcmeKeyStoreManager
     {
         if (path.isAbsolute())
             return path;
-        return basePath.resolve(path);
+        return _basePath.resolve(path);
     }
 
     // ASN.1 DER encoding helpers

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/AcmeKeyStoreManager.java
@@ -356,6 +356,50 @@ public class AcmeKeyStoreManager
         }
     }
 
+    /**
+     * Ensures a keystore exists at the given path, creating a self-signed certificate if needed.
+     * This static method can be called from XML configuration to initialize the keystore
+     * before the SSL context tries to load it.
+     *
+     * @param basePath the base path (typically jetty.base)
+     * @param keystorePath the relative path to the keystore
+     * @param password the keystore password
+     * @param domain the domain name for the self-signed certificate
+     * @throws Exception if keystore creation fails
+     */
+    public static void ensureKeyStoreExists(String basePath, String keystorePath, String password, String domain)
+        throws Exception
+    {
+        Path base = Path.of(basePath);
+        Path keystore = base.resolve(keystorePath);
+
+        if (Files.exists(keystore))
+        {
+            LOG.debug("Keystore already exists: {}", keystore);
+            return;
+        }
+
+        LOG.info("Creating initial self-signed keystore at {}", keystore);
+
+        // Create parent directories
+        Files.createDirectories(keystore.getParent());
+
+        // Generate key pair
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance(RSA_ALGORITHM);
+        keyGen.initialize(RSA_KEY_SIZE, new SecureRandom());
+        KeyPair keyPair = keyGen.generateKeyPair();
+
+        // Generate self-signed certificate
+        AcmeKeyStoreManager manager = new AcmeKeyStoreManager(base);
+        List<String> domains = domain != null && !domain.isEmpty()
+            ? List.of(domain)
+            : List.of("localhost");
+        X509Certificate cert = manager.generateSelfSignedCertificate(keyPair, domains, 90);
+
+        // Store in keystore
+        manager.storeCertificates(Path.of(keystorePath), password, keyPair.getPrivate(), List.of(cert));
+    }
+
     private KeyPair generateKeyPair() throws Exception
     {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(RSA_ALGORITHM);

--- a/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/package-info.java
+++ b/jetty-core/jetty-acme/src/main/java/org/eclipse/jetty/acme/package-info.java
@@ -1,0 +1,45 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+/**
+ * <p>ACME (Automatic Certificate Management Environment) support for Jetty.</p>
+ * <p>This module provides automatic TLS certificate management using the ACME protocol
+ * (RFC 8555), enabling integration with certificate authorities like Let's Encrypt.</p>
+ *
+ * <h2>Features</h2>
+ * <ul>
+ *   <li>Automatic certificate acquisition from ACME-compliant CAs</li>
+ *   <li>HTTP-01 challenge support for domain validation</li>
+ *   <li>Automatic certificate renewal before expiration</li>
+ *   <li>Hot-reload of certificates without server restart</li>
+ *   <li>Dry-run mode for testing without contacting ACME servers</li>
+ * </ul>
+ *
+ * <h2>Usage</h2>
+ * <p>Enable the ACME module in Jetty:</p>
+ * <pre>
+ * java -jar start.jar --add-modules=https,acme
+ * </pre>
+ *
+ * <p>Configure in {@code start.d/acme.ini}:</p>
+ * <pre>
+ * jetty.acme.domains=example.com,www.example.com
+ * jetty.acme.accountEmail=admin@example.com
+ * jetty.acme.termsOfServiceAgreed=true
+ * jetty.acme.dryRun=false
+ * </pre>
+ *
+ * @see org.eclipse.jetty.acme.AcmeCertificateManager
+ * @see org.eclipse.jetty.acme.AcmeConfiguration
+ */
+package org.eclipse.jetty.acme;

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeCertificateManagerTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeCertificateManagerTest.java
@@ -1,0 +1,123 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class AcmeCertificateManagerTest
+{
+    @TempDir
+    Path tempDir;
+
+    private Server server;
+    private AcmeConfiguration config;
+    private AcmeChallengeHandler challengeHandler;
+    private SslContextFactory.Server sslContextFactory;
+    private AcmeCertificateManager manager;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        server = new Server();
+
+        config = new AcmeConfiguration();
+        config.setDryRun(true);
+        config.setDomains("localhost");
+        config.setAccountKeyPath(tempDir.resolve("acme/account.key").toString());
+        config.setKeystorePath(tempDir.resolve("etc/keystore.p12").toString());
+
+        challengeHandler = new AcmeChallengeHandler();
+
+        sslContextFactory = new SslContextFactory.Server();
+
+        manager = new AcmeCertificateManager(config, sslContextFactory, challengeHandler);
+        manager.setServer(server);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        if (manager.isStarted())
+            manager.stop();
+        if (server.isStarted())
+            server.stop();
+    }
+
+    @Test
+    public void testDryRunGeneratesSelfSignedCertificate() throws Exception
+    {
+        manager.start();
+
+        // Keystore should be created
+        Path keystorePath = tempDir.resolve("etc/keystore.p12");
+        assertThat(Files.exists(keystorePath), is(true));
+
+        // Account key should be created
+        Path accountKeyPath = tempDir.resolve("acme/account.key");
+        assertThat(Files.exists(accountKeyPath), is(true));
+
+        assertThat(manager.isCertificateValid(), is(true));
+        assertThat(manager.getDaysUntilExpiry(), greaterThan(0L));
+    }
+
+    @Test
+    public void testStartAndStop() throws Exception
+    {
+        assertDoesNotThrow(() -> manager.start());
+        assertThat(manager.isStarted(), is(true));
+
+        assertDoesNotThrow(() -> manager.stop());
+        assertThat(manager.isStopped(), is(true));
+    }
+
+    @Test
+    public void testForceRenewalCheck() throws Exception
+    {
+        manager.start();
+
+        // Should not throw in dry-run mode
+        assertDoesNotThrow(() -> manager.forceRenewalCheck());
+
+        assertThat(manager.isCertificateValid(), is(true));
+    }
+
+    @Test
+    public void testGetConfiguration()
+    {
+        assertThat(manager.getConfiguration(), is(config));
+    }
+
+    @Test
+    public void testDryRunWithMultipleDomains() throws Exception
+    {
+        config.setDomains("example.com,www.example.com,api.example.com");
+
+        manager.start();
+
+        assertThat(manager.isCertificateValid(), is(true));
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeChallengeHandlerTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeChallengeHandlerTest.java
@@ -1,0 +1,162 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.net.URI;
+
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+public class AcmeChallengeHandlerTest
+{
+    private Server server;
+    private LocalConnector connector;
+    private AcmeChallengeHandler challengeHandler;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        server = new Server();
+        connector = new LocalConnector(server);
+        server.addConnector(connector);
+
+        challengeHandler = new AcmeChallengeHandler();
+
+        // Add a fallback handler
+        Handler.Sequence sequence = new Handler.Sequence();
+        sequence.addHandler(challengeHandler);
+        sequence.addHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                response.setStatus(HttpStatus.NOT_FOUND_404);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        server.setHandler(sequence);
+        server.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void testNoChallengeReturnsNotFound() throws Exception
+    {
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setURI("/.well-known/acme-challenge/test-token");
+        request.setVersion("HTTP/1.1");
+        request.setHeader("Host", "localhost");
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request.generate()));
+
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+
+    @Test
+    public void testChallengeReturnsAuthorization() throws Exception
+    {
+        String token = "test-token-12345";
+        String keyAuth = "test-token-12345.thumbprint-abc123";
+
+        challengeHandler.addChallenge(token, keyAuth);
+
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setURI("/.well-known/acme-challenge/" + token);
+        request.setVersion("HTTP/1.1");
+        request.setHeader("Host", "localhost");
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request.generate()));
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.get(HttpHeader.CONTENT_TYPE), containsString("text/plain"));
+        assertThat(response.getContent(), equalTo(keyAuth));
+    }
+
+    @Test
+    public void testChallengeRemoval() throws Exception
+    {
+        String token = "test-token-67890";
+        String keyAuth = "test-token-67890.thumbprint-xyz789";
+
+        challengeHandler.addChallenge(token, keyAuth);
+        challengeHandler.removeChallenge(token);
+
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setURI("/.well-known/acme-challenge/" + token);
+        request.setVersion("HTTP/1.1");
+        request.setHeader("Host", "localhost");
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request.generate()));
+
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+
+    @Test
+    public void testNonChallengePathNotHandled() throws Exception
+    {
+        HttpTester.Request request = HttpTester.newRequest();
+        request.setMethod("GET");
+        request.setURI("/some/other/path");
+        request.setVersion("HTTP/1.1");
+        request.setHeader("Host", "localhost");
+
+        HttpTester.Response response = HttpTester.parseResponse(connector.getResponse(request.generate()));
+
+        // Falls through to the 404 handler
+        assertThat(response.getStatus(), is(HttpStatus.NOT_FOUND_404));
+    }
+
+    @Test
+    public void testPendingChallengeCount()
+    {
+        assertThat(challengeHandler.getPendingChallengeCount(), is(0));
+
+        challengeHandler.addChallenge("token1", "auth1");
+        assertThat(challengeHandler.getPendingChallengeCount(), is(1));
+
+        challengeHandler.addChallenge("token2", "auth2");
+        assertThat(challengeHandler.getPendingChallengeCount(), is(2));
+
+        challengeHandler.removeChallenge("token1");
+        assertThat(challengeHandler.getPendingChallengeCount(), is(1));
+
+        challengeHandler.clearChallenges();
+        assertThat(challengeHandler.getPendingChallengeCount(), is(0));
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeChallengeHandlerTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeChallengeHandlerTest.java
@@ -46,12 +46,8 @@ public class AcmeChallengeHandlerTest
         connector = new LocalConnector(server);
         server.addConnector(connector);
 
-        challengeHandler = new AcmeChallengeHandler();
-
-        // Add a fallback handler
-        Handler.Sequence sequence = new Handler.Sequence();
-        sequence.addHandler(challengeHandler);
-        sequence.addHandler(new Handler.Abstract.NonBlocking()
+        // Create fallback handler that returns 404 for non-challenge requests
+        Handler fallbackHandler = new Handler.Abstract.NonBlocking()
         {
             @Override
             public boolean handle(Request request, Response response, Callback callback)
@@ -60,9 +56,12 @@ public class AcmeChallengeHandlerTest
                 callback.succeeded();
                 return true;
             }
-        });
+        };
 
-        server.setHandler(sequence);
+        // Wrap the fallback handler with the challenge handler
+        challengeHandler = new AcmeChallengeHandler(fallbackHandler);
+
+        server.setHandler(challengeHandler);
         server.start();
     }
 

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeClientTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeClientTest.java
@@ -1,0 +1,185 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.ByteBuffer;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AcmeClientTest
+{
+    private Server mockAcmeServer;
+    private ServerConnector connector;
+    private HttpClient httpClient;
+    private KeyPair accountKeyPair;
+    private String directoryUrl;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        // Generate account key pair
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, new SecureRandom());
+        accountKeyPair = keyGen.generateKeyPair();
+
+        // Create mock ACME server
+        mockAcmeServer = new Server();
+        connector = new ServerConnector(mockAcmeServer);
+        connector.setPort(0);
+        mockAcmeServer.addConnector(connector);
+
+        mockAcmeServer.setHandler(new MockAcmeHandler());
+        mockAcmeServer.start();
+
+        directoryUrl = "http://localhost:" + connector.getLocalPort() + "/directory";
+
+        // Create HTTP client
+        httpClient = new HttpClient();
+        httpClient.start();
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        if (httpClient != null)
+            httpClient.stop();
+        if (mockAcmeServer != null)
+            mockAcmeServer.stop();
+    }
+
+    @Test
+    public void testFetchDirectory() throws Exception
+    {
+        AcmeClient client = new AcmeClient(httpClient, accountKeyPair, directoryUrl);
+
+        client.fetchDirectory();
+
+        // Should not throw - directory was fetched
+    }
+
+    @Test
+    public void testFetchNonce() throws Exception
+    {
+        AcmeClient client = new AcmeClient(httpClient, accountKeyPair, directoryUrl);
+        client.fetchDirectory();
+
+        String nonce = client.fetchNonce();
+
+        assertThat(nonce, is(notNullValue()));
+        assertThat(nonce, is("mock-nonce-12345"));
+    }
+
+    @Test
+    public void testComputeKeyAuthorization() throws Exception
+    {
+        AcmeClient client = new AcmeClient(httpClient, accountKeyPair, directoryUrl);
+
+        String token = "test-token-xyz";
+        String keyAuth = client.computeKeyAuthorization(token);
+
+        assertThat(keyAuth, is(notNullValue()));
+        assertThat(keyAuth.startsWith(token + "."), is(true));
+    }
+
+    @Test
+    public void testFetchDirectoryFailure() throws Exception
+    {
+        AcmeClient client = new AcmeClient(httpClient, accountKeyPair,
+            "http://localhost:" + connector.getLocalPort() + "/invalid");
+
+        assertThrows(AcmeException.class, client::fetchDirectory);
+    }
+
+    /**
+     * Mock ACME server handler for testing.
+     */
+    private static class MockAcmeHandler extends Handler.Abstract.NonBlocking
+    {
+        @Override
+        public boolean handle(Request request, Response response, Callback callback)
+        {
+            String path = request.getHttpURI().getPath();
+
+            response.getHeaders().put("Replay-Nonce", "mock-nonce-12345");
+
+            if ("/directory".equals(path))
+            {
+                String directoryJson = """
+                    {
+                        "newNonce": "http://localhost:%d/new-nonce",
+                        "newAccount": "http://localhost:%d/new-account",
+                        "newOrder": "http://localhost:%d/new-order",
+                        "revokeCert": "http://localhost:%d/revoke-cert"
+                    }
+                    """.formatted(
+                    getPort(request), getPort(request), getPort(request), getPort(request)
+                );
+
+                response.setStatus(HttpStatus.OK_200);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
+                response.write(true, ByteBuffer.wrap(directoryJson.getBytes()), callback);
+                return true;
+            }
+            else if ("/new-nonce".equals(path))
+            {
+                response.setStatus(HttpStatus.OK_200);
+                callback.succeeded();
+                return true;
+            }
+            else if ("/new-account".equals(path))
+            {
+                String accountJson = """
+                    {
+                        "status": "valid",
+                        "contact": ["mailto:test@example.com"]
+                    }
+                    """;
+
+                response.setStatus(HttpStatus.CREATED_201);
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/json");
+                response.getHeaders().put("Location", "http://localhost:" + getPort(request) + "/acct/12345");
+                response.write(true, ByteBuffer.wrap(accountJson.getBytes()), callback);
+                return true;
+            }
+
+            response.setStatus(HttpStatus.NOT_FOUND_404);
+            callback.succeeded();
+            return true;
+        }
+
+        private int getPort(Request request)
+        {
+            return Request.getLocalPort(request);
+        }
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
@@ -1,0 +1,166 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AcmeConfigurationTest
+{
+    @Test
+    public void testDefaultConfiguration()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        assertThat(config.isDryRun(), is(true));
+        assertThat(config.getDirectoryUrl(), equalTo(AcmeConfiguration.LETSENCRYPT_STAGING_URL));
+        assertThat(config.getDomains(), is(empty()));
+        assertThat(config.getRenewalThresholdDays(), is(30));
+        assertThat(config.getCheckIntervalSeconds(), is(86400L));
+        assertThat(config.isTermsOfServiceAgreed(), is(false));
+    }
+
+    @Test
+    public void testSetDomainsFromString()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        config.setDomains("example.com,www.example.com");
+
+        assertThat(config.getDomains(), contains("example.com", "www.example.com"));
+    }
+
+    @Test
+    public void testSetDomainsWithSpaces()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        config.setDomains("example.com , www.example.com , api.example.com");
+
+        assertThat(config.getDomains(), contains("example.com", "www.example.com", "api.example.com"));
+    }
+
+    @Test
+    public void testSetDomainsFromList()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        config.setDomains(List.of("example.com", "www.example.com"));
+
+        assertThat(config.getDomains(), contains("example.com", "www.example.com"));
+    }
+
+    @Test
+    public void testSetAccountKeyPath()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        config.setAccountKeyPath("custom/path/account.key");
+
+        assertThat(config.getAccountKeyPath(), equalTo(Path.of("custom/path/account.key")));
+    }
+
+    @Test
+    public void testSetKeystorePath()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+
+        config.setKeystorePath("custom/keystore.p12");
+
+        assertThat(config.getKeystorePath(), equalTo(Path.of("custom/keystore.p12")));
+    }
+
+    @Test
+    public void testValidateInDryRunMode()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDryRun(true);
+
+        // Validation should pass even without required fields
+        assertDoesNotThrow(config::validate);
+    }
+
+    @Test
+    public void testValidateRequiresDomains()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDryRun(false);
+        config.setAccountEmail("admin@example.com");
+        config.setTermsOfServiceAgreed(true);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
+        assertThat(e.getMessage(), equalTo("At least one domain must be configured"));
+    }
+
+    @Test
+    public void testValidateRequiresEmail()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDryRun(false);
+        config.setDomains("example.com");
+        config.setTermsOfServiceAgreed(true);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
+        assertThat(e.getMessage(), equalTo("Account email must be configured"));
+    }
+
+    @Test
+    public void testValidateRequiresTermsAgreement()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDryRun(false);
+        config.setDomains("example.com");
+        config.setAccountEmail("admin@example.com");
+        config.setTermsOfServiceAgreed(false);
+
+        IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
+        assertThat(e.getMessage(), equalTo("Terms of service must be agreed to for production use"));
+    }
+
+    @Test
+    public void testValidatePassesWithAllRequired()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDryRun(false);
+        config.setDomains("example.com");
+        config.setAccountEmail("admin@example.com");
+        config.setTermsOfServiceAgreed(true);
+
+        assertDoesNotThrow(config::validate);
+    }
+
+    @Test
+    public void testToString()
+    {
+        AcmeConfiguration config = new AcmeConfiguration();
+        config.setDomains("example.com");
+        config.setAccountEmail("admin@example.com");
+
+        String str = config.toString();
+
+        assertThat(str.contains("dryRun=true"), is(true));
+        assertThat(str.contains("example.com"), is(true));
+        assertThat(str.contains("admin@example.com"), is(true));
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.acme;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
@@ -37,7 +38,7 @@ public class AcmeConfigurationTest
         assertThat(config.getDirectoryUrl(), equalTo(AcmeConfiguration.LETSENCRYPT_STAGING_URL));
         assertThat(config.getDomains(), is(empty()));
         assertThat(config.getRenewalThresholdDays(), is(30));
-        assertThat(config.getCheckIntervalSeconds(), is(86400L));
+        assertThat(config.getCheckInterval(), equalTo(Duration.ofDays(1)));
         assertThat(config.isTermsOfServiceAgreed(), is(false));
     }
 

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeConfigurationTest.java
@@ -16,8 +16,13 @@ package org.eclipse.jetty.acme;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -102,41 +107,46 @@ public class AcmeConfigurationTest
         assertDoesNotThrow(config::validate);
     }
 
-    @Test
-    public void testValidateRequiresDomains()
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("validationFailureCases")
+    public void testValidationFailures(String description, Consumer<AcmeConfiguration> setup, String expectedMessage)
     {
         AcmeConfiguration config = new AcmeConfiguration();
         config.setDryRun(false);
-        config.setAccountEmail("admin@example.com");
-        config.setTermsOfServiceAgreed(true);
+        setup.accept(config);
 
         IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
-        assertThat(e.getMessage(), equalTo("At least one domain must be configured"));
+        assertThat(e.getMessage(), equalTo(expectedMessage));
     }
 
-    @Test
-    public void testValidateRequiresEmail()
+    static Stream<Arguments> validationFailureCases()
     {
-        AcmeConfiguration config = new AcmeConfiguration();
-        config.setDryRun(false);
-        config.setDomains("example.com");
-        config.setTermsOfServiceAgreed(true);
-
-        IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
-        assertThat(e.getMessage(), equalTo("Account email must be configured"));
-    }
-
-    @Test
-    public void testValidateRequiresTermsAgreement()
-    {
-        AcmeConfiguration config = new AcmeConfiguration();
-        config.setDryRun(false);
-        config.setDomains("example.com");
-        config.setAccountEmail("admin@example.com");
-        config.setTermsOfServiceAgreed(false);
-
-        IllegalStateException e = assertThrows(IllegalStateException.class, config::validate);
-        assertThat(e.getMessage(), equalTo("Terms of service must be agreed to for production use"));
+        return Stream.of(
+            Arguments.of(
+                "missing domains",
+                (Consumer<AcmeConfiguration>)c ->
+                {
+                    c.setAccountEmail("admin@example.com");
+                    c.setTermsOfServiceAgreed(true);
+                },
+                "At least one domain must be configured"),
+            Arguments.of(
+                "missing email",
+                (Consumer<AcmeConfiguration>)c ->
+                {
+                    c.setDomains("example.com");
+                    c.setTermsOfServiceAgreed(true);
+                },
+                "Account email must be configured"),
+            Arguments.of(
+                "missing terms agreement",
+                (Consumer<AcmeConfiguration>)c ->
+                {
+                    c.setDomains("example.com");
+                    c.setAccountEmail("admin@example.com");
+                },
+                "Terms of service must be agreed to for production use")
+        );
     }
 
     @Test

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeJwsSignerTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeJwsSignerTest.java
@@ -1,0 +1,184 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Map;
+
+import org.eclipse.jetty.util.ajax.JSON;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasKey;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+public class AcmeJwsSignerTest
+{
+    private KeyPair keyPair;
+    private JSON json;
+    private AcmeJwsSigner signer;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, new SecureRandom());
+        keyPair = keyGen.generateKeyPair();
+
+        json = new JSON();
+        signer = new AcmeJwsSigner(keyPair, json);
+    }
+
+    @Test
+    public void testGetJwk()
+    {
+        Map<String, Object> jwk = signer.getJwk();
+
+        assertThat(jwk, hasKey("kty"));
+        assertThat(jwk.get("kty"), equalTo("RSA"));
+        assertThat(jwk, hasKey("n"));
+        assertThat(jwk, hasKey("e"));
+    }
+
+    @Test
+    public void testComputeThumbprint() throws Exception
+    {
+        String thumbprint = signer.computeThumbprint();
+
+        assertThat(thumbprint, is(notNullValue()));
+        assertThat(thumbprint.length(), is(43));
+        // Base64url should not have + or /
+        assertThat(thumbprint, not(containsString("+")));
+        assertThat(thumbprint, not(containsString("/")));
+        assertThat(thumbprint, not(containsString("=")));
+    }
+
+    @Test
+    public void testComputeKeyAuthorization() throws Exception
+    {
+        String token = "test-token-abc123";
+        String keyAuth = signer.computeKeyAuthorization(token);
+
+        assertThat(keyAuth, is(notNullValue()));
+        assertThat(keyAuth.startsWith(token + "."), is(true));
+    }
+
+    @Test
+    public void testSignWithJwk() throws Exception
+    {
+        Map<String, Object> payload = Map.of("test", "value");
+        String nonce = "test-nonce-12345";
+        String url = "https://acme.example.com/test";
+
+        String jwsJson = signer.sign(payload, nonce, url);
+
+        assertThat(jwsJson, is(notNullValue()));
+
+        // Parse the JWS
+        @SuppressWarnings("unchecked")
+        Map<String, String> jws = (Map<String, String>)json.fromJSON(jwsJson);
+
+        assertThat(jws, hasKey("protected"));
+        assertThat(jws, hasKey("payload"));
+        assertThat(jws, hasKey("signature"));
+
+        // Decode protected header
+        String protectedB64 = jws.get("protected");
+        String protectedJson = new String(Base64.getUrlDecoder().decode(protectedB64));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> header = (Map<String, Object>)json.fromJSON(protectedJson);
+
+        assertThat(header.get("alg"), equalTo("RS256"));
+        assertThat(header.get("nonce"), equalTo(nonce));
+        assertThat(header.get("url"), equalTo(url));
+        assertThat(header, hasKey("jwk"));
+        // No kid when account URL is not set
+        assertThat(header.get("kid"), is(nullValue()));
+    }
+
+    @Test
+    public void testSignWithKid() throws Exception
+    {
+        String accountUrl = "https://acme.example.com/acct/12345";
+        signer.setAccountUrl(accountUrl);
+
+        Map<String, Object> payload = Map.of("test", "value");
+        String nonce = "test-nonce-67890";
+        String url = "https://acme.example.com/test";
+
+        String jwsJson = signer.sign(payload, nonce, url);
+
+        // Parse the JWS
+        @SuppressWarnings("unchecked")
+        Map<String, String> jws = (Map<String, String>)json.fromJSON(jwsJson);
+
+        // Decode protected header
+        String protectedB64 = jws.get("protected");
+        String protectedJson = new String(Base64.getUrlDecoder().decode(protectedB64));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> header = (Map<String, Object>)json.fromJSON(protectedJson);
+
+        assertThat(header.get("kid"), equalTo(accountUrl));
+        // No jwk when kid is set
+        assertThat(header.get("jwk"), is(nullValue()));
+    }
+
+    @Test
+    public void testSignPostAsGet() throws Exception
+    {
+        String nonce = "test-nonce-aaaaa";
+        String url = "https://acme.example.com/resource";
+
+        // null payload means POST-as-GET
+        String jwsJson = signer.sign(null, nonce, url);
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> jws = (Map<String, String>)json.fromJSON(jwsJson);
+
+        // Payload should be empty string for POST-as-GET
+        assertThat(jws.get("payload"), equalTo(""));
+    }
+
+    @Test
+    public void testSetAndGetAccountUrl()
+    {
+        assertThat(signer.getAccountUrl(), is(nullValue()));
+
+        String accountUrl = "https://acme.example.com/acct/99999";
+        signer.setAccountUrl(accountUrl);
+
+        assertThat(signer.getAccountUrl(), equalTo(accountUrl));
+    }
+
+    @Test
+    public void testSignatureIsValid()
+    {
+        // Just verify that signing doesn't throw
+        Map<String, Object> payload = Map.of("resource", "new-reg");
+        String nonce = "valid-nonce";
+        String url = "https://acme.example.com/new-account";
+
+        assertDoesNotThrow(() -> signer.sign(payload, nonce, url));
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeKeyStoreManagerTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeKeyStoreManagerTest.java
@@ -1,0 +1,159 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+public class AcmeKeyStoreManagerTest
+{
+    @TempDir
+    Path tempDir;
+
+    private AcmeKeyStoreManager keyStoreManager;
+
+    @BeforeEach
+    public void setUp()
+    {
+        keyStoreManager = new AcmeKeyStoreManager(tempDir);
+    }
+
+    @Test
+    public void testGenerateDomainKeyPair() throws Exception
+    {
+        KeyPair keyPair = keyStoreManager.generateDomainKeyPair();
+
+        assertThat(keyPair, is(notNullValue()));
+        assertThat(keyPair.getPrivate(), is(notNullValue()));
+        assertThat(keyPair.getPublic(), is(notNullValue()));
+        assertThat(keyPair.getPrivate().getAlgorithm(), equalTo("RSA"));
+    }
+
+    @Test
+    public void testLoadOrGenerateAccountKey() throws Exception
+    {
+        Path accountKeyPath = Path.of("acme/account.key");
+
+        // First call should generate
+        KeyPair keyPair1 = keyStoreManager.loadOrGenerateAccountKey(accountKeyPath);
+        assertThat(keyPair1, is(notNullValue()));
+
+        // Key file should exist
+        Path fullPath = tempDir.resolve(accountKeyPath);
+        assertThat(Files.exists(fullPath), is(true));
+
+        // Second call should load the same key
+        KeyPair keyPair2 = keyStoreManager.loadOrGenerateAccountKey(accountKeyPath);
+        assertThat(keyPair2, is(notNullValue()));
+
+        // Should be the same key
+        assertThat(keyPair1.getPublic().getEncoded(), equalTo(keyPair2.getPublic().getEncoded()));
+    }
+
+    @Test
+    public void testGenerateCSR() throws Exception
+    {
+        KeyPair keyPair = keyStoreManager.generateDomainKeyPair();
+        List<String> domains = List.of("example.com", "www.example.com");
+
+        byte[] csr = keyStoreManager.generateCSR(keyPair, domains);
+
+        assertThat(csr, is(notNullValue()));
+        assertThat(csr.length, greaterThan(100));
+        // DER encoded CSR starts with SEQUENCE tag (0x30)
+        assertThat(csr[0], equalTo((byte)0x30));
+    }
+
+    @Test
+    public void testGenerateSelfSignedCertificate() throws Exception
+    {
+        KeyPair keyPair = keyStoreManager.generateDomainKeyPair();
+        List<String> domains = List.of("example.com", "www.example.com");
+
+        X509Certificate cert = keyStoreManager.generateSelfSignedCertificate(keyPair, domains, 90);
+
+        assertThat(cert, is(notNullValue()));
+        assertThat(cert.getSubjectX500Principal().getName(), containsString("CN=example.com"));
+        assertThat(cert.getIssuerX500Principal().getName(), containsString("CN=example.com"));
+
+        // Check SAN
+        assertThat(cert.getSubjectAlternativeNames(), is(notNullValue()));
+    }
+
+    @Test
+    public void testStoreCertificates() throws Exception
+    {
+        KeyPair keyPair = keyStoreManager.generateDomainKeyPair();
+        List<String> domains = List.of("test.example.com");
+        X509Certificate cert = keyStoreManager.generateSelfSignedCertificate(keyPair, domains, 30);
+
+        Path keystorePath = Path.of("etc/keystore.p12");
+        String password = "testpassword";
+
+        keyStoreManager.storeCertificates(keystorePath, password, keyPair.getPrivate(),
+            Collections.singletonList(cert));
+
+        // Verify file exists
+        Path fullPath = tempDir.resolve(keystorePath);
+        assertThat(Files.exists(fullPath), is(true));
+    }
+
+    @Test
+    public void testLoadCertificate() throws Exception
+    {
+        KeyPair keyPair = keyStoreManager.generateDomainKeyPair();
+        List<String> domains = List.of("load.example.com");
+        X509Certificate cert = keyStoreManager.generateSelfSignedCertificate(keyPair, domains, 30);
+
+        Path keystorePath = Path.of("etc/test-load.p12");
+        String password = "loadpassword";
+
+        keyStoreManager.storeCertificates(keystorePath, password, keyPair.getPrivate(),
+            Collections.singletonList(cert));
+
+        // Load the certificate back
+        X509Certificate loadedCert = keyStoreManager.loadCertificate(keystorePath, password);
+
+        assertThat(loadedCert, is(notNullValue()));
+        assertThat(loadedCert.getSubjectX500Principal().getName(),
+            equalTo(cert.getSubjectX500Principal().getName()));
+    }
+
+    @Test
+    public void testLoadCertificateFromNonExistentFile() throws Exception
+    {
+        Path keystorePath = Path.of("nonexistent/keystore.p12");
+
+        X509Certificate cert = keyStoreManager.loadCertificate(keystorePath, "password");
+
+        assertThat(cert, is(nullValue()));
+    }
+}

--- a/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeStagingIntegrationTest.java
+++ b/jetty-core/jetty-acme/src/test/java/org/eclipse/jetty/acme/AcmeStagingIntegrationTest.java
@@ -1,0 +1,93 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.acme;
+
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.SecureRandom;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+/**
+ * Integration tests against Let's Encrypt staging server.
+ * These tests require network access and are excluded from normal CI builds.
+ */
+@Tag("external")
+public class AcmeStagingIntegrationTest
+{
+    private HttpClient httpClient;
+    private KeyPair accountKeyPair;
+    private AcmeClient acmeClient;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        // Generate account key pair
+        KeyPairGenerator keyGen = KeyPairGenerator.getInstance("RSA");
+        keyGen.initialize(2048, new SecureRandom());
+        accountKeyPair = keyGen.generateKeyPair();
+
+        // Create HTTP client
+        httpClient = new HttpClient();
+        httpClient.start();
+
+        // Create ACME client for Let's Encrypt staging
+        acmeClient = new AcmeClient(httpClient, accountKeyPair,
+            AcmeConfiguration.LETSENCRYPT_STAGING_URL);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        if (httpClient != null)
+            httpClient.stop();
+    }
+
+    @Test
+    public void testFetchDirectoryFromStaging() throws Exception
+    {
+        acmeClient.fetchDirectory();
+        // If we get here without exception, the directory was fetched successfully
+    }
+
+    @Test
+    public void testFetchNonceFromStaging() throws Exception
+    {
+        acmeClient.fetchDirectory();
+        String nonce = acmeClient.fetchNonce();
+
+        assertThat(nonce, is(notNullValue()));
+        assertThat(nonce.isEmpty(), is(false));
+    }
+
+    @Test
+    public void testCreateAccountOnStaging() throws Exception
+    {
+        acmeClient.fetchDirectory();
+
+        // Create account with terms of service agreed
+        String accountUrl = acmeClient.createAccount("test@example.com", true);
+
+        assertThat(accountUrl, is(notNullValue()));
+        assertThat(accountUrl.contains("acme-staging"), is(true));
+    }
+}

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -18,7 +18,7 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-acme</artifactId>
-        <version>12.1.10-SNAPSHOT</version>
+        <version>12.1.11-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -17,6 +17,11 @@
     <dependencies>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>12.1.10-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-bouncycastle-client</artifactId>
         <version>12.1.11-SNAPSHOT</version>
       </dependency>
@@ -59,11 +64,6 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
         <version>12.1.11-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-acme</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -62,6 +62,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
         <version>12.1.11-SNAPSHOT</version>
       </dependency>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -62,6 +62,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>12.1.6-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-client</artifactId>
         <version>12.1.13-SNAPSHOT</version>
       </dependency>

--- a/jetty-core/jetty-bom/pom.xml
+++ b/jetty-core/jetty-bom/pom.xml
@@ -17,6 +17,11 @@
     <dependencies>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>12.1.10-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-bouncycastle-client</artifactId>
         <version>12.1.13-SNAPSHOT</version>
       </dependency>
@@ -59,11 +64,6 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
         <version>12.1.13-SNAPSHOT</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-acme</artifactId>
-        <version>12.1.6-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>

--- a/jetty-core/pom.xml
+++ b/jetty-core/pom.xml
@@ -13,6 +13,7 @@
   <description>Jetty Core API Parent</description>
 
   <modules>
+    <module>jetty-acme</module>
     <module>jetty-alpn</module>
     <module>jetty-annotations</module>
     <module>jetty-bom</module>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -21,6 +21,11 @@
   <dependencies>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-acme</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-bouncycastle-server</artifactId>
     </dependency>
     <dependency>
@@ -34,11 +39,6 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-alpn-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-acme</artifactId>
-      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -37,6 +37,11 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-acme</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-annotations</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-annotations</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -694,6 +694,11 @@
       </dependency>
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-acme</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-bouncycastle-client</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -730,11 +735,6 @@
       <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-alpn-server</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-acme</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Fixes #14401 by introducing a new `jetty-acme` module for automatic TLS certificate management using the ACME protocol (RFC 8555).                                                              

- Automatic certificate issuance and renewal via ACME protocol                                                                                                                 
- HTTP-01 challenge validation                                                                                                                                                 
- Hot-reload of renewed certificates without server restart                                                                                                                    
- Dry-run mode for testing with self-signed certificates                                                                                                                       
- Configurable renewal threshold and check intervals                                                                                                                           
- BadNonce automatic retry with exponential backoff                                                                                                                            
- Rate limit detection                                                                                                                                                         
- JMX management support

