### PR TITLE
Add support for http format in --add-modules=https://babb

### DIFF
--- a/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
@@ -104,6 +104,58 @@ If `--download-auth-header` is provided, it takes precedence over `--download-us
 
 NOTE: These authentication options apply to all HTTP downloads performed during the session, including files referenced in the `<<directive-files,[files]>>` sections of modules.
 
+[[remote-security]]
+=== Download URL Allowlist
+
+For security, Jetty restricts which URLs are accepted for remote module downloads.
+By default, only URLs starting with `https://repo1.maven.org/maven2/` are allowed.
+
+To add additional trusted URL prefixes, use one of the following options:
+
+==== URL Prefixes (Comma-Separated)
+
+----
+$ java -jar $JETTY_HOME/start.jar \
+    --download-allowed-urls=https://repo-a.example.com/,https://repo-b.example.com/ \
+    --add-modules=https://repo-a.example.com/acme-config-1.0.jar
+----
+
+==== URL Prefixes from a File
+
+----
+$ java -jar $JETTY_HOME/start.jar \
+    --download-allowed-urls-file=etc/download-allowlist.txt \
+    --add-modules=https://private-repo.example.com/artifacts/acme-config-1.0.jar
+----
+
+The file should contain one URL prefix per line.
+Lines starting with `#` are treated as comments, and blank lines are ignored:
+
+.etc/download-allowlist.txt
+----
+# Allowed download sources for remote modules
+
+# Maven Central (already included by default)
+# https://repo1.maven.org/maven2/
+
+# Corporate artifact repository
+https://private-repo.example.com/artifacts/
+
+# Staging repository
+https://staging.example.com/releases/
+----
+
+[IMPORTANT]
+====
+URL prefixes should end with `/` to prevent partial domain matching.
+For example, `https://repo.example.com/` will not match `https://repo.example.com.evil.org/`.
+
+Redirect targets are also validated against the allowlist -- a trusted server cannot redirect the download to an untrusted destination.
+
+The `--allow-insecure-http-downloads` option bypasses the allowlist entirely.
+This should only be used for testing purposes.
+====
+
 [[names]]
 == Module Names
 

