### PR TITLE
Issue #14522 Bundle org.eclipse.jetty.websocket.server OSGI metadata should exports org.eclipse.jetty.websocket.server.*

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
@@ -38,7 +38,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>org.eclipse.jetty.websocket.server;version=${project.version}</Export-Package>
+            <Export-Package>org.eclipse.jetty.websocket.server.*;version=${project.version}</Export-Package>
           </instructions>
         </configuration>
       </plugin>

--- a/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
+++ b/jetty-core/jetty-websocket/jetty-websocket-jetty-server/pom.xml
@@ -38,7 +38,7 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
-            <Export-Package>org.eclipse.jetty.websocket.server.internal;version=${project.version}</Export-Package>
+            <Export-Package>org.eclipse.jetty.websocket.server;version=${project.version}</Export-Package>
           </instructions>
         </configuration>
       </plugin>


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>
