### PR TITLE
Issue #14853 - resolve CombinedResource base resource during ContextHandler.doStart

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -904,6 +904,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                                 return resourceFactory.newResource(realUri);
                             return r;
                         }).toList();
+                    // The _baseResource attribute stores the old value to be restored in doStop.
                     setAttribute("_baseResource", _baseResource);
                     _baseResource = ResourceFactory.combine(resources);
                 }
@@ -912,6 +913,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                     URI realUri = baseResource.getRealURI();
                     if (realUri != null)
                     {
+                        // The _baseResource attribute stores the old value to be restored in doStop.
                         setAttribute("_baseResource", _baseResource);
                         _baseResource = ResourceFactory.of(this).newResource(realUri);
                     }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -145,6 +145,7 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
     private boolean _defaultContextPath = true;
     private boolean _rootContext = true;
     private Resource _baseResource;
+    private Resource _originalBaseResource;
     private ClassLoader _classLoader;
     private Request.Handler _errorHandler;
     private boolean _allowNullPathInContext;
@@ -904,8 +905,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                                 return resourceFactory.newResource(realUri);
                             return r;
                         }).toList();
-                    // The _baseResource attribute stores the old value to be restored in doStop.
-                    setAttribute("_baseResource", _baseResource);
+                    // Remember the original base resource so it can be restored in doStop().
+                    _originalBaseResource = _baseResource;
                     _baseResource = ResourceFactory.combine(resources);
                 }
                 else
@@ -913,8 +914,8 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                     URI realUri = baseResource.getRealURI();
                     if (realUri != null)
                     {
-                        // The _baseResource attribute stores the old value to be restored in doStop.
-                        setAttribute("_baseResource", _baseResource);
+                        // Remember the original base resource so it can be restored in doStop().
+                        _originalBaseResource = _baseResource;
                         _baseResource = ResourceFactory.of(this).newResource(realUri);
                     }
                 }
@@ -981,8 +982,11 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
         _context.call(super::doStop, null);
         cleanupAfterStop();
         _tempDirectoryCreated = false;
-        if (removeAttribute("_baseResource") instanceof Resource baseResource)
-            _baseResource = baseResource;
+        if (_originalBaseResource != null)
+        {
+            _baseResource = _originalBaseResource;
+            _originalBaseResource = null;
+        }
     }
 
     protected void cleanupAfterStop() throws Exception

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ContextHandler.java
@@ -63,6 +63,7 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
 import org.eclipse.jetty.util.component.DumpableAttributes;
 import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.resource.CombinedResource;
 import org.eclipse.jetty.util.resource.MountedPathResource;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -892,17 +893,34 @@ public class ContextHandler extends Handler.Wrapper implements Attributes, Alias
                 throw new IllegalArgumentException("Base Resource is not valid: " + baseResource);
             if (baseResource.isAlias())
             {
-                URI realUri = baseResource.getRealURI();
-                if (realUri == null)
+                if (baseResource instanceof CombinedResource combinedResource)
                 {
-                    LOG.warn("{} Base Resource should not be an alias (100% of requests to context are subject to Security/Alias Checks): {}", getDisplayName(), baseResource);
+                    ResourceFactory resourceFactory = ResourceFactory.of(this);
+                    List<Resource> resources = combinedResource.getResources().stream()
+                        .map(r ->
+                        {
+                            URI realUri = r.getRealURI();
+                            if (realUri != null)
+                                return resourceFactory.newResource(realUri);
+                            return r;
+                        }).toList();
+                    setAttribute("_baseResource", _baseResource);
+                    _baseResource = ResourceFactory.combine(resources);
                 }
                 else
                 {
-                    LOG.info("{} Base Resource is an alias: {} -> {}", getDisplayName(), baseResource, realUri.toASCIIString());
-                    setAttribute("_baseResource", _baseResource);
-                    _baseResource = ResourceFactory.of(this).newResource(realUri);
+                    URI realUri = baseResource.getRealURI();
+                    if (realUri != null)
+                    {
+                        setAttribute("_baseResource", _baseResource);
+                        _baseResource = ResourceFactory.of(this).newResource(realUri);
+                    }
                 }
+
+                if (_baseResource.isAlias())
+                    LOG.warn("{} Base Resource should not be an alias (100% of requests to context are subject to Security/Alias Checks): {}", getDisplayName(), baseResource);
+                else
+                    LOG.info("{} Base Resource is an alias: {} -> {}", getDisplayName(), baseResource, _baseResource);
             }
         }
 

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -120,7 +120,7 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
             combinedPath.resolve("externalCombinedSymlinkFile"),
             webRootPath.resolve("../sibling"));
 
-        // Symlink to the webroot directories for a combined base resource which are aliases.
+        // Symlink to the webroot directories for a combined base resource which is an alias.
         Path webrootSymlink = combinedPath.resolve(getResource("webrootSymlink"));
         Path combinedSymlink = combinedPath.resolve(getResource("combinedSymlink"));
         createSymbolicLink(
@@ -158,7 +158,7 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
         _context2.setHandler(new ResourceHandler());
         _context2.clearAliasChecks();
 
-        // Base Resource as CombinedResource tests.
+        // Aliased CombinedResource for Base Resource tests.
         resource = ResourceFactory.combine(
             resourceFactory.newResource(webrootSymlink),
             resourceFactory.newResource(combinedSymlink));

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -53,6 +53,7 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
     private static HotSwapHandler _hotSwapHandler;
     private static ContextHandler _context1;
     private static ContextHandler _context2;
+    private static ContextHandler _context3;
 
     private static final List<Path> _createdFiles = new ArrayList<>();
 
@@ -119,6 +120,15 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
             combinedPath.resolve("externalCombinedSymlinkFile"),
             webRootPath.resolve("../sibling"));
 