--- a/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/index.adoc
@@ -30,6 +30,80 @@ The standard Jetty modules that Jetty provides out-of-the-box are under `$JETTY_
 
 xref:modules/custom.adoc[Custom Jetty modules] should be put under `$JETTY_BASE/modules/`.
 
+[[remote]]
+== Installing Modules from a Remote URL
+
+In addition to enabling modules that are already present on the filesystem, you can install modules by downloading a _config JAR_ from a remote URL.
+
+A config JAR is a JAR (or ZIP) archive whose contents are extracted directly into `$JETTY_BASE`.
+It typically contains:
+
+* `modules/*.mod` -- module definition files
+* `etc/*.xml` -- XML configuration files
+* `lib/*.jar` -- library files
+* `resources/` -- resource files
+
+To install modules from a remote config JAR, pass the full URL as the value of `--add-modules`:
+
+----
+$ java -jar $JETTY_HOME/start.jar --add-modules=https://repo.example.com/org/acme/jetty-acme-config/1.0.0/jetty-acme-config-1.0.0.jar
+----
+
+When a URL is detected in `--add-modules`, Jetty will:
+
+. Download the config JAR from the URL.
+. Extract its contents into `$JETTY_BASE` (the `META-INF/` directory is excluded).
+. Register any new `+*.mod+` files found under `$JETTY_BASE/modules/`.
+. Enable all newly discovered modules and their transitive dependencies.
+
+If the config JAR contains multiple `+*.mod+` files, all of them are registered and enabled.
+
+You can combine remote URLs with regular module names in the same `--add-modules` option:
+
+----
+$ java -jar $JETTY_HOME/start.jar --add-modules=http,https://repo.example.com/acme-config-1.0.jar
+----
+
+[NOTE]
+====
+By default, only `https://` URLs are allowed.
+To permit downloads over plain `http://`, you must also pass the `--allow-insecure-http-downloads` option:
+
+----
+$ java -jar $JETTY_HOME/start.jar --allow-insecure-http-downloads --add-modules=http://internal-server/acme-config.jar
+----
+====
+
+[[remote-auth]]
+=== Authenticated Downloads
+
+If the remote server requires authentication, you can provide credentials via command-line options.
+
+==== HTTP Basic Authentication
+
+Use `--download-username` and `--download-password` to authenticate with HTTP Basic Auth:
+
+----
+$ java -jar $JETTY_HOME/start.jar \
+    --download-username=myuser \
+    --download-password=mypassword \
+    --add-modules=https://private-repo.example.com/acme-config-1.0.jar
+----
+
+==== Custom Authorization Header
+
+For other authentication schemes (such as Bearer tokens), use `--download-auth-header` to set the `Authorization` header directly:
+
+----
+$ java -jar $JETTY_HOME/start.jar \
+    --download-auth-header="Bearer eyJhbGciOi..." \
+    --add-modules=https://private-repo.example.com/acme-config-1.0.jar
+----
+
+If `--download-auth-header` is provided, it takes precedence over `--download-username` / `--download-password`.
+
+NOTE: These authentication options apply to all HTTP downloads performed during the session, including files referenced in the `<<directive-files,[files]>>` sections of modules.
+
 [[names]]
 == Module Names
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -16,12 +16,18 @@ package org.eclipse.jetty.start;
 import java.io.BufferedReader;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.net.ProxySelector;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.PathMatcher;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -33,6 +39,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.eclipse.jetty.start.builders.StartDirBuilder;
 import org.eclipse.jetty.start.builders.StartIniBuilder;
 import org.eclipse.jetty.start.fileinits.BaseHomeFileInitializer;
+import org.eclipse.jetty.start.fileinits.DownloadFileInitializer;
 import org.eclipse.jetty.start.fileinits.LocalFileInitializer;
 import org.eclipse.jetty.start.fileinits.MavenLocalRepoFileInitializer;
 import org.eclipse.jetty.start.fileinits.TestFileInitializer;
@@ -106,6 +113,17 @@ public class BaseBuilder
 
             // Normal URL downloads
             fileInitializers.add(new UriFileInitializer(startArgs, baseHome));
+
+            // Propagate download auth to all download-capable initializers
+            String authHeader = args.getDownloadAuthorizationHeader();
+            if (authHeader != null)
+            {
+                for (FileInitializer fi : fileInitializers)
+                {
+                    if (fi instanceof DownloadFileInitializer dfi)
+                        dfi.setAuthorizationHeader(authHeader);
+                }
+            }
         }
     }
 
@@ -118,6 +136,10 @@ public class BaseBuilder
     public boolean build() throws IOException
     {
         Modules modules = startArgs.getAllModules();
+
+        // Pre-process: download and extract any URL-based module references,
+        // replacing URLs in the startModules list with actual module names.
+        resolveRemoteModules(modules);
 
         // Select all the added modules to determine which ones are newly enabled
         Set<String> newlyAdded = new HashSet<>();
@@ -422,5 +444,153 @@ public class BaseBuilder
         }
 
         return dirty;
+    }
+
+    /**
+     * Tests whether a module name is actually a remote URL pointing to a config JAR.
+     *
+     * @param name the module name to test
+     * @return true if the name is an HTTP or HTTPS URL
+     */
+    static boolean isRemoteModuleUri(String name)
+    {
+        return name.startsWith("http://") || name.startsWith("https://");
+    }
+
+    /**
+     * Pre-processes the start modules list, downloading and extracting any entries
+     * that are remote URLs pointing to config JARs. Each URL entry is replaced in the
+     * start modules list with the actual module name(s) discovered inside the JAR.
+     *
+     * <p>A config JAR is a JAR/ZIP file whose contents are extracted directly into
+     * {@code ${jetty.base}}. It typically contains:</p>
+     * <ul>
+     *   <li>{@code modules/*.mod} — module definition files</li>
+     *   <li>{@code etc/*.xml} — XML configuration files</li>
+     *   <li>{@code lib/*.jar} — library files</li>
+     *   <li>{@code resources/} — resource files</li>
+     * </ul>
+     *
+     * @param modules the module registry to register newly discovered modules into
+     * @throws IOException if a download or extraction fails
+     */
+    private void resolveRemoteModules(Modules modules) throws IOException
+    {
+        List<String> startModules = startArgs.getStartModules();
+        List<String> resolved = new ArrayList<>();
+        boolean hasRemote = false;
+
+        for (String name : startModules)
+        {
+            if (isRemoteModuleUri(name))
+            {
+                hasRemote = true;
+                URI uri = URI.create(name);
+                StartLog.info("Downloading config JAR from %s", uri);
+
+                // Download to a temporary file
+                Path tempJar = downloadConfigJar(uri);
+
+                try
+                {
+                    // Extract JAR contents into ${jetty.base}
+                    Path jettyBase = baseHome.getBasePath();
+                    FS.extract(tempJar, jettyBase);
+
+                    // Register any new .mod files that were extracted
+                    Path modulesDir = jettyBase.resolve("modules");
+                    List<String> newModuleNames = modules.registerNewModules(modulesDir);
+
+                    if (newModuleNames.isEmpty())
+                    {
+                        StartLog.warn("No new modules found in config JAR: %s", uri);
+                    }
+                    else
+                    {
+                        StartLog.info("Discovered modules %s from %s", newModuleNames, uri);
+                    }
+
+                    resolved.addAll(newModuleNames);
+                }
+                finally
+                {
+                    // Clean up the temp file
+                    Files.deleteIfExists(tempJar);
+                }
+            }
+            else
+            {
+                resolved.add(name);
+            }
+        }
+
+        if (hasRemote)
+        {
+            // Replace the start modules list with the resolved names
+            startModules.clear();
+            startModules.addAll(resolved);
+        }
+    }
+
+    /**
+     * Downloads a config JAR from a remote URI to a temporary file.
+     *
+     * @param uri the URI to download from
+     * @return the path to the downloaded temporary file
+     * @throws IOException if the download fails
+     */
+    private Path downloadConfigJar(URI uri) throws IOException
+    {
+        if ("http".equalsIgnoreCase(uri.getScheme()) && !startArgs.isAllowInsecureHttpDownloads())
+        {
+            throw new IOException("Insecure HTTP download not allowed (use " +
+                StartArgs.ARG_ALLOW_INSECURE_HTTP_DOWNLOADS + " to bypass): " + uri);
+        }
+
+        HttpClient httpClient = HttpClient.newBuilder()
+            .followRedirects(startArgs.isAllowInsecureHttpDownloads()
+                ? HttpClient.Redirect.ALWAYS
+                : HttpClient.Redirect.NORMAL)
+            .proxy(ProxySelector.getDefault())
+            .build();
+
+        Path tempFile = Files.createTempFile("jetty-config-", ".jar");
+        try
+        {
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
+                .uri(uri)
+                .GET();
+            String authHeader = startArgs.getDownloadAuthorizationHeader();
+            if (authHeader != null)
+                reqBuilder.header("Authorization", authHeader);
+            HttpRequest request = reqBuilder.build();
+
+            HttpResponse<InputStream> response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            int status = response.statusCode();
+            if (status != 200)
+            {
+                Files.deleteIfExists(tempFile);
+                throw new IOException("URL GET Failure [status " + status + "] on " + uri);
+            }
+
+            try (InputStream in = response.body())
+            {
+                Files.copy(in, tempFile, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            return tempFile;
+        }
+        catch (InterruptedException e)
+        {
+            Files.deleteIfExists(tempFile);
+            throw new IOException("Download interrupted: " + uri, e);
+        }
+        catch (IOException e)
+        {
+            Files.deleteIfExists(tempFile);
+            throw e;
+        }
     }
 }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/BaseBuilder.java
@@ -35,6 +35,7 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import org.eclipse.jetty.start.builders.StartDirBuilder;
 import org.eclipse.jetty.start.builders.StartIniBuilder;
@@ -541,6 +542,9 @@ public class BaseBuilder
      */
     private Path downloadConfigJar(URI uri) throws IOException
     {
+        // Validate the initial URL against the allowlist
+        validateDownloadUrl(uri);
+
         if ("http".equalsIgnoreCase(uri.getScheme()) && !startArgs.isAllowInsecureHttpDownloads())
         {
             throw new IOException("Insecure HTTP download not allowed (use " +
@@ -568,6 +572,11 @@ public class BaseBuilder
             HttpResponse<InputStream> response =
                 httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());
 
+            // Validate the final URI after any redirects
+            URI finalUri = response.uri();
+            if (!finalUri.equals(uri))
+                validateDownloadUrl(finalUri);
+
             int status = response.statusCode();
             if (status != 200)
             {
@@ -592,5 +601,34 @@ public class BaseBuilder
             Files.deleteIfExists(tempFile);
             throw e;
         }
+    }
+
+    /**
+     * Validates that a download URI matches at least one allowed URL prefix.
+     * If {@code --allow-insecure-http-downloads} is enabled, the check is bypassed.
+     *
+     * @param uri the URI to validate
+     * @throws IOException if the URI does not match any allowed prefix
+     */
+    private void validateDownloadUrl(URI uri) throws IOException
+    {
+        if (startArgs.isAllowInsecureHttpDownloads())
+            return;
+
+        String uriString = uri.toString();
+        List<String> allowedUrls = startArgs.getDownloadAllowedUrls();
+
+        for (String prefix : allowedUrls)
+        {
+            if (uriString.startsWith(prefix))
+                return;
+        }
+
+        throw new IOException(String.format(
+            "Download URL not in allowlist: %s%nAllowed URL prefixes:%n%s%nUse %s=<prefix> or %s=<file> to add trusted download sources.",
+            uri,
+            allowedUrls.stream().map(p -> "  - " + p).collect(Collectors.joining(System.lineSeparator())),
+            StartArgs.ARG_DOWNLOAD_ALLOWED_URLS,
+            StartArgs.ARG_DOWNLOAD_ALLOWED_URLS_FILE));
     }
 }

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/Modules.java
@@ -251,7 +251,61 @@ public class Modules implements Iterable<Module>
         }
     }
 
