### PR TITLE
Disabled jetty-ee11 tests that fail on Windows, on Windows.

### DIFF
--- a/jetty-ee11/jetty-ee11-maven-plugin/src/test/java/org/eclipse/jetty/ee11/maven/plugin/TestForkedChild.java
+++ b/jetty-ee11/jetty-ee11-maven-plugin/src/test/java/org/eclipse/jetty/ee11/maven/plugin/TestForkedChild.java
@@ -39,6 +39,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -49,6 +51,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  * is the main that is executed by jetty:run/start in mode FORKED.
  */
 @ExtendWith(WorkDirExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class TestForkedChild
 {
     File testDir;

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/CrossContextDispatcherTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/CrossContextDispatcherTest.java
@@ -70,6 +70,8 @@ import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -85,6 +87,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class CrossContextDispatcherTest
 {
     public static final String MULTIPART = "--AaB03x\r\n" +

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/DefaultServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/DefaultServletTest.java
@@ -322,6 +322,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetPercent2F() throws Exception
     {
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
@@ -502,6 +503,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingAllowed() throws Exception
     {
         ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
@@ -542,6 +544,7 @@ public class DefaultServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows, because newlines")
     public void testIncludeListingForbidden() throws Exception
     {
         ServletHolder defHolder = context.addServlet(DefaultServlet.class, "/");
@@ -1000,6 +1003,7 @@ public class DefaultServletTest
 
     @ParameterizedTest
     @MethodSource("contextBreakoutScenarios")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testListingContextBreakout(Scenario scenario) throws Exception
     {
         ServletHolder defholder = context.addServlet(DefaultServlet.class, "/");

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/DispatcherTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/DispatcherTest.java
@@ -55,8 +55,11 @@ import org.eclipse.jetty.util.MultiMap;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -72,6 +75,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class DispatcherTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(DispatcherTest.class);
@@ -603,7 +607,7 @@ public class DispatcherTest
             HTTP/1.1 200 OK\r
             Connection: close\r
             \r
-            Include:
+            Include:\r
             Test 2 to too two
             ---
             """;

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/MultiPartServletTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.ee11.servlet;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -66,6 +67,8 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -85,6 +88,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class MultiPartServletTest
 {
     private static final int MAX_FILE_SIZE = 512 * 1024;
@@ -349,6 +353,7 @@ public class MultiPartServletTest
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testTempFilesDeletedOnError(boolean eager) throws Exception
     {
         byte[] bytes = new byte[2 * MAX_FILE_SIZE];
@@ -542,7 +547,7 @@ public class MultiPartServletTest
 
         assertEquals(200, response.getStatus());
         assertThat(response.getContentAsString(), containsString("Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog\n" +
-            "Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog"));
+            "Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog".replace("\n", System.lineSeparator())));
     }
 
     @ParameterizedTest

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestHeadersTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/RequestHeadersTest.java
@@ -165,7 +165,7 @@ public class RequestHeadersTest
             try (InputStream in = http.getInputStream())
             {
                 String resp = IO.toString(in, StandardCharsets.UTF_8);
-                assertThat("Response", resp, is("Locale = " + expectedLocale + "\n"));
+                assertThat("Response", resp, is("Locale = " + expectedLocale + System.lineSeparator()));
             }
         }
         finally

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResourceServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResourceServletTest.java
@@ -98,6 +98,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -402,6 +403,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetPercent2F() throws Exception
     {
         connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setUriCompliance(UriCompliance.UNSAFE);
@@ -582,6 +584,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingAllowed() throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");
@@ -622,6 +625,7 @@ public class ResourceServletTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testIncludeListingForbidden() throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");
@@ -1080,6 +1084,7 @@ public class ResourceServletTest
 
     @ParameterizedTest
     @MethodSource("contextBreakoutScenarios")
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testListingContextBreakout(Scenario scenario) throws Exception
     {
         ServletHolder holder = context.addServlet(ResourceServlet.class, "/");

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResponseHeadersTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResponseHeadersTest.java
@@ -37,6 +37,8 @@ import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -589,6 +591,7 @@ public class ResponseHeadersTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testFlushPrintWriter() throws Exception
     {
         ServletContextHandler contextHandler = new ServletContextHandler();

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletLifeCycleTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletLifeCycleTest.java
@@ -36,10 +36,13 @@ import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.Decorator;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class ServletLifeCycleTest
 {
     static final Queue<String> events = new ConcurrentLinkedQueue<>();

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletWrapperTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletWrapperTest.java
@@ -109,7 +109,7 @@ public class ServletWrapperTest
         String rawResponse = localConnector.getResponse(req.toString());
         HttpTester.Response resp = HttpTester.parseResponse(rawResponse);
         assertThat("Response.status", resp.getStatus(), is(200));
-        assertThat(resp.getContent(), is("Serviced!\n"));
+        assertThat(resp.getContent(), is("Serviced!" + System.lineSeparator()));
     }
 
     public static class HelloServlet extends HttpServlet

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/AllowedResourceAliasCheckerTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/AllowedResourceAliasCheckerTest.java
@@ -36,12 +36,15 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class AllowedResourceAliasCheckerTest
 {
     private static Server _server;

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/ClassLoaderProtectResourcesTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/ClassLoaderProtectResourcesTest.java
@@ -39,6 +39,8 @@ import org.example.webapp.ServletContainerInitializerDiscoveryServlet;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -46,6 +48,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
 
 @ExtendWith(WorkDirExtension.class)
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class ClassLoaderProtectResourcesTest
 {
     public WorkDir workDir;

--- a/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/test/java/org/eclipse/jetty/ee11/webapp/WebAppContextTest.java
@@ -86,6 +86,8 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -249,6 +251,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testProtectedTargetErrorPage() throws Exception
     {
         WebAppContext contextHandler = new WebAppContext();
@@ -909,6 +912,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testGetResourcePaths() throws Exception
     {
         Server server = newServer();
@@ -1108,6 +1112,7 @@ public class WebAppContextTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testRestartWebApp(WorkDir workDir) throws Exception
     {
         Server server = newServer();


### PR DESCRIPTION
This PR disables ee11 tests on Windows, which fail on Windows. Where appropriate also uses OS-agnostic separators instead of hardcoded ones.