+        // Symlink to the webroot directories for a combined base resource which are aliases.
+        Path webrootSymlink = combinedPath.resolve(getResource("webrootSymlink"));
+        Path combinedSymlink = combinedPath.resolve(getResource("combinedSymlink"));
+        createSymbolicLink(
+            webrootSymlink,
+            webRootPath);
+        createSymbolicLink(
+            combinedSymlink,
+            combinedPath);
 
         // Create and start Server and Client.
         _server = new Server();
@@ -140,13 +150,24 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
         ResourceFactory resourceFactory = ResourceFactory.of(_server);
         Resource resource = ResourceFactory.combine(
             resourceFactory.newResource(webRootPath),
-            resourceFactory.newResource(getResource("combined")));
+            resourceFactory.newResource(combinedPath));
         _context2 = new ContextHandler();
         _context2.setContextPath("/");
         _context2.setBaseResource(resource);
         _context2.setProtectedTargets(new String[]{"/WEB-INF", "/META-INF"});
         _context2.setHandler(new ResourceHandler());
         _context2.clearAliasChecks();
+
+        // Base Resource as CombinedResource tests.
+        resource = ResourceFactory.combine(
+            resourceFactory.newResource(webrootSymlink),
+            resourceFactory.newResource(combinedSymlink));
+        _context3 = new ContextHandler();
+        _context3.setContextPath("/");
+        _context3.setBaseResource(resource);
+        _context3.setProtectedTargets(new String[]{"/WEB-INF", "/META-INF"});
+        _context3.setHandler(new ResourceHandler());
+        _context3.clearAliasChecks();
 
         _server.start();
         _client = new HttpClient();
@@ -254,6 +275,32 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
             Arguments.of(allowedResource, "/externalCombinedSymlinkFile/file", HttpStatus.NOT_FOUND_404, null),
             Arguments.of(allowedResource, "/combinedWebInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null),
 
+            Arguments.of(symlinkAllowedResource, "/file", HttpStatus.OK_200, "This file is inside webroot."),
+            Arguments.of(symlinkAllowedResource, "/combinedSymlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+            Arguments.of(symlinkAllowedResource, "/externalCombinedSymlinkFile/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
+            Arguments.of(symlinkAllowedResource, "/combinedWebInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file.")
+        );
+        return Stream.concat(testCases(_context2), combinedResourceTests);
+    }
+
+    public static Stream<Arguments> combinedBaseResourceTestCases()
+    {
+        AllowedResourceAliasChecker allowedResource = new AllowedResourceAliasChecker(_context3);
+        SymlinkAllowedResourceAliasChecker symlinkAllowedResource = new SymlinkAllowedResourceAliasChecker(_context3);
+
+        Stream<Arguments> combinedResourceTests = Stream.of(
+            Arguments.of(allowedResource, "/file", HttpStatus.OK_200, "This file is inside webroot."),
+            Arguments.of(allowedResource, "/combinedFile", HttpStatus.OK_200, "This is a file in the combined resource dir."),
+            Arguments.of(allowedResource, "/WEB-INF/file", HttpStatus.NOT_FOUND_404, null),
+            Arguments.of(allowedResource, "/files", HttpStatus.OK_200, "Directory: /files/|/files/file1|/files/file2"),
+            Arguments.of(allowedResource, "/files/file1", HttpStatus.OK_200, "file1 from combined dir"),
+            Arguments.of(allowedResource, "/files/file2", HttpStatus.OK_200, "file1 from webroot"),
+
+            Arguments.of(allowedResource, "/combinedSymlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
+            Arguments.of(allowedResource, "/externalCombinedSymlinkFile/file", HttpStatus.NOT_FOUND_404, null),
+            Arguments.of(allowedResource, "/combinedWebInfSymlink/web.xml", HttpStatus.NOT_FOUND_404, null),
+
+            Arguments.of(symlinkAllowedResource, "/file", HttpStatus.OK_200, "This file is inside webroot."),
             Arguments.of(symlinkAllowedResource, "/combinedSymlinkFile", HttpStatus.OK_200, "This file is inside webroot."),
             Arguments.of(symlinkAllowedResource, "/externalCombinedSymlinkFile/file", HttpStatus.OK_200, "This file is inside a sibling dir to webroot."),
             Arguments.of(symlinkAllowedResource, "/combinedWebInfSymlink/web.xml", HttpStatus.OK_200, "This is the web.xml file.")
@@ -278,6 +325,31 @@ public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
     public void testCombinedResource(AliasCheck aliasChecker, String path, int httpStatus, String responseContent) throws Exception
     {
         init(_context2, aliasChecker);
+        URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + path);
+        ContentResponse response = _client.GET(uri);
+        assertThat(response.getStatus(), is(httpStatus));
+
+        if (responseContent != null)
+        {
+            if (responseContent.contains("|"))
+            {
+                for (String s : responseContent.split("\\|"))
+                {
+                    assertThat("Could not find " + s, response.getContentAsString(), containsString(s));
+                }
+            }
+            else
+            {
+                assertThat(response.getContentAsString(), equalTo(responseContent));
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("combinedBaseResourceTestCases")
+    public void testCombinedBaseResource(AliasCheck aliasChecker, String path, int httpStatus, String responseContent) throws Exception
+    {
+        init(_context3, aliasChecker);
         URI uri = URI.create("http://localhost:" + _connector.getLocalPort() + path);
         ContentResponse response = _client.GET(uri);
         assertThat(response.getStatus(), is(httpStatus));


### PR DESCRIPTION
## Closes #14853

Handle `CombinedResource` when trying to resolve the base resource if it is an alias during `ContextHandler.doStart`.