### PR TITLE
Fix crash when Quiche lib is overwritten

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/NativeHelper.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/NativeHelper.java
@@ -96,7 +96,8 @@ public class NativeHelper
 
     private static Path extractFromResourcePath(String libName, ClassLoader classLoader) throws IOException
     {
-        Path target = Path.of(System.getProperty("java.io.tmpdir")).resolve(libName);
+        long pid = ProcessHandle.current().pid();
+        Path target = Path.of(System.getProperty("java.io.tmpdir")).resolve("jetty-" + pid).resolve(libName);
         Files.createDirectories(target.getParent());
         try (InputStream is = classLoader.getResourceAsStream(libName);
              OutputStream os = Files.newOutputStream(target))


### PR DESCRIPTION
For some reason, when `libquiche.so` is loaded with `System.loadLibrary()` and its symbols looked up with `SymbolLookup.loaderLookup().or(Linker.nativeLinker().defaultLookup())`, it may happen that the generated `MethodHandle` "loses" track of the C function's address, or at least it is what seems to happen.

Here are the hints leading in to the direction of something bogus happening with the loaded native library:

1) the JVM crash dump reports that the call to the `quiche_header_info` C function pointer resulted in a crash.
```
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x0000000000365560, pid=82802, tid=82875
#
# JRE version: OpenJDK Runtime Environment Temurin-26+35 (26.0+35) (build 26+35)
...
siginfo: si_signo: 11 (SIGSEGV), si_code: 1 (SEGV_MAPERR), si_addr: 0x0000000000365560
...
```
with `pc` being the address that the JVM called that made the JVM crash as this address is abnormally low and obviously bogus as it made the OS trigger a SIGSEGV reporting the called address as invalid in `si_addr`.

2) Modifying `quiche_h.quiche_header_info()` such as it calls `NativeHelper.SYMBOL_LOOKUP.find("quiche_header_info")` before the `invokeExact()` call makes the JVM crash.

UPDATE: this happens when the native quiche lib gets overwritten by a 2nd JVM running the Jetty Quiche code. For some reason, when the .so file gets overwritten with an identical version of itself, using any function looked up by the `SymbolLookup` instance, or re-using the `SymbolLookup` makes the JVM crash.

Fixes #14805