-    private Module registerModule(Path file)
+    /**
+     * Scan a directory for {@code .mod} files and register any that are not already known.
+     *
+     * @param modulesDir the directory to scan (e.g. {@code ${jetty.base}/modules/})
+     * @return the list of newly registered module names
+     * @throws IOException if unable to scan the directory
+     */
+    public List<String> registerNewModules(Path modulesDir) throws IOException
+    {
+        List<String> newModuleNames = new ArrayList<>();
+        if (!Files.isDirectory(modulesDir))
+            return newModuleNames;
+
+        try (Stream<Path> modFiles = Files.walk(modulesDir))
+        {
+            modFiles
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().endsWith(".mod"))
+                .forEach(modFile ->
+                {
+                    // Derive the module name the same way the Module constructor does:
+                    // relative path under modules/ directory, without the .mod extension.
+                    Path relative = modulesDir.relativize(modFile);
+                    StringBuilder nameBuilder = new StringBuilder();
+                    for (int i = 0; i < relative.getNameCount(); i++)
+                    {
+                        if (i > 0)
+                            nameBuilder.append("/");
+                        nameBuilder.append(relative.getName(i));
+                    }
+                    String fileName = nameBuilder.toString();
+                    String moduleName = fileName.substring(0, fileName.length() - ".mod".length());
+
+                    if (_names.containsKey(moduleName))
+                    {
+                        StartLog.debug("Module [%s] already registered, skipping", moduleName);
+                        return;
+                    }
+
+                    Module module = registerModule(modFile);
+                    newModuleNames.add(module.getName());
+                    StartLog.info("Registered remote module [%s]", module.getName());
+                });
+        }
+        return newModuleNames;
+    }
+
+    /**
+     * Register a single module from a {@code .mod} file.
+     *
+     * @param file the path to the {@code .mod} file
+     * @return the registered Module
+     * @throws IllegalStateException if the file cannot be read or parsed
+     */
+    Module registerModule(Path file)
     {
         if (!FS.canReadFile(file))
         {

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -16,10 +16,12 @@ package org.eclipse.jetty.start;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -52,6 +54,9 @@ public class StartArgs
     public static final Set<String> ALL_PARTS = Set.of("java", "opts", "path", "main", "args", "envs");
     public static final Set<String> ARG_PARTS = Set.of("args", "envs");
     public static final String ARG_ALLOW_INSECURE_HTTP_DOWNLOADS = "--allow-insecure-http-downloads";
+    public static final String ARG_DOWNLOAD_USERNAME = "--download-username";
+    public static final String ARG_DOWNLOAD_PASSWORD = "--download-password";
+    public static final String ARG_DOWNLOAD_AUTH_HEADER = "--download-auth-header";
 
     private static final String JETTY_VERSION_KEY = "jetty.version";
     private static final String JETTY_TAG_NAME_KEY = "jetty.tag.version";
@@ -183,6 +188,9 @@ public class StartArgs
     private String execProperties;
     private boolean allowInsecureHttpDownloads = false;
     private boolean approveAllLicenses = false;
+    private String downloadUsername;
+    private String downloadPassword;
+    private String downloadAuthHeader;
 
     /**
      * The jetty environment holds the main configuration used from the primary classloader for Jetty.
@@ -787,6 +795,42 @@ public class StartArgs
         return allowInsecureHttpDownloads;
     }
 
+    public String getDownloadUsername()
+    {
+        return downloadUsername;
+    }
+
+    public String getDownloadPassword()
+    {
+        return downloadPassword;
+    }
+
+    public String getDownloadAuthHeader()
+    {
+        return downloadAuthHeader;
+    }
+
+    /**
+     * Returns the resolved {@code Authorization} header value for HTTP downloads.
+     * <p>If {@code --download-auth-header} is set, it is returned as-is (e.g. {@code "Bearer token"}).
+     * Otherwise, if {@code --download-username} and {@code --download-password} are set,
+     * an HTTP Basic Auth header value is computed.</p>
+     *
+     * @return the Authorization header value, or {@code null} if no credentials are configured
+     */
+    public String getDownloadAuthorizationHeader()
+    {
+        if (downloadAuthHeader != null)
+            return downloadAuthHeader;
+        if (downloadUsername != null && downloadPassword != null)
+        {
+            String credentials = downloadUsername + ":" + downloadPassword;
+            String encoded = Base64.getEncoder().encodeToString(credentials.getBytes(StandardCharsets.UTF_8));
+            return "Basic " + encoded;
+        }
+        return null;
+    }
+
     public boolean isApproveAllLicenses()
     {
         return approveAllLicenses;
@@ -1076,6 +1120,23 @@ public class StartArgs
         if (ARG_ALLOW_INSECURE_HTTP_DOWNLOADS.equals(arg))
         {
             allowInsecureHttpDownloads = true;
+            return environment;
+        }
+
+        // Download authentication
+        if (arg.startsWith(ARG_DOWNLOAD_USERNAME + "="))
+        {
+            downloadUsername = Props.getValue(arg);
+            return environment;
+        }
+        if (arg.startsWith(ARG_DOWNLOAD_PASSWORD + "="))
+        {
+            downloadPassword = Props.getValue(arg);
+            return environment;
+        }
+        if (arg.startsWith(ARG_DOWNLOAD_AUTH_HEADER + "="))
+        {
+            downloadAuthHeader = Props.getValue(arg);
             return environment;
         }
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/StartArgs.java
@@ -57,6 +57,9 @@ public class StartArgs
     public static final String ARG_DOWNLOAD_USERNAME = "--download-username";
     public static final String ARG_DOWNLOAD_PASSWORD = "--download-password";
     public static final String ARG_DOWNLOAD_AUTH_HEADER = "--download-auth-header";
+    public static final String ARG_DOWNLOAD_ALLOWED_URLS = "--download-allowed-urls";
+    public static final String ARG_DOWNLOAD_ALLOWED_URLS_FILE = "--download-allowed-urls-file";
+    public static final String DEFAULT_ALLOWED_URL_PREFIX = "https://repo1.maven.org/maven2/";
 
     private static final String JETTY_VERSION_KEY = "jetty.version";
     private static final String JETTY_TAG_NAME_KEY = "jetty.tag.version";
@@ -191,6 +194,7 @@ public class StartArgs
     private String downloadUsername;
     private String downloadPassword;
     private String downloadAuthHeader;
+    private final List<String> downloadAllowedUrls = new ArrayList<>(List.of(DEFAULT_ALLOWED_URL_PREFIX));
 
     /**
      * The jetty environment holds the main configuration used from the primary classloader for Jetty.
@@ -831,6 +835,11 @@ public class StartArgs
         return null;
     }
 
+    public List<String> getDownloadAllowedUrls()
+    {
+        return downloadAllowedUrls;
+    }
+
     public boolean isApproveAllLicenses()
     {
         return approveAllLicenses;
@@ -1137,6 +1146,32 @@ public class StartArgs
         if (arg.startsWith(ARG_DOWNLOAD_AUTH_HEADER + "="))
         {
             downloadAuthHeader = Props.getValue(arg);
+            return environment;
+        }
+
+        // Download URL allowlist
+        if (arg.startsWith(ARG_DOWNLOAD_ALLOWED_URLS + "=") && !arg.startsWith(ARG_DOWNLOAD_ALLOWED_URLS_FILE + "="))
+        {
+            downloadAllowedUrls.addAll(Props.getValues(arg));
+            return environment;
+        }
+        if (arg.startsWith(ARG_DOWNLOAD_ALLOWED_URLS_FILE + "="))
+        {
+            Path allowlistFile = baseHome.getPath(Props.getValue(arg));
+            if (!FS.canReadFile(allowlistFile))
+                throw new UsageException(UsageException.ERR_BAD_ARG, "%s file is not readable: %s", ARG_DOWNLOAD_ALLOWED_URLS_FILE, allowlistFile);
+            try
+            {
+                TextFile file = new TextFile(allowlistFile);
+                for (String line : file)
+                {
+                    downloadAllowedUrls.add(line);
+                }
+            }
+            catch (IOException e)
+            {
+                throw new UsageException(UsageException.ERR_BAD_ARG, "Failed to read %s: %s", ARG_DOWNLOAD_ALLOWED_URLS_FILE, allowlistFile);
+            }
             return environment;
         }
 

--- a/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/DownloadFileInitializer.java
+++ b/jetty-core/jetty-start/src/main/java/org/eclipse/jetty/start/fileinits/DownloadFileInitializer.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.start.StartLog;
 public abstract class DownloadFileInitializer extends FileInitializer
 {
     private HttpClient httpClient;
+    private String authorizationHeader;
 
     protected DownloadFileInitializer(BaseHome basehome, String... scheme)
     {
@@ -41,6 +42,16 @@ public abstract class DownloadFileInitializer extends FileInitializer
     }
 
     protected abstract boolean allowInsecureHttpDownloads();
+
+    /**
+     * Sets the {@code Authorization} header value to include on download requests.
+     *
+     * @param authorizationHeader the header value (e.g. {@code "Basic ..."} or {@code "Bearer ..."}), or {@code null}
+     */
+    public void setAuthorizationHeader(String authorizationHeader)
+    {
+        this.authorizationHeader = authorizationHeader;
+    }
 
     protected void download(URI uri, Path destination) throws IOException
     {
@@ -69,10 +80,12 @@ public abstract class DownloadFileInitializer extends FileInitializer
 
         try
         {
-            HttpRequest request = HttpRequest.newBuilder()
+            HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
                 .uri(uri)
-                .GET()
-                .build();
+                .GET();
+            if (authorizationHeader != null)
+                reqBuilder.header("Authorization", authorizationHeader);
+            HttpRequest request = reqBuilder.build();
 
             HttpResponse<InputStream> response =
                 httpClient.send(request, HttpResponse.BodyHandlers.ofInputStream());

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
@@ -14,7 +14,7 @@
 package org.eclipse.jetty.tests.distribution;
 
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,9 +23,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
-import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.tests.testers.JettyHomeTester;
 import org.eclipse.jetty.tests.testers.Tester;
+import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -35,6 +42,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * Tests for downloading modules from a URL via {@code --add-modules=<url>}.
+ *
+ * @see <a href="https://github.com/jetty/jetty.project/issues/175">Issue #175</a>
  */
 public class DownloadModuleTests extends AbstractJettyHomeTest
 {
@@ -47,6 +56,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
      */
     private Path createConfigJar(Path directory, String moduleName) throws Exception
     {
+        Files.createDirectories(directory);
         Path jarFile = directory.resolve(moduleName + "-config.jar");
 
         String modContent = """
@@ -73,6 +83,96 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         return jarFile;
     }
 
+    /**
+     * Starts an embedded Jetty server that serves the given content at the specified path.
+     *
+     * @param contextPath the URL path to serve the content at
+     * @param content the byte content to serve
+     * @return the started Server (caller must stop it)
+     */
+    private Server startFileServer(String contextPath, byte[] content) throws Exception
+    {
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                if (!Request.getPathInContext(request).equals(contextPath))
+                {
+                    Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
+                    return true;
+                }
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/java-archive");
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH, content.length);
+                response.write(true, ByteBuffer.wrap(content), callback);
+                return true;
+            }
+        });
+
+        server.start();
+        return server;
+    }
+
+    /**
+     * Starts an embedded Jetty server that requires the specified Authorization header.
+     * Returns 401 (for Basic) or 403 (for other schemes) if the header is missing or wrong.
+     *
+     * @param contextPath the URL path to serve the content at
+     * @param content the byte content to serve
+     * @param expectedAuthHeader the expected Authorization header value
+     * @param failStatus the HTTP status to return on auth failure (e.g. 401 or 403)
+     * @return the started Server (caller must stop it)
+     */
+    private Server startAuthFileServer(String contextPath, byte[] content,
+                                       String expectedAuthHeader, int failStatus) throws Exception
+    {
+        Server server = new Server();
+        ServerConnector connector = new ServerConnector(server);
+        connector.setPort(0);
+        server.addConnector(connector);
+
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                if (!Request.getPathInContext(request).equals(contextPath))
+                {
+                    Response.writeError(request, response, callback, HttpStatus.NOT_FOUND_404);
+                    return true;
+                }
+
+                String authHeader = request.getHeaders().get(HttpHeader.AUTHORIZATION);
+                if (!expectedAuthHeader.equals(authHeader))
+                {
+                    if (failStatus == HttpStatus.UNAUTHORIZED_401)
+                        response.getHeaders().put(HttpHeader.WWW_AUTHENTICATE, "Basic realm=\"test\"");
+                    Response.writeError(request, response, callback, failStatus);
+                    return true;
+                }
+
+                response.getHeaders().put(HttpHeader.CONTENT_TYPE, "application/java-archive");
+                response.getHeaders().put(HttpHeader.CONTENT_LENGTH, content.length);
+                response.write(true, ByteBuffer.wrap(content), callback);
+                return true;
+            }
+        });
+
+        server.start();
+        return server;
+    }
+
+    private static int getPort(Server server)
+    {
+        return server.getBean(ServerConnector.class).getLocalPort();
+//        return ((ServerConnector)server.getConnectors()[0]).getLocalPort();
+    }
+
     @Test
     public void testAddModuleFromUrl() throws Exception
     {
@@ -85,25 +185,12 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
 
         String moduleName = "test-download";
         Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
-
-        // Start a local HTTP server to serve the config JAR.
-        int httpPort = Tester.freePort();
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
         byte[] jarBytes = Files.readAllBytes(configJar);
-        httpServer.createContext("/" + configJar.getFileName(), exchange ->
-        {
-            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
-            exchange.sendResponseHeaders(200, jarBytes.length);
-            try (OutputStream os = exchange.getResponseBody())
-            {
-                os.write(jarBytes);
-            }
-        });
-        httpServer.start();
 
+        Server fileServer = startFileServer("/" + configJar.getFileName(), jarBytes);
         try
         {
-            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+            String downloadUrl = "http://localhost:" + getPort(fileServer) + "/" + configJar.getFileName();
 
             // Use --add-modules with a full URL to download and install the module.
             try (JettyHomeTester.Run run = distribution.start(
@@ -134,7 +221,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         }
         finally
         {
-            httpServer.stop(0);
+            fileServer.stop();
         }
     }
 
@@ -180,24 +267,11 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
             jos.closeEntry();
         }
 
-        // Start a local HTTP server to serve the config JAR.
-        int httpPort = Tester.freePort();
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
         byte[] jarBytes = Files.readAllBytes(jarFile);
-        httpServer.createContext("/multi-config.jar", exchange ->
-        {
-            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
-            exchange.sendResponseHeaders(200, jarBytes.length);
-            try (OutputStream os = exchange.getResponseBody())
-            {
-                os.write(jarBytes);
-            }
-        });
-        httpServer.start();
-
+        Server fileServer = startFileServer("/multi-config.jar", jarBytes);
         try
         {
-            String downloadUrl = "http://localhost:" + httpPort + "/multi-config.jar";
+            String downloadUrl = "http://localhost:" + getPort(fileServer) + "/multi-config.jar";
 
             // Download and install the config JAR containing multiple modules.
             try (JettyHomeTester.Run run = distribution.start(
@@ -216,7 +290,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         }
         finally
         {
-            httpServer.stop(0);
+            fileServer.stop();
         }
     }
 
@@ -251,24 +325,11 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
             jos.closeEntry();
         }
 
-        // Start a local HTTP server to serve the config JAR.
-        int fileServerPort = Tester.freePort();
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", fileServerPort), 0);
         byte[] jarBytes = Files.readAllBytes(jarFile);
-        httpServer.createContext("/" + jarFile.getFileName(), exchange ->
-        {
-            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
-            exchange.sendResponseHeaders(200, jarBytes.length);
-            try (OutputStream os = exchange.getResponseBody())
-            {
-                os.write(jarBytes);
-            }
-        });
-        httpServer.start();
-
+        Server fileServer = startFileServer("/" + jarFile.getFileName(), jarBytes);
         try
         {
-            String downloadUrl = "http://localhost:" + fileServerPort + "/" + jarFile.getFileName();
+            String downloadUrl = "http://localhost:" + getPort(fileServer) + "/" + jarFile.getFileName();
 
             // Step 1: Download and install the module.
             try (JettyHomeTester.Run run1 = distribution.start(
@@ -292,7 +353,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         }
         finally
         {
-            httpServer.stop(0);
+            fileServer.stop();
         }
     }
 
@@ -314,32 +375,12 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         String expectedAuth = "Basic " + Base64.getEncoder()
             .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
 
-        // Start a local HTTP server that requires Basic Auth.
-        int httpPort = Tester.freePort();
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
         byte[] jarBytes = Files.readAllBytes(configJar);
-        httpServer.createContext("/" + configJar.getFileName(), exchange ->
-        {
-            String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
-            if (!expectedAuth.equals(authHeader))
-            {
-                exchange.getResponseHeaders().set("WWW-Authenticate", "Basic realm=\"test\"");
-                exchange.sendResponseHeaders(401, -1);
-                exchange.close();
-                return;
-            }
-            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
-            exchange.sendResponseHeaders(200, jarBytes.length);
-            try (OutputStream os = exchange.getResponseBody())
-            {
-                os.write(jarBytes);
-            }
-        });
-        httpServer.start();
-
+        Server fileServer = startAuthFileServer(
+            "/" + configJar.getFileName(), jarBytes, expectedAuth, HttpStatus.UNAUTHORIZED_401);
         try
         {
-            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+            String downloadUrl = "http://localhost:" + getPort(fileServer) + "/" + configJar.getFileName();
 
             try (JettyHomeTester.Run run = distribution.start(
                 "--allow-insecure-http-downloads",
@@ -357,7 +398,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         }
         finally
         {
-            httpServer.stop(0);
+            fileServer.stop();
         }
     }
 
@@ -376,31 +417,12 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
 
         String bearerToken = "my-secret-token-12345";
 
-        // Start a local HTTP server that requires a Bearer token.
-        int httpPort = Tester.freePort();
-        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
         byte[] jarBytes = Files.readAllBytes(configJar);
-        httpServer.createContext("/" + configJar.getFileName(), exchange ->
-        {
-            String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
-            if (!("Bearer " + bearerToken).equals(authHeader))
-            {
-                exchange.sendResponseHeaders(403, -1);
-                exchange.close();
-                return;
-            }
-            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
-            exchange.sendResponseHeaders(200, jarBytes.length);
-            try (OutputStream os = exchange.getResponseBody())
-            {
-                os.write(jarBytes);
-            }
-        });
-        httpServer.start();
-
+        Server fileServer = startAuthFileServer(
+            "/" + configJar.getFileName(), jarBytes, "Bearer " + bearerToken, HttpStatus.FORBIDDEN_403);
         try
         {
-            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+            String downloadUrl = "http://localhost:" + getPort(fileServer) + "/" + configJar.getFileName();
 
             try (JettyHomeTester.Run run = distribution.start(
                 "--allow-insecure-http-downloads",
@@ -417,7 +439,7 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
         }
         finally
         {
-            httpServer.stop(0);
+            fileServer.stop();
         }
     }
 }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
@@ -1,0 +1,423 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.tests.distribution;
+
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Base64;
+import java.util.concurrent.TimeUnit;
+import java.util.jar.JarEntry;
+import java.util.jar.JarOutputStream;
+
+import com.sun.net.httpserver.HttpServer;
+import org.eclipse.jetty.tests.testers.JettyHomeTester;
+import org.eclipse.jetty.tests.testers.Tester;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for downloading modules from a URL via {@code --add-modules=<url>}.
+ */
+public class DownloadModuleTests extends AbstractJettyHomeTest
+{
+    /**
+     * Creates a config JAR containing a simple module definition.
+     * The JAR structure mirrors what would be extracted into {@code ${jetty.base}}:
+     * <pre>
+     *   modules/test-download.mod
+     * </pre>
+     */
+    private Path createConfigJar(Path directory, String moduleName) throws Exception
+    {
+        Path jarFile = directory.resolve(moduleName + "-config.jar");
+
+        String modContent = """
+            [description]
+            Test module installed from a remote URL.
+
+            [depend]
+            server
+
+            [ini-template]
+            ## Test property
+            # test.download.property=value
+            """;
+
+        try (OutputStream fos = Files.newOutputStream(jarFile);
+             JarOutputStream jos = new JarOutputStream(fos))
+        {
+            JarEntry modEntry = new JarEntry("modules/" + moduleName + ".mod");
+            jos.putNextEntry(modEntry);
+            jos.write(modContent.getBytes());
+            jos.closeEntry();
+        }
+
+        return jarFile;
+    }
+
+    @Test
+    public void testAddModuleFromUrl() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-download";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+
+        // Start a local HTTP server to serve the config JAR.
+        int httpPort = Tester.freePort();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+        httpServer.createContext("/" + configJar.getFileName(), exchange ->
+        {
+            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
+            exchange.sendResponseHeaders(200, jarBytes.length);
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(jarBytes);
+            }
+        });
+        httpServer.start();
+
+        try
+        {
+            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+
+            // Use --add-modules with a full URL to download and install the module.
+            try (JettyHomeTester.Run run = distribution.start(
+                "--allow-insecure-http-downloads",
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            // Verify the module file was extracted into ${jetty.base}/modules/.
+            Path installedMod = jettyBase.resolve("modules/" + moduleName + ".mod");
+            assertTrue(Files.exists(installedMod),
+                "Module file should have been extracted to " + installedMod);
+
+            // Verify the module was enabled (start.d/test-download.ini or start.ini should reference it).
+            Path startD = jettyBase.resolve("start.d/" + moduleName + ".ini");
+            Path startIni = jettyBase.resolve("start.ini");
+            assertTrue(Files.exists(startD) || Files.exists(startIni),
+                "Module should be enabled in start.d or start.ini");
+
+            if (Files.exists(startD))
+            {
+                String iniContent = Files.readString(startD);
+                assertTrue(iniContent.contains("--modules=" + moduleName),
+                    "start.d INI should contain --modules=" + moduleName);
+            }
+        }
+        finally
+        {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testAddModuleFromUrlWithMultipleModules() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        // Create a config JAR containing two module definitions.
+        Path workDir = Files.createDirectories(jettyBase.resolve("work"));
+        Path jarFile = workDir.resolve("multi-config.jar");
+
+        String modAlpha = """
+            [description]
+            Alpha module from remote config JAR.
+
+            [depend]
+            server
+            """;
+
+        String modBeta = """
+            [description]
+            Beta module from remote config JAR.
+
+            [depend]
+            server
+            """;
+
+        try (OutputStream fos = Files.newOutputStream(jarFile);
+             JarOutputStream jos = new JarOutputStream(fos))
+        {
+            jos.putNextEntry(new JarEntry("modules/test-alpha.mod"));
+            jos.write(modAlpha.getBytes());
+            jos.closeEntry();
+
+            jos.putNextEntry(new JarEntry("modules/test-beta.mod"));
+            jos.write(modBeta.getBytes());
+            jos.closeEntry();
+        }
+
+        // Start a local HTTP server to serve the config JAR.
+        int httpPort = Tester.freePort();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
+        byte[] jarBytes = Files.readAllBytes(jarFile);
+        httpServer.createContext("/multi-config.jar", exchange ->
+        {
+            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
+            exchange.sendResponseHeaders(200, jarBytes.length);
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(jarBytes);
+            }
+        });
+        httpServer.start();
+
+        try
+        {
+            String downloadUrl = "http://localhost:" + httpPort + "/multi-config.jar";
+
+            // Download and install the config JAR containing multiple modules.
+            try (JettyHomeTester.Run run = distribution.start(
+                "--allow-insecure-http-downloads",
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            // Verify both module files were extracted.
+            assertTrue(Files.exists(jettyBase.resolve("modules/test-alpha.mod")),
+                "test-alpha.mod should have been extracted");
+            assertTrue(Files.exists(jettyBase.resolve("modules/test-beta.mod")),
+                "test-beta.mod should have been extracted");
+        }
+        finally
+        {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testAddModuleFromUrlAndStartServer() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-download-http";
+        Path workDir = Files.createDirectories(jettyBase.resolve("work"));
+        Path jarFile = workDir.resolve(moduleName + "-config.jar");
+
+        // Create a module that depends on http (so the server actually starts and listens).
+        String modContent = """
+            [description]
+            Test module that enables HTTP via remote download.
+
+            [depend]
+            http
+            """;
+
+        try (OutputStream fos = Files.newOutputStream(jarFile);
+             JarOutputStream jos = new JarOutputStream(fos))
+        {
+            jos.putNextEntry(new JarEntry("modules/" + moduleName + ".mod"));
+            jos.write(modContent.getBytes());
+            jos.closeEntry();
+        }
+
+        // Start a local HTTP server to serve the config JAR.
+        int fileServerPort = Tester.freePort();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", fileServerPort), 0);
+        byte[] jarBytes = Files.readAllBytes(jarFile);
+        httpServer.createContext("/" + jarFile.getFileName(), exchange ->
+        {
+            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
+            exchange.sendResponseHeaders(200, jarBytes.length);
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(jarBytes);
+            }
+        });
+        httpServer.start();
+
+        try
+        {
+            String downloadUrl = "http://localhost:" + fileServerPort + "/" + jarFile.getFileName();
+
+            // Step 1: Download and install the module.
+            try (JettyHomeTester.Run run1 = distribution.start(
+                "--allow-insecure-http-downloads",
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run1.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run1.logs());
+                assertEquals(0, run1.getExitValue(), run1.logs());
+            }
+
+            // Step 2: Start the server with the downloaded module.
+            int jettyPort = Tester.freePort();
+            try (JettyHomeTester.Run run2 = distribution.start("jetty.http.port=" + jettyPort))
+            {
+                assertTrue(run2.awaitForJettyStart(), run2.logs());
+
+                startHttpClient();
+                org.eclipse.jetty.client.ContentResponse response = client.GET("http://localhost:" + jettyPort);
+                assertThat(response.getStatus(), is(404));
+            }
+        }
+        finally
+        {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testAddModuleFromUrlWithBasicAuth() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-basic-auth";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+
+        String username = "testuser";
+        String password = "testpass";
+        String expectedAuth = "Basic " + Base64.getEncoder()
+            .encodeToString((username + ":" + password).getBytes(StandardCharsets.UTF_8));
+
+        // Start a local HTTP server that requires Basic Auth.
+        int httpPort = Tester.freePort();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+        httpServer.createContext("/" + configJar.getFileName(), exchange ->
+        {
+            String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
+            if (!expectedAuth.equals(authHeader))
+            {
+                exchange.getResponseHeaders().set("WWW-Authenticate", "Basic realm=\"test\"");
+                exchange.sendResponseHeaders(401, -1);
+                exchange.close();
+                return;
+            }
+            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
+            exchange.sendResponseHeaders(200, jarBytes.length);
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(jarBytes);
+            }
+        });
+        httpServer.start();
+
+        try
+        {
+            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+
+            try (JettyHomeTester.Run run = distribution.start(
+                "--allow-insecure-http-downloads",
+                "--download-username=" + username,
+                "--download-password=" + password,
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            Path installedMod = jettyBase.resolve("modules/" + moduleName + ".mod");
+            assertTrue(Files.exists(installedMod),
+                "Module file should have been extracted to " + installedMod);
+        }
+        finally
+        {
+            httpServer.stop(0);
+        }
+    }
+
+    @Test
+    public void testAddModuleFromUrlWithBearerToken() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-bearer-auth";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+
+        String bearerToken = "my-secret-token-12345";
+
+        // Start a local HTTP server that requires a Bearer token.
+        int httpPort = Tester.freePort();
+        HttpServer httpServer = HttpServer.create(new InetSocketAddress("localhost", httpPort), 0);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+        httpServer.createContext("/" + configJar.getFileName(), exchange ->
+        {
+            String authHeader = exchange.getRequestHeaders().getFirst("Authorization");
+            if (!("Bearer " + bearerToken).equals(authHeader))
+            {
+                exchange.sendResponseHeaders(403, -1);
+                exchange.close();
+                return;
+            }
+            exchange.getResponseHeaders().set("Content-Type", "application/java-archive");
+            exchange.sendResponseHeaders(200, jarBytes.length);
+            try (OutputStream os = exchange.getResponseBody())
+            {
+                os.write(jarBytes);
+            }
+        });
+        httpServer.start();
+
+        try
+        {
+            String downloadUrl = "http://localhost:" + httpPort + "/" + configJar.getFileName();
+
+            try (JettyHomeTester.Run run = distribution.start(
+                "--allow-insecure-http-downloads",
+                "--download-auth-header=Bearer " + bearerToken,
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            Path installedMod = jettyBase.resolve("modules/" + moduleName + ".mod");
+            assertTrue(Files.exists(installedMod),
+                "Module file should have been extracted to " + installedMod);
+        }
+        finally
+        {
+            httpServer.stop(0);
+        }
+    }
+}

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/DownloadModuleTests.java
@@ -442,4 +442,127 @@ public class DownloadModuleTests extends AbstractJettyHomeTest
             fileServer.stop();
         }
     }
+
+    @Test
+    public void testAddModuleFromDisallowedUrl() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-blocked";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+
+        Server fileServer = startFileServer("/" + configJar.getFileName(), jarBytes);
+        try
+        {
+            String downloadUrl = "https://localhost:" + getPort(fileServer) + "/" + configJar.getFileName();
+
+            // Without --allow-insecure-http-downloads, the URL must match the allowlist.
+            // localhost is not in the default allowlist, so the download should be rejected.
+            try (JettyHomeTester.Run run = distribution.start(
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertTrue(run.getExitValue() != 0 || run.getLogs().stream().anyMatch(l -> l.contains("not in allowlist")),
+                    "Download from non-allowed URL should fail: " + run.getLogs());
+            }
+        }
+        finally
+        {
+            fileServer.stop();
+        }
+    }
+
+    @Test
+    public void testAddModuleFromExplicitlyAllowedUrl() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-explicit-allow";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+
+        Server fileServer = startFileServer("/" + configJar.getFileName(), jarBytes);
+        try
+        {
+            int port = getPort(fileServer);
+            String downloadUrl = "http://localhost:" + port + "/" + configJar.getFileName();
+            String allowedPrefix = "http://localhost:" + port + "/";
+
+            // Use --download-allowed-urls to explicitly allow this localhost URL.
+            try (JettyHomeTester.Run run = distribution.start(
+                "--download-allowed-urls=" + allowedPrefix,
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            Path installedMod = jettyBase.resolve("modules/" + moduleName + ".mod");
+            assertTrue(Files.exists(installedMod),
+                "Module file should have been extracted to " + installedMod);
+        }
+        finally
+        {
+            fileServer.stop();
+        }
+    }
+
+    @Test
+    public void testAddModuleFromUrlWithAllowlistFile() throws Exception
+    {
+        Path jettyBase = newTestJettyBaseDirectory();
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .jettyBase(jettyBase)
+            .build();
+
+        String moduleName = "test-file-allowlist";
+        Path configJar = createConfigJar(jettyBase.resolve("work"), moduleName);
+        byte[] jarBytes = Files.readAllBytes(configJar);
+
+        Server fileServer = startFileServer("/" + configJar.getFileName(), jarBytes);
+        try
+        {
+            int port = getPort(fileServer);
+            String downloadUrl = "http://localhost:" + port + "/" + configJar.getFileName();
+            String allowedPrefix = "http://localhost:" + port + "/";
+
+            // Create an allowlist file with comments and blank lines.
+            Path allowlistFile = jettyBase.resolve("download-allowlist.txt");
+            Files.writeString(allowlistFile,
+                "# Allowed download sources\n" +
+                "\n" +
+                "# Test server\n" +
+                allowedPrefix + "\n");
+
+            // Use --download-allowed-urls-file to load allowed prefixes from file.
+            try (JettyHomeTester.Run run = distribution.start(
+                "--download-allowed-urls-file=" + allowlistFile.toAbsolutePath(),
+                "--add-modules=" + downloadUrl))
+            {
+                assertTrue(run.awaitForStart(START_TIMEOUT, TimeUnit.SECONDS), run.logs());
+                assertEquals(0, run.getExitValue(), run.logs());
+            }
+
+            Path installedMod = jettyBase.resolve("modules/" + moduleName + ".mod");
+            assertTrue(Files.exists(installedMod),
+                "Module file should have been extracted to " + installedMod);
+        }
+        finally
+        {
+            fileServer.stop();
+        }
+    }
 }


### PR DESCRIPTION
- **new feature to download module from a http url, with possible authentication using basic user/pass or customer Authorization header**
- **Use Jetty server**
