### PR TITLE
Update jetty-start testing

### DIFF
--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.start;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -24,9 +23,9 @@ import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
-
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
@@ -97,7 +96,7 @@ public class BaseHomeTest
         String ref = hb.toShortForm(startIni);
         assertThat("Reference", ref, startsWith("${jetty.home}"));
 
-        String contents = Files.readString(startIni, StandardCharsets.UTF_8);
+        String contents = Files.readString(startIni, UTF_8);
         assertThat("Contents", contents, containsString("Home Ini"));
     }
 
@@ -194,7 +193,7 @@ public class BaseHomeTest
         String ref = hb.toShortForm(startIni);
         assertThat("Reference", ref, startsWith("${jetty.base}"));
 
-        String contents = Files.readString(startIni, StandardCharsets.UTF_8);
+        String contents = Files.readString(startIni, UTF_8);
         assertThat("Contents", contents, containsString("Base Ini"));
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/BaseHomeTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -24,7 +23,8 @@ import java.util.List;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
+
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -86,10 +86,10 @@ public class BaseHomeTest
     @Test
     public void testGetPathOnlyHome() throws IOException
     {
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
 
         ConfigSources config = new ConfigSources();
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
 
         BaseHome hb = new BaseHome(config);
         Path startIni = hb.getPath("start.ini");
@@ -104,10 +104,10 @@ public class BaseHomeTest
     @Test
     public void testGetPathsOnlyHome() throws IOException
     {
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
 
         ConfigSources config = new ConfigSources();
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
 
         BaseHome hb = new BaseHome(config);
         List<Path> paths = hb.getPaths("start.d/*");
@@ -118,7 +118,7 @@ public class BaseHomeTest
         expected.add("${jetty.home}/start.d/jsp.ini");
         expected.add("${jetty.home}/start.d/logging.ini");
         expected.add("${jetty.home}/start.d/ssl.ini");
-        FSTest.toFsSeparators(expected);
+        expected.replaceAll(FS::separators);
 
         assertPathList(hb, "Paths found", expected, paths);
     }
@@ -126,10 +126,10 @@ public class BaseHomeTest
     @Test
     public void testGetPathsOnlyHomeInisOnly() throws IOException
     {
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
 
         ConfigSources config = new ConfigSources();
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
 
         BaseHome hb = new BaseHome(config);
         List<Path> paths = hb.getPaths("start.d/*.ini");
@@ -140,7 +140,7 @@ public class BaseHomeTest
         expected.add("${jetty.home}/start.d/jsp.ini");
         expected.add("${jetty.home}/start.d/logging.ini");
         expected.add("${jetty.home}/start.d/ssl.ini");
-        FSTest.toFsSeparators(expected);
+        expected.replaceAll(FS::separators);
 
         assertPathList(hb, "Paths found", expected, paths);
     }
@@ -148,12 +148,12 @@ public class BaseHomeTest
     @Test
     public void testGetPathsBoth() throws IOException
     {
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
-        File baseDir = MavenTestingUtils.getTestResourceDir("hb.1/base");
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
+        Path baseDir = MavenPaths.findTestResourceDir("hb.1/base");
 
         ConfigSources config = new ConfigSources();
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
+        config.add(new JettyBaseConfigSource(baseDir));
+        config.add(new JettyHomeConfigSource(homeDir));
 
         BaseHome hb = new BaseHome(config);
         List<Path> paths = hb.getPaths("start.d/*.ini");
@@ -165,7 +165,7 @@ public class BaseHomeTest
         expected.add("${jetty.base}/start.d/logging.ini");
         expected.add("${jetty.home}/start.d/ssl.ini");
         expected.add("${jetty.base}/start.d/myapp.ini");
-        FSTest.toFsSeparators(expected);
+        expected.replaceAll(FS::separators);
 
         assertPathList(hb, "Paths found", expected, paths);
     }
@@ -181,12 +181,12 @@ public class BaseHomeTest
     @Test
     public void testGetPathBoth() throws IOException
     {
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
-        File baseDir = MavenTestingUtils.getTestResourceDir("hb.1/base");
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
+        Path baseDir = MavenPaths.findTestResourceDir("hb.1/base");
 
         ConfigSources config = new ConfigSources();
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
+        config.add(new JettyBaseConfigSource(baseDir));
+        config.add(new JettyHomeConfigSource(homeDir));
 
         BaseHome hb = new BaseHome(config);
         Path startIni = hb.getPath("start.ini");

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/FSTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/FSTest.java
@@ -13,14 +13,11 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.MavenPaths;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
@@ -36,22 +33,22 @@ public class FSTest
     @Test
     public void testCanReadDirectory()
     {
-        File targetDir = MavenTestingUtils.getTargetDir();
-        assertTrue(FS.canReadDirectory(targetDir.toPath()), "Can read dir: " + targetDir);
+        Path targetDir = MavenPaths.targetDir();
+        assertTrue(FS.canReadDirectory(targetDir), "Can read dir: " + targetDir);
     }
 
     @Test
     public void testCanReadDirectoryNotDir()
     {
-        File bogusFile = MavenTestingUtils.getTestResourceFile("bogus.xml");
-        assertFalse(FS.canReadDirectory(bogusFile.toPath()), "Can read dir: " + bogusFile);
+        Path bogusFile = MavenPaths.findTestResourceFile("bogus.xml");
+        assertFalse(FS.canReadDirectory(bogusFile), "Can read dir: " + bogusFile);
     }
 
     @Test
     public void testCanReadFile()
     {
-        File pom = MavenTestingUtils.getProjectFile("pom.xml");
-        assertTrue(FS.canReadFile(pom.toPath()), "Can read file: " + pom);
+        Path pom = MavenPaths.projectFile("pom.xml");
+        assertTrue(FS.canReadFile(pom), "Can read file: " + pom);
     }
 
     @Test
@@ -63,19 +60,5 @@ public class FSTest
         Files.deleteIfExists(bad);
         assertThrows(IOException.class, () -> FS.extractZip(archive, dest));
         assertFalse(Files.exists(bad), "The escaper prevention didn't work, you should not have a /tmp/evil.txt file, but you do.");
-    }
-
-    /**
-     * Utility method used by other test cases
-     *
-     * @param expected the expected String paths to be converted (in place)
-     */
-    public static void toFsSeparators(List<String> expected)
-    {
-        for (int i = 0; i < expected.size(); i++)
-        {
-            String fixed = FS.separators(expected.get(i));
-            expected.set(i, fixed);
-        }
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/JarVersionTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/JarVersionTest.java
@@ -15,7 +15,7 @@ package org.eclipse.jetty.start;
 
 import java.nio.file.Path;
 
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,7 +25,7 @@ public class JarVersionTest
 {
     private void assertJarVersion(String jarname, String expectedVersion)
     {
-        Path jarfile = MavenTestingUtils.getTestResourcePathFile(jarname);
+        Path jarfile = MavenPaths.findTestResourceFile(jarname);
         assertThat("Jar: " + jarname, JarVersion.getVersion(jarfile), containsString(expectedVersion));
     }
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/MainTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.start;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -26,6 +25,7 @@ import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
@@ -75,11 +75,11 @@ public class MainTest
         Main main = new Main();
         StartArgs args = main.processCommandLine(cmdLineArgs.toArray(new String[0]));
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             PrintStream out = new PrintStream(baos, true, StandardCharsets.UTF_8))
+             PrintStream out = new PrintStream(baos, true, UTF_8))
         {
             main.listConfig(out, args);
             out.flush();
-            output = List.of(baos.toString(StandardCharsets.UTF_8).split(System.lineSeparator()));
+            output = List.of(baos.toString(UTF_8).split(System.lineSeparator()));
         }
 
         // Test a System Property that comes from JVM
@@ -113,7 +113,7 @@ public class MainTest
         List<String> output;
 
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
-             PrintStream out = new PrintStream(baos, true, StandardCharsets.UTF_8))
+             PrintStream out = new PrintStream(baos, true, UTF_8))
         {
             PrintStream originalStream = StartLog.setStream(new PrintStream(out));
             try
@@ -122,7 +122,7 @@ public class MainTest
                 StartArgs args = main.processCommandLine(cmdLineArgs.toArray(new String[0]));
                 main.start(args);
                 out.flush();
-                output = List.of(baos.toString(StandardCharsets.UTF_8).split(System.lineSeparator()));
+                output = List.of(baos.toString(UTF_8).split(System.lineSeparator()));
             }
             finally
             {

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
@@ -24,7 +24,8 @@ import org.eclipse.jetty.start.config.CommandLineConfigSource;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
@@ -44,7 +45,7 @@ public class ModuleGraphWriterTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path homeDir = MavenPaths.findTestResourceDir("dist-home");
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleGraphWriterTest.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.start;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 
@@ -24,13 +23,13 @@ import org.eclipse.jetty.start.config.CommandLineConfigSource;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTimeout;
@@ -89,8 +88,8 @@ public class ModuleGraphWriterTest
         {
             Process p = Runtime.getRuntime().exec(args);
 
-            try (BufferedReader bri = new BufferedReader(new InputStreamReader(p.getInputStream(), StandardCharsets.UTF_8));
-                 BufferedReader bre = new BufferedReader(new InputStreamReader(p.getErrorStream(), StandardCharsets.UTF_8)))
+            try (BufferedReader bri = new BufferedReader(new InputStreamReader(p.getInputStream(), UTF_8));
+                 BufferedReader bre = new BufferedReader(new InputStreamReader(p.getErrorStream(), UTF_8)))
             {
                 String line;
                 while ((line = bri.readLine()) != null)

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 
@@ -21,7 +20,8 @@ import org.eclipse.jetty.start.config.CommandLineConfigSource;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
@@ -41,7 +41,7 @@ public class ModuleTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path homeDir = MavenPaths.findTestResourceDir("dist-home");
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -54,8 +54,8 @@ public class ModuleTest
         // Initialize
         BaseHome basehome = new BaseHome(config);
 
-        File file = MavenTestingUtils.getTestResourceFile("dist-home/modules/main.mod");
-        Module module = new Module(basehome, file.toPath());
+        Path file = MavenPaths.findTestResourceFile("dist-home/modules/main.mod");
+        Module module = new Module(basehome, file);
 
         assertThat("Module Name", module.getName(), is("main"));
         assertThat("Module Depends Size", module.getDepends().size(), is(1));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModuleTest.java
@@ -20,7 +20,6 @@ import org.eclipse.jetty.start.config.CommandLineConfigSource;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
@@ -187,7 +187,10 @@ public class ModulesTest
         expectedLibs.add("lib/optional.jar");
         expectedLibs.add("lib/base.jar");
 
-        List<String> actualLibs = normalizeLibs(active);
+        List<String> actualLibs = active.stream()
+            .flatMap(m -> m.getLibs().stream())
+            .distinct()
+            .toList();
         assertThat("Resolved Libs: " + actualLibs, actualLibs, contains(expectedLibs.toArray()));
 
         // Assert XML List
@@ -195,7 +198,10 @@ public class ModulesTest
         expectedXmls.add("etc/optional.xml");
         expectedXmls.add("etc/base.xml");
 
-        List<String> actualXmls = normalizeXmls(active);
+        List<String> actualXmls = active.stream()
+            .flatMap(m -> m.getXmls().stream())
+            .distinct()
+            .toList();
         assertThat("Resolved XMLs: " + actualXmls, actualXmls, contains(expectedXmls.toArray()));
     }
 
@@ -348,37 +354,5 @@ public class ModulesTest
 
         Props props = args.getJettyEnvironment().getProperties();
         assertThat(props.getString("bar.name"), is("dynamic"));
-    }
-
-    private List<String> normalizeLibs(List<Module> active)
-    {
-        List<String> libs = new ArrayList<>();
-        for (Module module : active)
-        {
-            for (String lib : module.getLibs())
-            {
-                if (!libs.contains(lib))
-                {
-                    libs.add(lib);
-                }
-            }
-        }
-        return libs;
-    }
-
-    private List<String> normalizeXmls(List<Module> active)
-    {
-        List<String> xmls = new ArrayList<>();
-        for (Module module : active)
-        {
-            for (String xml : module.getXmls())
-            {
-                if (!xmls.contains(xml))
-                {
-                    xmls.add(xml);
-                }
-            }
-        }
-        return xmls;
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/ModulesTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -23,7 +22,7 @@ import org.eclipse.jetty.start.config.CommandLineConfigSource;
 import org.eclipse.jetty.start.config.ConfigSources;
 import org.eclipse.jetty.start.config.JettyBaseConfigSource;
 import org.eclipse.jetty.start.config.JettyHomeConfigSource;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
@@ -46,7 +45,7 @@ public class ModulesTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path homeDir = MavenPaths.findTestResourceDir("dist-home");
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -102,18 +101,18 @@ public class ModulesTest
     public void testLoadShallowModulesOnly() throws IOException
     {
         // Test Env
-        File homeDir = MavenTestingUtils.getTestResourceDir("jetty home with spaces");
+        Path homeDir = MavenPaths.findTestResourceDir("jetty home with spaces");
         // intentionally setup top level resources dir (as this would have many
         // deep references)
-        File baseDir = MavenTestingUtils.getTestResourcesDir();
+        Path baseDir = MavenPaths.projectBase().resolve("src/test/resources");
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
         CommandLineConfigSource cmdLineSource = new CommandLineConfigSource(cmdLine);
         ConfigSources config = new ConfigSources();
         config.add(cmdLineSource);
-        config.add(new JettyHomeConfigSource(homeDir.toPath()));
-        config.add(new JettyBaseConfigSource(baseDir.toPath()));
+        config.add(new JettyHomeConfigSource(homeDir));
+        config.add(new JettyBaseConfigSource(baseDir));
 
         // Initialize
         BaseHome basehome = new BaseHome(config);
@@ -142,7 +141,7 @@ public class ModulesTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("dist-home");
+        Path homeDir = MavenPaths.findTestResourceDir("dist-home");
         String[] cmdLine = new String[]{"jetty.version=TEST"};
 
         // Configuration
@@ -205,7 +204,7 @@ public class ModulesTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path homeDir = MavenPaths.findTestResourceDir("non-required-deps");
         String[] cmdLine = new String[]{"bar.type=cannot-find-me"};
 
         // Configuration
@@ -254,7 +253,7 @@ public class ModulesTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path homeDir = MavenPaths.findTestResourceDir("non-required-deps");
         String[] cmdLine = new String[]{"bar.type=dive"};
 
         // Configuration
@@ -305,7 +304,7 @@ public class ModulesTest
     {
         Path baseDir = workDir.getEmptyPathDir();
         // Test Env
-        Path homeDir = MavenTestingUtils.getTestResourcePathDir("non-required-deps");
+        Path homeDir = MavenPaths.findTestResourceDir("non-required-deps");
         String[] cmdLine = new String[]{"bar.type=dynamic"};
 
         // Configuration

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PathFinderTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PathFinderTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
@@ -21,8 +20,9 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.stream.Stream;
 
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
@@ -35,8 +35,8 @@ public class PathFinderTest
     public void testFindInis(WorkDir workDir) throws IOException
     {
         Path basePath = workDir.getPath();
-        File homeDir = MavenTestingUtils.getTestResourceDir("hb.1/home");
-        Path homePath = homeDir.toPath().toAbsolutePath();
+        Path homeDir = MavenPaths.findTestResourceDir("hb.1/home");
+        Path homePath = homeDir.toAbsolutePath();
 
         PathFinder finder = new PathFinder();
         finder.setFileMatcher("glob:**/*.ini");
@@ -51,7 +51,7 @@ public class PathFinderTest
         expected.add("${jetty.home}/start.d/logging.ini");
         expected.add("${jetty.home}/start.d/ssl.ini");
         expected.add("${jetty.home}/start.ini");
-        FSTest.toFsSeparators(expected);
+        expected.replaceAll(FS::separators);
 
         BaseHome hb = new BaseHome(new String[]{"jetty.home=" + homePath.toString(), "jetty.base=" + basePath.toString()});
         BaseHomeTest.assertPathList(hb, "Files found", expected, finder);
@@ -61,29 +61,27 @@ public class PathFinderTest
     public void testFindMods(WorkDir workDir) throws IOException
     {
         Path basePath = workDir.getEmptyPathDir();
-        File homeDir = MavenTestingUtils.getTestResourceDir("dist-home");
-        Path homePath = homeDir.toPath().toAbsolutePath();
+        Path homeDir = MavenPaths.findTestResourceDir("dist-home");
+        Path homePath = homeDir.toAbsolutePath();
 
         List<String> expected = new ArrayList<>();
-        File modulesDir = new File(homeDir, "modules");
-        for (File file : modulesDir.listFiles())
+        Path modulesDir = homeDir.resolve("modules");
+        try (Stream<Path> listStream = Files.list(modulesDir))
         {
-            if (file.getName().endsWith(".mod"))
-            {
-                expected.add("${jetty.home}/modules/" + file.getName());
-            }
+            listStream
+                .filter(Files::isRegularFile)
+                .filter(p -> p.getFileName().toString().endsWith(".mod"))
+                .map(p -> FS.separators("${jetty.home}/modules/" + p.getFileName()))
+                .forEach(expected::add);
         }
-        FSTest.toFsSeparators(expected);
-
-        Path modulesPath = modulesDir.toPath();
 
         PathFinder finder = new PathFinder();
         finder.setFileMatcher(PathMatchers.getMatcher("modules/*.mod"));
-        finder.setBase(modulesPath);
+        finder.setBase(modulesDir);
 
-        Files.walkFileTree(modulesPath, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, finder);
+        Files.walkFileTree(modulesDir, EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, finder);
 
-        BaseHome hb = new BaseHome(new String[]{"jetty.home=" + homePath.toString(), "jetty.base=" + basePath.toString()});
+        BaseHome hb = new BaseHome(new String[]{"jetty.home=" + homePath, "jetty.base=" + basePath});
         BaseHomeTest.assertPathList(hb, "Files found", expected, finder);
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyDump.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyDump.java
@@ -21,6 +21,9 @@ import java.util.Objects;
 import java.util.Properties;
 import java.util.function.Predicate;
 
+/**
+ * This is used to test changes to "main.class" property.
+ */
 public class PropertyDump
 {
     public static void main(String[] args)

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
@@ -224,7 +224,7 @@ public class PropertyPassingTest
             --module=empty
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
-            """.replace('/', File.separatorChar);
+            """;
         Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
 
         // Setup command line
@@ -242,7 +242,7 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini".replace('/', File.separatorChar));
+        Path expectedPath = base.resolve("etc/config.ini");
         assertThat(output, containsString("test.config=" + expectedPath));
     }
 
@@ -269,7 +269,7 @@ public class PropertyPassingTest
             --module=env-config
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
-            """.replace('/', File.separatorChar);
+            """;
         Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
 
         // Setup command line
@@ -287,7 +287,7 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini".replace('/', File.separatorChar));
+        Path expectedPath = base.resolve("etc/config.ini");
         assertThat(output, containsString("test.config=" + expectedPath));
     }
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
@@ -242,8 +242,9 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini");
-        assertThat(output, containsString("test.config=" + expectedPath));
+        // The property is defined as `test.config=${jetty.base}/etc/config.ini`
+        // so we must maintain the slashes for the `/etc/config.ini` portion (even if it is running on windows)
+        assertThat(output, containsString("test.config=%s/etc/config.ini".formatted(base)));
     }
 
     @Test
@@ -287,8 +288,9 @@ public class PropertyPassingTest
         String output = collectRunOutput(commands);
 
         // Test for values
-        Path expectedPath = base.resolve("etc/config.ini");
-        assertThat(output, containsString("test.config=" + expectedPath));
+        // The property is defined as `test.config=${jetty.base}/etc/config.ini`
+        // so we must maintain the slashes for the `/etc/config.ini` portion (even if it is running on windows)
+        assertThat(output, containsString("test.config=%s/etc/config.ini".formatted(base)));
     }
 
     private String getClassPath()

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/PropertyPassingTest.java
@@ -20,7 +20,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.io.StringWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -35,6 +34,7 @@ import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -225,7 +225,7 @@ public class PropertyPassingTest
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
             """;
-        Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
+        Files.writeString(ini, iniBody, UTF_8);
 
         // Setup command line
         List<String> commands = new ArrayList<>();
@@ -261,7 +261,7 @@ public class PropertyPassingTest
             # configuration option
             # test.config=${jetty.home}/etc/eex-config.ini
             """;
-        Files.writeString(module, moduleBody, StandardCharsets.UTF_8);
+        Files.writeString(module, moduleBody, UTF_8);
         Path ini = base.resolve("start.d/config.ini");
         FS.ensureDirectoryExists(ini.getParent());
         String iniBody = """
@@ -270,7 +270,7 @@ public class PropertyPassingTest
             # TESTING THIS (it should expand the ${jetty.base} portion
             test.config=${jetty.base}/etc/config.ini
             """;
-        Files.writeString(ini, iniBody, StandardCharsets.UTF_8);
+        Files.writeString(ini, iniBody, UTF_8);
 
         // Setup command line
         List<String> commands = new ArrayList<>();

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/TestEnv.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/TestEnv.java
@@ -21,15 +21,15 @@ import java.nio.file.Path;
 
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 
 public class TestEnv
 {
     public static void copyTestDir(String testResourceDir, Path destDir) throws IOException
     {
         FS.ensureDirExists(destDir);
-        Path srcDir = MavenTestingUtils.getTestResourcePathDir(testResourceDir);
-        IO.copyDir(srcDir.toFile(), destDir.toFile());
+        Path srcDir = MavenPaths.findTestResourceDir(testResourceDir);
+        IO.copyDir(srcDir, destDir);
     }
 
     public static void makeFile(Path dir, String relFilePath, String... contents) throws IOException

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
@@ -38,7 +38,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @ExtendWith(WorkDirExtension.class) 
 public class ConfigSourcesTest
 {
-
     private void assertIdOrder(ConfigSources sources, String... expectedOrder)
     {
         List<String> actualList = new ArrayList<>();

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/config/ConfigSourcesTest.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jetty.start.Props.Prop;
@@ -47,7 +46,7 @@ public class ConfigSourcesTest
         {
             actualList.add(source.getId());
         }
-        List<String> expectedList = Arrays.asList(expectedOrder);
+        List<String> expectedList = List.of(expectedOrder);
         assertThat("ConfigSources.id order", actualList, contains(expectedList.toArray()));
     }
 

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenLocalRepoFileInitializerTest.java
@@ -15,8 +15,12 @@ package org.eclipse.jetty.start.fileinits;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
 
 import org.eclipse.jetty.start.BaseHome;
 import org.eclipse.jetty.start.config.ConfigSources;
@@ -31,6 +35,8 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.greaterThan;
@@ -210,21 +216,21 @@ public class MavenLocalRepoFileInitializerTest
         FS.ensureEmpty(snapshotLocalRepoDir);
 
         MavenLocalRepoFileInitializer repo =
-            new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false, "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty/jetty-rewrite/12.0.22-SNAPSHOT/jar";
+            new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false, "https://central.sonatype.com/repository/maven-snapshots/");
+        String ref = "maven://org.eclipse.jetty/jetty-rewrite/12.0.34-SNAPSHOT/jar";
         Coordinates coords = repo.getCoordinates(URI.create(ref));
         assertThat("Coordinates", coords, notNullValue());
 
         assertThat("coords.groupId", coords.groupId, is("org.eclipse.jetty"));
         assertThat("coords.artifactId", coords.artifactId, is("jetty-rewrite"));
-        assertThat("coords.version", coords.version, is("12.0.22-SNAPSHOT"));
+        assertThat("coords.version", coords.version, is("12.0.34-SNAPSHOT"));
         assertThat("coords.type", coords.type, is("jar"));
         assertThat("coords.classifier", coords.classifier, is(nullValue()));
 
         assertThat("coords.toCentralURI", coords.toCentralURI().toASCIIString(),
-            is("https://oss.sonatype.org/content/repositories/jetty-snapshots/org/eclipse/jetty/jetty-rewrite/12.0.22-SNAPSHOT/jetty-rewrite-12.0.22-SNAPSHOT.jar"));
+            is("https://central.sonatype.com/repository/maven-snapshots/org/eclipse/jetty/jetty-rewrite/12.0.34-SNAPSHOT/jetty-rewrite-12.0.34-SNAPSHOT.jar"));
 
-        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-12.0.22-SNAPSHOT.jar");
+        Path destination = baseHome.getBasePath().resolve("jetty-rewrite-12.0.34-SNAPSHOT.jar");
         repo.download(coords, destination);
         assertThat(Files.exists(destination), is(true));
         assertThat("Snapshot File size", Files.size(destination), greaterThan(10_000L));
@@ -240,8 +246,8 @@ public class MavenLocalRepoFileInitializerTest
 
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
-                "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
+                "https://central.sonatype.com/repository/maven-snapshots/");
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.34-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:company/");
 
@@ -258,8 +264,8 @@ public class MavenLocalRepoFileInitializerTest
 
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
-                "https://oss.sonatype.org/content/repositories/jetty-snapshots/");
-        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
+                "https://central.sonatype.com/repository/maven-snapshots/");
+        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.34-SNAPSHOT/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:/");
 
@@ -267,20 +273,37 @@ public class MavenLocalRepoFileInitializerTest
     }
 
     @Test
-    @Tag("external")
     public void testDownloadButOffline()
         throws Exception
     {
         Path snapshotLocalRepoDir = testdir.resolve("snapshot-repo");
         FS.ensureEmpty(snapshotLocalRepoDir);
 
+        // Create a jar file in this "local repo" that doesn't exist on a real maven repo (for testing reasons, don't want false positives)
+        Path jarFile = snapshotLocalRepoDir.resolve("org/eclipse/jetty/eeX/demos/jetty-eeX-demo-simple-webapp/12.99.9/jetty-eeX-demo-simple-webapp-12.99.9-config.jar");
+        FS.ensureDirExists(jarFile.getParent());
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        URI uri = URI.create("jar:" + jarFile.toUri().toASCIIString());
+        try (FileSystem zipfs = FileSystems.newFileSystem(uri, env))
+        {
+            Path root = zipfs.getPath("/");
+            Path dir = root.resolve("modules");
+            Files.createDirectories(dir);
+            Files.writeString(dir.resolve("eeX-demo.mod"), """
+                [description]
+                Test Demo Module (doesn't do anything)
+                """, UTF_8);
+        }
+
         MavenLocalRepoFileInitializer repo =
             new MavenLocalRepoFileInitializer(baseHome, snapshotLocalRepoDir, false,
-                "https://oss.sonatype.org/content/repositories/jetty-snapshots/").offline(true);
-        String ref = "maven://org.eclipse.jetty.ee10.demos/jetty-ee10-demo-simple-webapp/12.0.22-SNAPSHOT/jar/config";
+                "https://central.sonatype.com/repository/maven-snapshots/").offline(true);
+        String ref = "maven://org.eclipse.jetty.eeX.demos/jetty-eeX-demo-simple-webapp/12.99.9/jar/config";
         Path baseDir = baseHome.getBasePath();
         repo.create(URI.create(ref), "extract:/");
 
-        assertThat(Files.exists(baseDir.resolve("modules/ee10-demo-simple.mod")), is(false));
+        assertThat(baseDir.resolve("modules/eeX-demo.mod"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/fileinits/MavenMetadataTest.java
@@ -20,7 +20,7 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.junit.jupiter.api.Test;
 import org.xml.sax.SAXException;
 
@@ -34,7 +34,7 @@ public class MavenMetadataTest
     @Test
     public void testParseExample() throws ParserConfigurationException, SAXException, IOException
     {
-        Path example = MavenTestingUtils.getTestResourcePathFile("example-maven-metadata.xml");
+        Path example = MavenPaths.findTestResourceFile("example-maven-metadata.xml");
         MavenMetadata mavenMetadata = new MavenMetadata(example);
 
         assertThat("Metadata.groupId", mavenMetadata.getGroupId(), is("org.eclipse.jetty"));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.start.usecases;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -44,6 +43,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(WorkDirExtension.class)
@@ -109,7 +109,7 @@ public abstract class AbstractUseCase
                 lib/base.jar
                 [xml]
                 etc/base.xml
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
         Files.writeString(modules.resolve("extra.mod"),
             """
                 [depend]
@@ -120,7 +120,7 @@ public abstract class AbstractUseCase
                 etc/extra.xml
                 [ini]
                 extra.prop=value0
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
         Files.writeString(modules.resolve("main.mod"),
             """
                 [depend]
@@ -138,7 +138,7 @@ public abstract class AbstractUseCase
                 main.prop=value0
                 [ini-template]
                 # main.prop=valueT
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
         Files.writeString(modules.resolve("optional.mod"),
             """
                 [lib]
@@ -147,7 +147,7 @@ public abstract class AbstractUseCase
                 etc/optional.xml
                 [ini]
                 optional.prop=value0
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
     }
 
     public static class ExecResults
@@ -252,7 +252,7 @@ public abstract class AbstractUseCase
             execResults.baseHome = main.getBaseHome();
 
             StartLog.setStream(originalStream);
-            execResults.output = out.toString(StandardCharsets.UTF_8);
+            execResults.output = out.toString(UTF_8);
         }
         catch (Exception e)
         {

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AbstractUseCase.java
@@ -63,7 +63,7 @@ public abstract class AbstractUseCase
     }
 
     @BeforeEach
-    public void setupTest() throws IOException
+    public void setupTest()
     {
         testdir = workDir.getEmptyPathDir();
         // Create empty base directory for testcase to use
@@ -252,7 +252,7 @@ public abstract class AbstractUseCase
             execResults.baseHome = main.getBaseHome();
 
             StartLog.setStream(originalStream);
-            execResults.output = out.toString(StandardCharsets.UTF_8.name());
+            execResults.output = out.toString(StandardCharsets.UTF_8);
         }
         catch (Exception e)
         {

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AgentPropertiesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AgentPropertiesTest.java
@@ -13,11 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,6 +21,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -42,40 +39,38 @@ public class AgentPropertiesTest extends AbstractUseCase
         FS.touch(baseDir.resolve("lib/agent-jdk-1.6.jar"));
         FS.touch(baseDir.resolve("lib/agent-jdk-1.7.jar"));
         FS.touch(baseDir.resolve("lib/agent-jdk-1.8.jar"));
-        Files.write(baseDir.resolve("modules/agent.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "[lib]",
-                "lib/agent-jdk-${java.vm.specification.version}.jar"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main,agent"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/agent.mod"),
+        """
+            [depend]
+            main
+            [lib]
+            lib/agent-jdk-${java.vm.specification.version}.jar
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main,agent
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "java.vm.specification.version=1.7"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.base}/lib/agent-jdk-1.7.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.base}/lib/agent-jdk-1.7.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AlternatesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/AlternatesTest.java
@@ -13,11 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,6 +21,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -41,69 +38,64 @@ public class AlternatesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/ndb.xml"));
-        Files.write(baseDir.resolve("modules/alternate.mod"),
-            Arrays.asList(
-                "[provides]",
-                "default",
-                "[ini]",
-                "default.option=alternate"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/default.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[ini]",
-                "default.option=default"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[optional]",
-                "default",
-                "[ini]",
-                "noDft.option=A"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[depend]",
-                "default",
-                "[xml]",
-                "etc/ndb.xml",
-                "[ini]",
-                "noDft.option=B"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternate.mod"),
+            """
+            [provides]
+            default
+            [ini]
+            default.option=alternate
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/default.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [ini]
+            default.option=default
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionA.mod"),
+            """
+            [provides]
+            noDft
+            [optional]
+            default
+            [ini]
+            noDft.option=A
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionB.mod"),
+            """
+            [provides]
+            noDft
+            [depend]
+            default
+            [xml]
+            etc/ndb.xml
+            [ini]
+            noDft.option=B
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=noDftOptionA"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -125,71 +117,66 @@ public class AlternatesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/ndb.xml"));
-        Files.write(baseDir.resolve("modules/alternate.mod"),
-            Arrays.asList(
-                "[provides]",
-                "default",
-                "[ini]",
-                "default.option=alternate"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/default.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[ini]",
-                "default.option=default"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[optional]",
-                "default",
-                "[ini]",
-                "noDft.option=A"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[depend]",
-                "default",
-                "[xml]",
-                "etc/ndb.xml",
-                "[ini]",
-                "noDft.option=B"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternate.mod"),
+            """
+            [provides]
+            default
+            [ini]
+            default.option=alternate
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/default.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [ini]
+            default.option=default
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionA.mod"),
+            """
+            [provides]
+            noDft
+            [optional]
+            default
+            [ini]
+            noDft.option=A
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionB.mod"),
+            """
+            [provides]
+            noDft
+            [depend]
+            default
+            [xml]
+            etc/ndb.xml
+            [ini]
+            noDft.option=B
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=noDftOptionB"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/d.xml"),
+            FS.separators("${jetty.base}/etc/ndb.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -212,70 +199,65 @@ public class AlternatesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/ndb.xml"));
-        Files.write(baseDir.resolve("modules/alternate.mod"),
-            Arrays.asList(
-                "[provides]",
-                "default",
-                "[ini]",
-                "default.option=alternate"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/default.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[ini]",
-                "default.option=default"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[optional]",
-                "default",
-                "[ini]",
-                "noDft.option=A"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[depend]",
-                "default",
-                "[xml]",
-                "etc/ndb.xml",
-                "[ini]",
-                "noDft.option=B"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternate.mod"),
+            """
+            [provides]
+            default
+            [ini]
+            default.option=alternate
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/default.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [ini]
+            default.option=default
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionA.mod"),
+            """
+            [provides]
+            noDft
+            [optional]
+            default
+            [ini]
+            noDft.option=A
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionB.mod"),
+            """
+            [provides]
+            noDft
+            [depend]
+            default
+            [xml]
+            etc/ndb.xml
+            [ini]
+            noDft.option=B
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=alternate,noDftOptionB"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/ndb.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -298,52 +280,47 @@ public class AlternatesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/ndb.xml"));
-        Files.write(baseDir.resolve("modules/alternate.mod"),
-            Arrays.asList(
-                "[provides]",
-                "default",
-                "[ini]",
-                "default.option=alternate"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/default.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[ini]",
-                "default.option=default"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[optional]",
-                "default",
-                "[ini]",
-                "noDft.option=A"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[depend]",
-                "default",
-                "[xml]",
-                "etc/ndb.xml",
-                "[ini]",
-                "noDft.option=B"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternate.mod"),
+            """
+            [provides]
+            default
+            [ini]
+            default.option=alternate
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/default.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [ini]
+            default.option=default
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionA.mod"),
+            """
+            [provides]
+            noDft
+            [optional]
+            default
+            [ini]
+            noDft.option=A
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionB.mod"),
+            """
+            [provides]
+            noDft
+            [depend]
+            default
+            [xml]
+            etc/ndb.xml
+            [ini]
+            noDft.option=B
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=alternate,default"
         );
         ExecResults results = exec(runArgs, false);
@@ -362,77 +339,72 @@ public class AlternatesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/ndb.xml"));
-        Files.write(baseDir.resolve("modules/alternate.mod"),
-            Arrays.asList(
-                "[provides]",
-                "default",
-                "[ini]",
-                "default.option=alternate"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/default.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[ini]",
-                "default.option=default"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[optional]",
-                "default",
-                "[ini]",
-                "noDft.option=A"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/noDftOptionB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "noDft",
-                "[depend]",
-                "default",
-                "[xml]",
-                "etc/ndb.xml",
-                "[ini]",
-                "noDft.option=B"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternate.mod"),
+            """
+            [provides]
+            default
+            [ini]
+            default.option=alternate
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/default.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [ini]
+            default.option=default
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionA.mod"),
+            """
+            [provides]
+            noDft
+            [optional]
+            default
+            [ini]
+            noDft.option=A
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/noDftOptionB.mod"),
+            """
+            [provides]
+            noDft
+            [depend]
+            default
+            [xml]
+            etc/ndb.xml
+            [ini]
+            noDft.option=B
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+        """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=noDftOptionB"
         );
         exec(prepareArgs, true);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=alternate"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/ndb.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/ndb.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartTest.java
@@ -13,18 +13,18 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.jetty.toolchain.test.PathAssert;
+import org.eclipse.jetty.start.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -36,14 +36,13 @@ public class BarebonesAddToStartTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=optional"
         );
@@ -54,20 +53,20 @@ public class BarebonesAddToStartTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/optional.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -80,7 +79,7 @@ public class BarebonesAddToStartTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertFileExists("Required File: start.ini", results.baseHome.getPath("start.ini"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required File: start.ini", results.baseHome.getPath("start.ini"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddToStartdTest.java
@@ -13,18 +13,18 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.jetty.toolchain.test.PathAssert;
+import org.eclipse.jetty.start.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -36,14 +36,13 @@ public class BarebonesAddToStartdTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=optional"
@@ -55,20 +54,20 @@ public class BarebonesAddToStartdTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/optional.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -81,8 +80,8 @@ public class BarebonesAddToStartdTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertFileExists("Required File: start.d/start.ini", results.baseHome.getPath("start.d/start.ini"));
-        PathAssert.assertFileExists("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required File: start.d/start.ini", results.baseHome.getPath("start.d/start.ini"), isRegularFile());
+        assertThat("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddUnknownTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAddUnknownTest.java
@@ -13,14 +13,12 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
@@ -31,14 +29,13 @@ public class BarebonesAddUnknownTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=unknown"

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAlreadyEnabledTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesAlreadyEnabledTest.java
@@ -13,18 +13,18 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.eclipse.jetty.toolchain.test.PathAssert;
+import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -36,14 +36,13 @@ public class BarebonesAlreadyEnabledTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=main"
         );
@@ -54,18 +53,18 @@ public class BarebonesAlreadyEnabledTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -77,8 +76,8 @@ public class BarebonesAlreadyEnabledTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertFileExists("Required File: start.ini", results.baseHome.getPath("start.ini"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required File: start.ini", results.baseHome.getPath("start.ini"), isRegularFile());
 
         // === Validate Specific Lines Exist in Output
         assertOutputContainsRegex(prepareResults.output, "INFO  : main already enabled by \\[\\$\\{jetty.base}[\\\\/]start.ini\\]");

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BarebonesTest.java
@@ -13,17 +13,16 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jetty.start.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -35,29 +34,28 @@ public class BarebonesTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Arrays.asList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = Collections.emptyList();
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasehomeWithfilesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasehomeWithfilesTest.java
@@ -13,16 +13,15 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
@@ -39,25 +38,24 @@ public class BasehomeWithfilesTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules/withfiles/four/sub"));
         FS.ensureDirExists(baseDir.resolve("modules/withfiles/four/sub/dir"));
 
-        Files.write(baseDir.resolve("modules/withfiles.mod"),
-            Arrays.asList(
-                "[files]",
-                "basehome:modules/withfiles/test.txt|one/renamed.txt",
-                "basehome:modules/withfiles/test.txt|two/",
-                "three/",
-                "basehome:modules/withfiles/test.txt|three",
-                "basehome:modules/withfiles",
-                "basehome:modules/withfiles/four/|five/",
-                "six/",
-                "basehome:modules/withfiles/four/sub|six"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/withfiles.mod"),
+            """
+            [files]
+            basehome:modules/withfiles/test.txt|one/renamed.txt
+            basehome:modules/withfiles/test.txt|two/
+            three/
+            basehome:modules/withfiles/test.txt|three
+            basehome:modules/withfiles
+            basehome:modules/withfiles/four/|five/
+            six/
+            basehome:modules/withfiles/four/sub|six
+            """, UTF_8);
         FS.touch(baseDir.resolve("modules/withfiles/four/sub/dir/test.txt"));
         FS.touch(baseDir.resolve("modules/withfiles/four/test.txt"));
         FS.touch(baseDir.resolve("modules/withfiles/test.txt"));
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=withfiles"
@@ -69,7 +67,7 @@ public class BasehomeWithfilesTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Downloaded Files
-        List<String> expectedDownloads = Arrays.asList(
+        List<String> expectedDownloads = List.of(
             "basehome:modules/withfiles/test.txt|one/renamed.txt",
             "basehome:modules/withfiles/test.txt|two/",
             "basehome:modules/withfiles/test.txt|three",
@@ -81,12 +79,12 @@ public class BasehomeWithfilesTest extends AbstractUseCase
         assertThat("Downloads", actualDownloads, containsInAnyOrder(expectedDownloads.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertFileExists("Required File: test.txt", results.baseHome.getPath("test.txt"));
-        PathAssert.assertFileExists("Required File: one/renamed.txt", results.baseHome.getPath("one/renamed.txt"));
-        PathAssert.assertFileExists("Required File: two/test.txt", results.baseHome.getPath("two/test.txt"));
-        PathAssert.assertFileExists("Required File: three/test.txt", results.baseHome.getPath("three/test.txt"));
-        PathAssert.assertFileExists("Required File: four/sub/dir/test.txt", results.baseHome.getPath("four/sub/dir/test.txt"));
-        PathAssert.assertFileExists("Required File: five/sub/dir/test.txt", results.baseHome.getPath("five/sub/dir/test.txt"));
-        PathAssert.assertFileExists("Required File: six/sub/dir/test.txt", results.baseHome.getPath("six/sub/dir/test.txt"));
+        assertThat("Required File: test.txt", results.baseHome.getPath("test.txt"), isRegularFile());
+        assertThat("Required File: one/renamed.txt", results.baseHome.getPath("one/renamed.txt"), isRegularFile());
+        assertThat("Required File: two/test.txt", results.baseHome.getPath("two/test.txt"), isRegularFile());
+        assertThat("Required File: three/test.txt", results.baseHome.getPath("three/test.txt"), isRegularFile());
+        assertThat("Required File: four/sub/dir/test.txt", results.baseHome.getPath("four/sub/dir/test.txt"), isRegularFile());
+        assertThat("Required File: five/sub/dir/test.txt", results.baseHome.getPath("five/sub/dir/test.txt"), isRegularFile());
+        assertThat("Required File: six/sub/dir/test.txt", results.baseHome.getPath("six/sub/dir/test.txt"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicPropertiesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicPropertiesTest.java
@@ -13,16 +13,15 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.jetty.start.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -35,15 +34,14 @@ public class BasicPropertiesTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Arrays.asList(
-                "--modules=main",
-                "jetty.http.port=${port}"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            jetty.http.port=${port}
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Arrays.asList(
+        List<String> runArgs = List.of(
             "other=value",
             "port=9090",
             "add+=beginning",
@@ -64,18 +62,18 @@ public class BasicPropertiesTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/BasicTest.java
@@ -15,12 +15,9 @@ package org.eclipse.jetty.start.usecases;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -28,10 +25,11 @@ import java.util.Set;
 import org.eclipse.jetty.start.Props;
 import org.eclipse.jetty.start.UsageException;
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
-import org.eclipse.jetty.toolchain.test.PathAssert;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -48,11 +46,10 @@ public class BasicTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(homeDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
     }
 
     @Test
@@ -60,11 +57,10 @@ public class BasicTest extends AbstractUseCase
     {
         setupDistHome();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -72,18 +68,18 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -95,7 +91,7 @@ public class BasicTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
 
         // === Validate home/base property uri values
         Props props = results.startArgs.getJettyEnvironment().getProperties();
@@ -118,12 +114,11 @@ public class BasicTest extends AbstractUseCase
     {
         setupDistHome();
 
-        Files.write(baseDir.resolve("start.ini"),
-            List.of(
-                "--modules=main",
-                "--modules=does-not-exist"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            --modules=does-not-exist
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -144,13 +139,12 @@ public class BasicTest extends AbstractUseCase
     {
         setupDistHome();
 
-        Files.write(baseDir.resolve("start.ini"),
-            List.of(
-                "--modules=main",
-                "--modules=does-not-exist",
-                "--modules=also-not-present"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            --modules=does-not-exist
+            --modules=also-not-present
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -169,13 +163,12 @@ public class BasicTest extends AbstractUseCase
     @Test
     public void testProvidersUsingDefault() throws Exception
     {
-        Path homePath = MavenTestingUtils.getTestResourcePathDir("providers-home");
+        Path homePath = MavenPaths.findTestResourceDir("providers-home");
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=server"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=server
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -184,7 +177,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-a.xml".replace('/', File.separatorChar));
+        List<String> expectedXmls = List.of(FS.separators("${jetty.home}/etc/logging-a.xml"));
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -203,13 +196,12 @@ public class BasicTest extends AbstractUseCase
     @Test
     public void testProvidersUsingSpecific() throws Exception
     {
-        Path homePath = MavenTestingUtils.getTestResourcePathDir("providers-home");
+        Path homePath = MavenPaths.findTestResourceDir("providers-home");
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=server"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=server
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -219,7 +211,7 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = List.of("${jetty.home}/etc/logging-b.xml".replace('/', File.separatorChar));
+        List<String> expectedXmls = List.of(FS.separators("${jetty.home}/etc/logging-b.xml"));
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
@@ -240,11 +232,10 @@ public class BasicTest extends AbstractUseCase
     {
         setupDistHome();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -256,8 +247,8 @@ public class BasicTest extends AbstractUseCase
         runArgs.add("-Xmx1g");
 
         // Arbitrary Libs
-        Path extraJar = MavenTestingUtils.getTestResourcePathFile("extra-libs/example.jar").toRealPath();
-        Path extraDir = MavenTestingUtils.getTestResourcePathDir("extra-resources").toRealPath();
+        Path extraJar = MavenPaths.findTestResourceFile("extra-libs/example.jar").toRealPath();
+        Path extraDir = MavenPaths.findTestResourceDir("extra-resources").toRealPath();
 
         assertThat("Extra Jar exists: " + extraJar, Files.exists(extraJar), is(true));
         assertThat("Extra Dir exists: " + extraDir, Files.exists(extraDir), is(true));
@@ -273,23 +264,23 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/config.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/config-foo.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/config-bar.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.home}/etc/config.xml"),
+            FS.separators("${jetty.home}/etc/config-foo.xml"),
+            FS.separators("${jetty.home}/etc/config-bar.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
+        List<String> expectedLibs = List.of(
             extraJar.toString(),
             extraDir.toString(),
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -301,10 +292,10 @@ public class BasicTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
 
         // === Validate JVM args
-        List<String> expectedJvmArgs = Arrays.asList(
+        List<String> expectedJvmArgs = List.of(
             "-Xms1g",
             "-Xmx1g"
         );
@@ -317,11 +308,10 @@ public class BasicTest extends AbstractUseCase
     {
         setupDistHome();
 
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = new ArrayList<>();
@@ -334,23 +324,23 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.home}/etc/extra.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/optional.jar"),
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra0.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra1.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -364,7 +354,7 @@ public class BasicTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
     }
 
     @Test
@@ -381,18 +371,18 @@ public class BasicTest extends AbstractUseCase
         ExecResults results = exec(runArgs, true);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DatabaseTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DatabaseTest.java
@@ -13,10 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -25,6 +22,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -40,49 +38,46 @@ public class DatabaseTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.ensureDirExists(baseDir.resolve("lib"));
         FS.ensureDirExists(baseDir.resolve("lib/db"));
-        Files.write(baseDir.resolve("etc/db.xml"),
-            Collections.singletonList(
-                "<!-- build up org.eclipse.jetty.plus.jndi.Resource here  -->"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("etc/db.xml"),
+            """
+            <!-- build up org.eclipse.jetty.plus.jndi.Resource here  -->
+            """, UTF_8);
         FS.touch(baseDir.resolve("lib/db/bonecp.jar"));
         FS.touch(baseDir.resolve("lib/db/mysql-driver.jar"));
-        Files.write(baseDir.resolve("modules/db.mod"),
-            Arrays.asList(
-                "[lib]",
-                "lib/db/*.jar",
-                "[xml]",
-                "etc/db.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Arrays.asList(
-                "--modules=main,db",
-                "mysql.user=frank",
-                "mysql.pass=secret"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/db.mod"),
+            """
+            [lib]
+            lib/db/*.jar
+            [xml]
+            etc/db.xml
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main,db
+            mysql.user=frank
+            mysql.pass=secret
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = Collections.emptyList();
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/db.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/db.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.base}/lib/db/bonecp.jar".replace('/', File.separatorChar),
-            "${jetty.base}/lib/db/mysql-driver.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.base}/lib/db/bonecp.jar"),
+            FS.separators("${jetty.base}/lib/db/mysql-driver.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DynamicDependTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/DynamicDependTest.java
@@ -13,11 +13,7 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -25,6 +21,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,51 +35,47 @@ public class DynamicDependTest extends AbstractUseCase
 
         FS.ensureDirExists(baseDir.resolve("modules/impl"));
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("modules/dynamic.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "impl/dynamic-${java.version}"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/impl/dynamic-1.7.0_31.mod"),
-            Arrays.asList(
-                "[ini]",
-                "dynamic=1.7.0_31-from-mod"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/impl/dynamic-1.8.0_05.mod"),
-            Arrays.asList(
-                "[ini]",
-                "dynamic=1.8.0_05_from_mod"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dynamic.mod"),
+            """
+            [depend]
+            main
+            impl/dynamic-${java.version}
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/impl/dynamic-1.7.0_31.mod"),
+            """
+            [ini]
+            dynamic=1.7.0_31-from-mod
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/impl/dynamic-1.8.0_05.mod"),
+            """
+            [ini]
+            dynamic=1.8.0_05_from_mod
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Arrays.asList(
+        List<String> runArgs = List.of(
             "java.version=1.7.0_31",
             "--modules=dynamic"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -102,51 +95,47 @@ public class DynamicDependTest extends AbstractUseCase
 
         FS.ensureDirExists(baseDir.resolve("modules/impl"));
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("modules/dynamic.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "impl/dynamic-${java.version}"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/impl/dynamic-1.7.0_31.mod"),
-            Arrays.asList(
-                "[ini]",
-                "dynamic=1.7.0_31-from-mod"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/impl/dynamic-1.8.0_05.mod"),
-            Arrays.asList(
-                "[ini]",
-                "dynamic=1.8.0_05_from_mod"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dynamic.mod"),
+            """
+            [depend]
+            main
+            impl/dynamic-${java.version}
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/impl/dynamic-1.7.0_31.mod"),
+            """
+            [ini]
+            dynamic=1.7.0_31-from-mod
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/impl/dynamic-1.8.0_05.mod"),
+            """
+            [ini]
+            dynamic=1.8.0_05_from_mod
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Arrays.asList(
+        List<String> runArgs = List.of(
             "java.version=1.8.0_05",
             "--modules=dynamic"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartCreateStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartCreateStartdTest.java
@@ -13,17 +13,16 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,7 +37,7 @@ public class EmptyAddToStartCreateStartdTest extends AbstractUseCase
         FS.touch(baseDir.resolve("unrelated.txt"));
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=extra",
             "--create-startd",
@@ -51,23 +50,23 @@ public class EmptyAddToStartCreateStartdTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.home}/etc/extra.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/optional.jar"),
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra0.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra1.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -81,9 +80,9 @@ public class EmptyAddToStartCreateStartdTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertFileExists("Required File: start.d/extra.ini", results.baseHome.getPath("start.d/extra.ini"));
-        PathAssert.assertFileExists("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required File: start.d/extra.ini", results.baseHome.getPath("start.d/extra.ini"), isRegularFile());
+        assertThat("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"), isRegularFile());
 
         // === Validate Specific Lines Exist in Output
         assertOutputContainsRegex(prepareResults.output, "mkdir \\$\\{jetty.base\\}[\\\\/]maindir");

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyAddToStartTest.java
@@ -13,17 +13,15 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,7 +36,7 @@ public class EmptyAddToStartTest extends AbstractUseCase
         FS.touch(baseDir.resolve("unrelated.txt"));
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=extra,optional"
         );
@@ -49,23 +47,23 @@ public class EmptyAddToStartTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.home}/etc/extra.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/optional.jar"),
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra0.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra1.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -79,7 +77,7 @@ public class EmptyAddToStartTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertDirExists("Required Directory: start.d/", results.baseHome.getPath("start.d/"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required Directory: start.d/", results.baseHome.getPath("start.d/"), isDirectory());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyCreateStartdTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EmptyCreateStartdTest.java
@@ -13,17 +13,16 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isDirectory;
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,7 +37,7 @@ public class EmptyCreateStartdTest extends AbstractUseCase
         FS.touch(baseDir.resolve("unrelated.txt"));
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=extra,optional"
@@ -50,23 +49,23 @@ public class EmptyCreateStartdTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/optional.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/extra.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/optional.xml"),
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.home}/etc/extra.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/optional.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra0.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/extra/extra1.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/optional.jar"),
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra0.jar"),
+            FS.separators("${jetty.home}/lib/extra/extra1.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -80,9 +79,9 @@ public class EmptyCreateStartdTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertDirExists("Required Directory: maindir/", results.baseHome.getPath("maindir/"));
-        PathAssert.assertDirExists("Required Directory: start.d/", results.baseHome.getPath("start.d/"));
-        PathAssert.assertFileExists("Required File: start.d/extra.ini", results.baseHome.getPath("start.d/extra.ini"));
-        PathAssert.assertFileExists("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"));
+        assertThat("Required Directory: maindir/", results.baseHome.getPath("maindir/"), isDirectory());
+        assertThat("Required Directory: start.d/", results.baseHome.getPath("start.d/"), isDirectory());
+        assertThat("Required File: start.d/extra.ini", results.baseHome.getPath("start.d/extra.ini"), isRegularFile());
+        assertThat("Required File: start.d/optional.ini", results.baseHome.getPath("start.d/optional.ini"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -45,41 +43,39 @@ public class EnvironmentsTest extends AbstractUseCase
 
         FS.touch(baseDir.resolve("lib/envA.jar"));
         FS.touch(baseDir.resolve("etc/envA.xml"));
-        Files.write(baseDir.resolve("modules/feature-envA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "feature-envA",
-                "[environment]",
-                "envA",
-                "[depends]",
-                "main",
-                "[xml]",
-                "etc/envA.xml",
-                "[lib]",
-                "lib/envA.jar",
-                "[ini]",
-                "feature.option=envA"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/feature-envA.mod"),
+            """
+            [provides]
+            feature-envA
+            [environment]
+            envA
+            [depends]
+            main
+            [xml]
+            etc/envA.xml
+            [lib]
+            lib/envA.jar
+            [ini]
+            feature.option=envA
+            """, StandardCharsets.UTF_8);
 
         FS.touch(baseDir.resolve("lib/envB.jar"));
         FS.touch(baseDir.resolve("etc/envB.xml"));
-        Files.write(baseDir.resolve("modules/feature-envB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "feature-envB",
-                "[environment]",
-                "envB",
-                "[depends]",
-                "main",
-                "[xml]",
-                "etc/envB.xml",
-                "[lib]",
-                "lib/envB.jar",
-                "[ini]",
-                "feature.option=envB"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/feature-envB.mod"),
+            """
+            [provides]
+            feature-envB
+            [environment]
+            envB
+            [depends]
+            main
+            [xml]
+            etc/envB.xml
+            [lib]
+            lib/envB.jar
+            [ini]
+            feature.option=envB
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(
@@ -89,18 +85,18 @@ public class EnvironmentsTest extends AbstractUseCase
 
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/EnvironmentsTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.List;
@@ -23,6 +22,7 @@ import org.eclipse.jetty.start.StartEnvironment;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -57,7 +57,7 @@ public class EnvironmentsTest extends AbstractUseCase
             lib/envA.jar
             [ini]
             feature.option=envA
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         FS.touch(baseDir.resolve("lib/envB.jar"));
         FS.touch(baseDir.resolve("etc/envB.xml"));
@@ -75,7 +75,7 @@ public class EnvironmentsTest extends AbstractUseCase
             lib/envB.jar
             [ini]
             feature.option=envB
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/Files0Test.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/Files0Test.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +20,7 @@ import java.util.List;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -38,7 +38,7 @@ public class Files0Test extends AbstractUseCase
             """
             [files]
             basehome:modules/demo/demo-config.xml|etc/demo-config.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         FS.touch(baseDir.resolve("modules/demo/demo-config.xml"));
 
         // === Prepare Jetty Base using Main

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/Files0Test.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/Files0Test.java
@@ -15,14 +15,13 @@ package org.eclipse.jetty.start.usecases;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
@@ -35,16 +34,15 @@ public class Files0Test extends AbstractUseCase
 
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.ensureDirExists(baseDir.resolve("modules/demo"));
-        Files.write(baseDir.resolve("modules/demo.mod"),
-            Arrays.asList(
-                "[files]",
-                "basehome:modules/demo/demo-config.xml|etc/demo-config.xml"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/demo.mod"),
+            """
+            [files]
+            basehome:modules/demo/demo-config.xml|etc/demo-config.xml
+            """, StandardCharsets.UTF_8);
         FS.touch(baseDir.resolve("modules/demo/demo-config.xml"));
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=demo"
@@ -56,13 +54,13 @@ public class Files0Test extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Downloaded Files
-        List<String> expectedDownloads = Arrays.asList(
+        List<String> expectedDownloads = List.of(
             "basehome:modules/demo/demo-config.xml|etc/demo-config.xml"
         );
         List<String> actualDownloads = results.getDownloads();
         assertThat("Downloads", actualDownloads, containsInAnyOrder(expectedDownloads.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertFileExists("Required File: etc/demo-config.xml", results.baseHome.getPath("etc/demo-config.xml"));
+        assertThat("Required File: etc/demo-config.xml", results.baseHome.getPath("etc/demo-config.xml"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/LoopTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/LoopTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +20,7 @@ import java.util.List;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 
@@ -40,36 +40,36 @@ public class LoopTest extends AbstractUseCase
             """
             [provides]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/richard.mod"),
             """
             [depends]
             harry
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/harry.mod"),
             """
             [depends]
             tom
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/other.mod"),
             """
             [provides]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/root.mod"),
             """
             [depends]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/tom.mod"),
             """
             [depends]
             richard
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.ini"),
             """
             --modules=root
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(
@@ -103,36 +103,36 @@ public class LoopTest extends AbstractUseCase
             """
             [provides]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/richard.mod"),
             """
             [depends]
             dynamic/harry
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dynamic/harry.mod"),
             """
             [depends]
             tom
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/other.mod"),
             """
             [provides]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/root.mod"),
             """
             [depends]
             branch
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/tom.mod"),
             """
             [depends]
             richard
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.ini"),
             """
             --modules=root
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/LoopTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/LoopTest.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.start.usecases;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -37,50 +36,43 @@ public class LoopTest extends AbstractUseCase
         // Create loop
         // richard -> harry -> tom -> richard
 
-        Files.write(baseDir.resolve("modules/branch.mod"),
-            Arrays.asList(
-                "[provides]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/richard.mod"),
-            Arrays.asList(
-                "[depends]",
-                "harry"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/harry.mod"),
-            Arrays.asList(
-                "[depends]",
-                "tom"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/other.mod"),
-            Arrays.asList(
-                "[provides]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/root.mod"),
-            Arrays.asList(
-                "[depends]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/tom.mod"),
-            Arrays.asList(
-                "[depends]",
-                "richard"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=root"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/branch.mod"),
+            """
+            [provides]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/richard.mod"),
+            """
+            [depends]
+            harry
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/harry.mod"),
+            """
+            [depends]
+            tom
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/other.mod"),
+            """
+            [provides]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/root.mod"),
+            """
+            [depends]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/tom.mod"),
+            """
+            [depends]
+            richard
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=root
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=tom"
@@ -107,50 +99,43 @@ public class LoopTest extends AbstractUseCase
         // Create loop
         // richard -> dynamic/harry -> tom -> richard
 
-        Files.write(baseDir.resolve("modules/branch.mod"),
-            Arrays.asList(
-                "[provides]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/richard.mod"),
-            Arrays.asList(
-                "[depends]",
-                "dynamic/harry"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dynamic/harry.mod"),
-            Arrays.asList(
-                "[depends]",
-                "tom"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/other.mod"),
-            Arrays.asList(
-                "[provides]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/root.mod"),
-            Arrays.asList(
-                "[depends]",
-                "branch"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/tom.mod"),
-            Arrays.asList(
-                "[depends]",
-                "richard"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=root"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/branch.mod"),
+            """
+            [provides]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/richard.mod"),
+            """
+            [depends]
+            dynamic/harry
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dynamic/harry.mod"),
+            """
+            [depends]
+            tom
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/other.mod"),
+            """
+            [provides]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/root.mod"),
+            """
+            [depends]
+            branch
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/tom.mod"),
+            """
+            [depends]
+            richard
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=root
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=tom"

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +22,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -46,44 +46,44 @@ public class OrderedTest extends AbstractUseCase
             alternate
             [xml]
             etc/alternateA.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/alternateB.mod"),
             """
             [provides]
             alternate
             [xml]
             etc/alternateB.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/convenience.mod"),
             """
             [depends]
             replacement
             something-else
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dependent.mod"),
             """
             [depends]
             alternate
             [xml]
             etc/dependent.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/original.mod"),
             """
             [ini]
             impl=original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/replacement.mod"),
             """
             [provides]
             original
             [ini]
             impl=replacement
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/something-else.mod"),
             """
             [depends]
             original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(
@@ -116,44 +116,44 @@ public class OrderedTest extends AbstractUseCase
             alternate
             [xml]
             etc/alternateA.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/alternateB.mod"),
             """
             [provides]
             alternate
             [xml]
             etc/alternateB.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/convenience.mod"),
             """
             [depends]
             replacement
             something-else
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dependent.mod"),
             """
             [depends]
             alternate
             [xml]
             etc/dependent.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/original.mod"),
             """
             [ini]
             impl=original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/replacement.mod"),
             """
             [provides]
             original
             [ini]
             impl=replacement
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/something-else.mod"),
             """
             [depends]
             original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(
@@ -186,44 +186,44 @@ public class OrderedTest extends AbstractUseCase
             alternate
             [xml]
             etc/alternateA.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/alternateB.mod"),
             """
             [provides]
             alternate
             [xml]
             etc/alternateB.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/convenience.mod"),
             """
             [depends]
             replacement
             something-else
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dependent.mod"),
             """
             [depends]
             alternate
             [xml]
             etc/dependent.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/original.mod"),
             """
             [ini]
             impl=original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/replacement.mod"),
             """
             [provides]
             original
             [ini]
             impl=replacement
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/something-else.mod"),
             """
             [depends]
             original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(
@@ -251,44 +251,44 @@ public class OrderedTest extends AbstractUseCase
             alternate
             [xml]
             etc/alternateA.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/alternateB.mod"),
             """
             [provides]
             alternate
             [xml]
             etc/alternateB.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/convenience.mod"),
             """
             [depends]
             replacement
             something-else
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dependent.mod"),
             """
             [depends]
             alternate
             [xml]
             etc/dependent.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/original.mod"),
             """
             [ini]
             impl=original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/replacement.mod"),
             """
             [provides]
             original
             [ini]
             impl=replacement
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/something-else.mod"),
             """
             [depends]
             original
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = List.of(
@@ -339,7 +339,7 @@ public class OrderedTest extends AbstractUseCase
             implA=implA
             [ini-template]
             implA=implA
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/abstractB.mod"),
             """
             [depend]
@@ -350,19 +350,19 @@ public class OrderedTest extends AbstractUseCase
             implB=implB
             [ini-template]
             implB=implB
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dynamic/implA.mod"),
             """
             [depend]
             provided
             [xml]
             etc/implA.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/dynamic/implB.mod"),
             """
             [xml]
             etc/implB.xml
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/OrderedTest.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -42,68 +40,61 @@ public class OrderedTest extends AbstractUseCase
         FS.touch(baseDir.resolve("etc/alternateA.xml"));
         FS.touch(baseDir.resolve("etc/alternateB.xml"));
         FS.touch(baseDir.resolve("etc/dependent.xml"));
-        Files.write(baseDir.resolve("modules/alternateA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateA.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/alternateB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateB.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/convenience.mod"),
-            Arrays.asList(
-                "[depends]",
-                "replacement",
-                "something-else"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dependent.mod"),
-            Arrays.asList(
-                "[depends]",
-                "alternate",
-                "[xml]",
-                "etc/dependent.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/original.mod"),
-            Arrays.asList(
-                "[ini]",
-                "impl=original"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/replacement.mod"),
-            Arrays.asList(
-                "[provides]",
-                "original",
-                "[ini]",
-                "impl=replacement"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/something-else.mod"),
-            Arrays.asList(
-                "[depends]",
-                "original"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateA.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateA.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateB.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateB.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/convenience.mod"),
+            """
+            [depends]
+            replacement
+            something-else
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dependent.mod"),
+            """
+            [depends]
+            alternate
+            [xml]
+            etc/dependent.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/original.mod"),
+            """
+            [ini]
+            impl=original
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/replacement.mod"),
+            """
+            [provides]
+            original
+            [ini]
+            impl=replacement
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/something-else.mod"),
+            """
+            [depends]
+            original
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=alternateA,dependent"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/alternateA.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/dependent.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.base}/etc/alternateA.xml"),
+            FS.separators("${jetty.base}/etc/dependent.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
@@ -119,68 +110,61 @@ public class OrderedTest extends AbstractUseCase
         FS.touch(baseDir.resolve("etc/alternateA.xml"));
         FS.touch(baseDir.resolve("etc/alternateB.xml"));
         FS.touch(baseDir.resolve("etc/dependent.xml"));
-        Files.write(baseDir.resolve("modules/alternateA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateA.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/alternateB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateB.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/convenience.mod"),
-            Arrays.asList(
-                "[depends]",
-                "replacement",
-                "something-else"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dependent.mod"),
-            Arrays.asList(
-                "[depends]",
-                "alternate",
-                "[xml]",
-                "etc/dependent.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/original.mod"),
-            Arrays.asList(
-                "[ini]",
-                "impl=original"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/replacement.mod"),
-            Arrays.asList(
-                "[provides]",
-                "original",
-                "[ini]",
-                "impl=replacement"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/something-else.mod"),
-            Arrays.asList(
-                "[depends]",
-                "original"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateA.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateA.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateB.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateB.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/convenience.mod"),
+            """
+            [depends]
+            replacement
+            something-else
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dependent.mod"),
+            """
+            [depends]
+            alternate
+            [xml]
+            etc/dependent.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/original.mod"),
+            """
+            [ini]
+            impl=original
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/replacement.mod"),
+            """
+            [provides]
+            original
+            [ini]
+            impl=replacement
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/something-else.mod"),
+            """
+            [depends]
+            original
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=dependent,alternateA"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/alternateA.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/dependent.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.base}/etc/alternateA.xml"),
+            FS.separators("${jetty.base}/etc/dependent.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
@@ -196,60 +180,53 @@ public class OrderedTest extends AbstractUseCase
         FS.touch(baseDir.resolve("etc/alternateA.xml"));
         FS.touch(baseDir.resolve("etc/alternateB.xml"));
         FS.touch(baseDir.resolve("etc/dependent.xml"));
-        Files.write(baseDir.resolve("modules/alternateA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateA.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/alternateB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateB.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/convenience.mod"),
-            Arrays.asList(
-                "[depends]",
-                "replacement",
-                "something-else"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dependent.mod"),
-            Arrays.asList(
-                "[depends]",
-                "alternate",
-                "[xml]",
-                "etc/dependent.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/original.mod"),
-            Arrays.asList(
-                "[ini]",
-                "impl=original"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/replacement.mod"),
-            Arrays.asList(
-                "[provides]",
-                "original",
-                "[ini]",
-                "impl=replacement"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/something-else.mod"),
-            Arrays.asList(
-                "[depends]",
-                "original"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateA.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateA.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateB.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateB.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/convenience.mod"),
+            """
+            [depends]
+            replacement
+            something-else
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dependent.mod"),
+            """
+            [depends]
+            alternate
+            [xml]
+            etc/dependent.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/original.mod"),
+            """
+            [ini]
+            impl=original
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/replacement.mod"),
+            """
+            [provides]
+            original
+            [ini]
+            impl=replacement
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/something-else.mod"),
+            """
+            [depends]
+            original
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=dependent"
         );
         ExecResults results = exec(runArgs, false);
@@ -268,77 +245,70 @@ public class OrderedTest extends AbstractUseCase
         FS.touch(baseDir.resolve("etc/alternateA.xml"));
         FS.touch(baseDir.resolve("etc/alternateB.xml"));
         FS.touch(baseDir.resolve("etc/dependent.xml"));
-        Files.write(baseDir.resolve("modules/alternateA.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateA.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/alternateB.mod"),
-            Arrays.asList(
-                "[provides]",
-                "alternate",
-                "[xml]",
-                "etc/alternateB.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/convenience.mod"),
-            Arrays.asList(
-                "[depends]",
-                "replacement",
-                "something-else"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dependent.mod"),
-            Arrays.asList(
-                "[depends]",
-                "alternate",
-                "[xml]",
-                "etc/dependent.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/original.mod"),
-            Arrays.asList(
-                "[ini]",
-                "impl=original"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/replacement.mod"),
-            Arrays.asList(
-                "[provides]",
-                "original",
-                "[ini]",
-                "impl=replacement"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/something-else.mod"),
-            Arrays.asList(
-                "[depends]",
-                "original"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateA.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateA.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/alternateB.mod"),
+            """
+            [provides]
+            alternate
+            [xml]
+            etc/alternateB.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/convenience.mod"),
+            """
+            [depends]
+            replacement
+            something-else
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dependent.mod"),
+            """
+            [depends]
+            alternate
+            [xml]
+            etc/dependent.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/original.mod"),
+            """
+            [ini]
+            impl=original
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/replacement.mod"),
+            """
+            [provides]
+            original
+            [ini]
+            impl=replacement
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/something-else.mod"),
+            """
+            [depends]
+            original
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
-        List<String> runArgs = Collections.singletonList(
+        List<String> runArgs = List.of(
             "--modules=main,convenience"
         );
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -361,45 +331,41 @@ public class OrderedTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("etc"));
         FS.touch(baseDir.resolve("etc/implA.xml"));
         FS.touch(baseDir.resolve("etc/implB.xml"));
-        Files.write(baseDir.resolve("modules/abstractA.mod"),
-            Arrays.asList(
-                "[depend]",
-                "dynamic/${implA}",
-                "[ini]",
-                "implA=implA",
-                "[ini-template]",
-                "implA=implA"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/abstractB.mod"),
-            Arrays.asList(
-                "[depend]",
-                "dynamic/${implB}",
-                "[provide]",
-                "provided",
-                "[ini]",
-                "implB=implB",
-                "[ini-template]",
-                "implB=implB"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dynamic/implA.mod"),
-            Arrays.asList(
-                "[depend]",
-                "provided",
-                "[xml]",
-                "etc/implA.xml"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/dynamic/implB.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/implB.xml"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/abstractA.mod"),
+            """
+            [depend]
+            dynamic/${implA}
+            [ini]
+            implA=implA
+            [ini-template]
+            implA=implA
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/abstractB.mod"),
+            """
+            [depend]
+            dynamic/${implB}
+            [provide]
+            provided
+            [ini]
+            implB=implB
+            [ini-template]
+            implB=implB
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dynamic/implA.mod"),
+            """
+            [depend]
+            provided
+            [xml]
+            etc/implA.xml
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/dynamic/implB.mod"),
+            """
+            [xml]
+            etc/implB.xml
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "--add-modules=abstractB,abstractA"
@@ -411,9 +377,9 @@ public class OrderedTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.base}/etc/implB.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/implA.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.base}/etc/implB.xml"),
+            FS.separators("${jetty.base}/etc/implA.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
@@ -13,19 +13,17 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.PathAssert;
 import org.junit.jupiter.api.Test;
 
+import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -40,41 +38,38 @@ public class ParameterizedTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("etc"));
         FS.ensureDirExists(baseDir.resolve("start.d"));
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("etc/commands.txt"),
-            Arrays.asList(
-                "name0=changed0",
-                "name1=changed1",
-                "--add-modules=parameterized",
-                "# ignore this"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/parameterized.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "[ini]",
-                "name=value",
-                "name0?=default",
-                "name2?=two",
-                "[ini-template]",
-                "name0=value0",
-                "# name1=value1",
-                "# name2=too"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.d/tobeupdated.ini"),
-            Arrays.asList(
-                "#p=v",
-                "property=value",
-                "#comment",
-                "property0=value0",
-                "#comment",
-                "#property1=value1"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("etc/commands.txt"),
+            """
+            name0=changed0
+            name1=changed1
+            --add-modules=parameterized
+            # ignore this
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/parameterized.mod"),
+            """
+            [depend]
+            main
+            [ini]
+            name=value
+            name0?=default
+            name2?=two
+            [ini-template]
+            name0=value0
+            # name1=value1
+            # name2=too
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
+            """
+            #p=v
+            property=value
+            #comment
+            property0=value0
+            #comment
+            #property1=value1
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "other=value",
@@ -90,18 +85,18 @@ public class ParameterizedTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -119,7 +114,7 @@ public class ParameterizedTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertFileExists("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"));
+        assertThat("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"), isRegularFile());
     }
 
     @Test
@@ -130,41 +125,38 @@ public class ParameterizedTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("etc"));
         FS.ensureDirExists(baseDir.resolve("start.d"));
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("etc/commands.txt"),
-            Arrays.asList(
-                "name0=changed0",
-                "name1=changed1",
-                "--add-modules=parameterized",
-                "# ignore this"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/parameterized.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "[ini]",
-                "name=value",
-                "name0?=default",
-                "name2?=two",
-                "[ini-template]",
-                "name0=value0",
-                "# name1=value1",
-                "# name2=too"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.d/tobeupdated.ini"),
-            Arrays.asList(
-                "#p=v",
-                "property=value",
-                "#comment",
-                "property0=value0",
-                "#comment",
-                "#property1=value1"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("etc/commands.txt"),
+            """
+            name0=changed0
+            name1=changed1
+            --add-modules=parameterized
+            # ignore this
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/parameterized.mod"),
+            """
+            [depend]
+            main
+            [ini]
+            name=value
+            name0?=default
+            name2?=two
+            [ini-template]
+            name0=value0
+            # name1=value1
+            # name2=too
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
+            """
+            #p=v
+            property=value
+            #comment
+            property0=value0
+            #comment
+            #property1=value1
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "other=value",
@@ -178,18 +170,18 @@ public class ParameterizedTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -207,7 +199,7 @@ public class ParameterizedTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertFileExists("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"));
+        assertThat("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"), isRegularFile());
     }
 
     @Test
@@ -218,41 +210,38 @@ public class ParameterizedTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("etc"));
         FS.ensureDirExists(baseDir.resolve("start.d"));
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("etc/commands.txt"),
-            Arrays.asList(
-                "name0=changed0",
-                "name1=changed1",
-                "--add-modules=parameterized",
-                "# ignore this"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/parameterized.mod"),
-            Arrays.asList(
-                "[depend]",
-                "main",
-                "[ini]",
-                "name=value",
-                "name0?=default",
-                "name2?=two",
-                "[ini-template]",
-                "name0=value0",
-                "# name1=value1",
-                "# name2=too"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.d/tobeupdated.ini"),
-            Arrays.asList(
-                "#p=v",
-                "property=value",
-                "#comment",
-                "property0=value0",
-                "#comment",
-                "#property1=value1"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("etc/commands.txt"),
+            """
+            name0=changed0
+            name1=changed1
+            --add-modules=parameterized
+            # ignore this
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/parameterized.mod"),
+            """
+            [depend]
+            main
+            [ini]
+            name=value
+            name0?=default
+            name2?=two
+            [ini-template]
+            name0=value0
+            # name1=value1
+            # name2=too
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
+            """
+            #p=v
+            property=value
+            #comment
+            property0=value0
+            #comment
+            #property1=value1
+            """, StandardCharsets.UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--create-startd",
             "other=value",
@@ -272,18 +261,18 @@ public class ParameterizedTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -302,6 +291,6 @@ public class ParameterizedTest extends AbstractUseCase
         assertThat("Properties", actualProperties, containsInAnyOrder(expectedProperties.toArray()));
 
         // === Validate Specific Jetty Base Files/Dirs Exist
-        PathAssert.assertFileExists("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"));
+        assertThat("Required File: start.d/parameterized.ini", results.baseHome.getPath("start.d/parameterized.ini"), isRegularFile());
     }
 }

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/ParameterizedTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +22,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jetty.toolchain.test.PathMatchers.isRegularFile;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -44,7 +44,7 @@ public class ParameterizedTest extends AbstractUseCase
             name1=changed1
             --add-modules=parameterized
             # ignore this
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/parameterized.mod"),
             """
             [depend]
@@ -57,7 +57,7 @@ public class ParameterizedTest extends AbstractUseCase
             name0=value0
             # name1=value1
             # name2=too
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
             """
             #p=v
@@ -66,7 +66,7 @@ public class ParameterizedTest extends AbstractUseCase
             property0=value0
             #comment
             #property1=value1
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(
@@ -131,7 +131,7 @@ public class ParameterizedTest extends AbstractUseCase
             name1=changed1
             --add-modules=parameterized
             # ignore this
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/parameterized.mod"),
             """
             [depend]
@@ -144,7 +144,7 @@ public class ParameterizedTest extends AbstractUseCase
             name0=value0
             # name1=value1
             # name2=too
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
             """
             #p=v
@@ -153,7 +153,7 @@ public class ParameterizedTest extends AbstractUseCase
             property0=value0
             #comment
             #property1=value1
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(
@@ -216,7 +216,7 @@ public class ParameterizedTest extends AbstractUseCase
             name1=changed1
             --add-modules=parameterized
             # ignore this
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/parameterized.mod"),
             """
             [depend]
@@ -229,7 +229,7 @@ public class ParameterizedTest extends AbstractUseCase
             name0=value0
             # name1=value1
             # name2=too
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.d/tobeupdated.ini"),
             """
             #p=v
@@ -238,7 +238,7 @@ public class ParameterizedTest extends AbstractUseCase
             property0=value0
             #comment
             #property1=value1
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
         List<String> prepareArgs = List.of(

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,6 +22,7 @@ import org.eclipse.jetty.start.FS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.eclipse.jetty.toolchain.test.ExtraMatchers.ordered;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -46,7 +46,7 @@ public class PropertyOverrideTest extends AbstractUseCase
             main
             [ini-template]
             # jetty.sslContext.keyStorePassword=default
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("modules"));
 
@@ -56,13 +56,13 @@ public class PropertyOverrideTest extends AbstractUseCase
             ssl
             [ini]
             %s
-            """.formatted(propRef), StandardCharsets.UTF_8);
+            """.formatted(propRef), UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("start.d"));
         Files.writeString(baseDir.resolve("start.d/main.ini"),
             """
             --modules=ssl-ini
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> commandLine = List.of(
@@ -118,7 +118,7 @@ public class PropertyOverrideTest extends AbstractUseCase
             main
             [ini-template]
             # jetty.sslContext.keyStorePassword=default
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("modules"));
 
@@ -128,14 +128,14 @@ public class PropertyOverrideTest extends AbstractUseCase
             ssl
             [ini]
             %s
-            """.formatted(propRef), StandardCharsets.UTF_8);
+            """.formatted(propRef), UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("start.d"));
         Files.writeString(baseDir.resolve("start.d/main.ini"),
             """
             --modules=ssl-ini
             jetty.sslContext.keyStorePassword=storepwd
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> commandLine = List.of();

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/PropertyOverrideTest.java
@@ -13,17 +13,13 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jetty.start.FS;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -44,32 +40,29 @@ public class PropertyOverrideTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(homeDir.resolve("modules/ssl.mod"),
-            List.of(
-                "[depend]",
-                "main",
-                "[ini-template]",
-                "# jetty.sslContext.keyStorePassword=default"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(homeDir.resolve("modules/ssl.mod"),
+            """
+            [depend]
+            main
+            [ini-template]
+            # jetty.sslContext.keyStorePassword=default
+            """, StandardCharsets.UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("modules"));
 
-        Files.write(baseDir.resolve("modules/ssl-ini.mod"),
-            List.of(
-                "[depend]",
-                "ssl",
-                "[ini]",
-                propRef
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/ssl-ini.mod"),
+            """
+            [depend]
+            ssl
+            [ini]
+            %s
+            """.formatted(propRef), StandardCharsets.UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("start.d"));
-        Files.write(baseDir.resolve("start.d/main.ini"),
-            List.of(
-                "--modules=ssl-ini"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.d/main.ini"),
+            """
+            --modules=ssl-ini
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
         List<String> commandLine = List.of(
@@ -79,18 +72,18 @@ public class PropertyOverrideTest extends AbstractUseCase
         ExecResults results = exec(commandLine, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, ordered(expectedXmls));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, ordered(expectedLibs));
@@ -119,52 +112,48 @@ public class PropertyOverrideTest extends AbstractUseCase
     {
         setupStandardHomeDir();
 
-        Files.write(homeDir.resolve("modules/ssl.mod"),
-            List.of(
-                "[depend]",
-                "main",
-                "[ini-template]",
-                "# jetty.sslContext.keyStorePassword=default"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(homeDir.resolve("modules/ssl.mod"),
+            """
+            [depend]
+            main
+            [ini-template]
+            # jetty.sslContext.keyStorePassword=default
+            """, StandardCharsets.UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("modules"));
 
-        Files.write(baseDir.resolve("modules/ssl-ini.mod"),
-            List.of(
-                "[depend]",
-                "ssl",
-                "[ini]",
-                propRef
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/ssl-ini.mod"),
+            """
+            [depend]
+            ssl
+            [ini]
+            %s
+            """.formatted(propRef), StandardCharsets.UTF_8);
 
         FS.ensureDirectoryExists(baseDir.resolve("start.d"));
-        Files.write(baseDir.resolve("start.d/main.ini"),
-            List.of(
-                "--modules=ssl-ini",
-                // this should override mod default
-                "jetty.sslContext.keyStorePassword=storepwd"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.d/main.ini"),
+            """
+            --modules=ssl-ini
+            jetty.sslContext.keyStorePassword=storepwd
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
         List<String> commandLine = List.of();
         ExecResults results = exec(commandLine, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, ordered(expectedXmls));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, ordered(expectedLibs));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/TransientIniTemplateTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/TransientIniTemplateTest.java
@@ -13,12 +13,9 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -30,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -45,32 +43,29 @@ public class TransientIniTemplateTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("modules"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/t.xml"));
-        Files.write(baseDir.resolve("modules/direct.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[depend]",
-                "transient",
-                "[ini-template]",
-                "direct.option=direct"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/transient.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/t.xml",
-                "[optional]",
-                "main"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/direct.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [depend]
+            transient
+            [ini-template]
+            direct.option=direct
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/transient.mod"),
+            """
+            [xml]
+            etc/t.xml
+            [optional]
+            main
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=direct"
         );
@@ -81,20 +76,20 @@ public class TransientIniTemplateTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/t.xml"),
+            FS.separators("${jetty.base}/etc/d.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -117,36 +112,33 @@ public class TransientIniTemplateTest extends AbstractUseCase
         FS.ensureDirExists(baseDir.resolve("etc"));
         FS.touch(baseDir.resolve("etc/d.xml"));
         FS.touch(baseDir.resolve("etc/t.xml"));
-        Files.write(baseDir.resolve("modules/direct.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/d.xml",
-                "[depend]",
-                "transient",
-                "[ini-template]",
-                "direct.option=direct"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/transient.mod"),
-            Arrays.asList(
-                "[xml]",
-                "etc/t.xml",
-                "[optional]",
-                "main",
-                "[ini]",
-                "transient.option=transient",
-                "[ini-template]",
-                "transient.option=transient"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Collections.singletonList(
-                "--modules=main"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/direct.mod"),
+            """
+            [xml]
+            etc/d.xml
+            [depend]
+            transient
+            [ini-template]
+            direct.option=direct
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("modules/transient.mod"),
+            """
+            [xml]
+            etc/t.xml
+            [optional]
+            main
+            [ini]
+            transient.option=transient
+            [ini-template]
+            transient.option=transient
+            """, UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=direct"
         );
@@ -157,20 +149,20 @@ public class TransientIniTemplateTest extends AbstractUseCase
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/t.xml"),
+            FS.separators("${jetty.base}/etc/d.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));
@@ -201,7 +193,7 @@ public class TransientIniTemplateTest extends AbstractUseCase
                 transient
                 [ini-template]
                 direct.option=direct
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
         Files.writeString(baseDir.resolve("modules/transient.mod"),
             """
                 [xml]
@@ -210,10 +202,10 @@ public class TransientIniTemplateTest extends AbstractUseCase
                 main
                 [ini-template]
                 transient.option=transient
-                """, StandardCharsets.UTF_8);
+                """, UTF_8);
 
         // === Prepare Jetty Base using Main
-        List<String> prepareArgs = Arrays.asList(
+        List<String> prepareArgs = List.of(
             "--testing-mode",
             "--add-modules=direct"
         );
@@ -233,20 +225,20 @@ public class TransientIniTemplateTest extends AbstractUseCase
         assertThat("INI files", actualInis, contains(expectedInis));
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/t.xml".replace('/', File.separatorChar),
-            "${jetty.base}/etc/d.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml"),
+            FS.separators("${jetty.base}/etc/t.xml"),
+            FS.separators("${jetty.base}/etc/d.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
 import java.util.HashSet;
@@ -23,6 +22,7 @@ import java.util.Set;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -41,18 +41,18 @@ public class VersionedModulesTest extends AbstractUseCase
             9.3
             [ini]
             the-future=is-new
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("modules/old.mod"),
             """
             [defaults]
             from-module=old
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
         Files.writeString(baseDir.resolve("start.ini"),
             """
             --modules=main
             --modules=old
             --modules=new
-            """, StandardCharsets.UTF_8);
+            """, UTF_8);
 
         // === Execute Main
         List<String> runArgs = Collections.emptyList();

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/usecases/VersionedModulesTest.java
@@ -13,10 +13,8 @@
 
 package org.eclipse.jetty.start.usecases;
 
-import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -37,45 +35,42 @@ public class VersionedModulesTest extends AbstractUseCase
         setupStandardHomeDir();
 
         FS.ensureDirExists(baseDir.resolve("modules"));
-        Files.write(baseDir.resolve("modules/new.mod"),
-            Arrays.asList(
-                "[version]",
-                "9.3",
-                "[ini]",
-                "the-future=is-new"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("modules/old.mod"),
-            Arrays.asList(
-                "[defaults]",
-                "from-module=old"
-            ),
-            StandardCharsets.UTF_8);
-        Files.write(baseDir.resolve("start.ini"),
-            Arrays.asList(
-                "--modules=main",
-                "--modules=old",
-                "--modules=new"
-            ),
-            StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/new.mod"),
+            """
+            [version]
+            9.3
+            [ini]
+            the-future=is-new
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("modules/old.mod"),
+            """
+            [defaults]
+            from-module=old
+            """, StandardCharsets.UTF_8);
+        Files.writeString(baseDir.resolve("start.ini"),
+            """
+            --modules=main
+            --modules=old
+            --modules=new
+            """, StandardCharsets.UTF_8);
 
         // === Execute Main
         List<String> runArgs = Collections.emptyList();
         ExecResults results = exec(runArgs, false);
 
         // === Validate Resulting XMLs
-        List<String> expectedXmls = Arrays.asList(
-            "${jetty.home}/etc/base.xml".replace('/', File.separatorChar),
-            "${jetty.home}/etc/main.xml".replace('/', File.separatorChar)
+        List<String> expectedXmls = List.of(
+            FS.separators("${jetty.home}/etc/base.xml"),
+            FS.separators("${jetty.home}/etc/main.xml")
         );
         List<String> actualXmls = results.getXmls();
         assertThat("XML Resolution Order", actualXmls, contains(expectedXmls.toArray()));
 
         // === Validate Resulting LIBs
-        List<String> expectedLibs = Arrays.asList(
-            "${jetty.home}/lib/base.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/main.jar".replace('/', File.separatorChar),
-            "${jetty.home}/lib/other.jar".replace('/', File.separatorChar)
+        List<String> expectedLibs = List.of(
+            FS.separators("${jetty.home}/lib/base.jar"),
+            FS.separators("${jetty.home}/lib/main.jar"),
+            FS.separators("${jetty.home}/lib/other.jar")
         );
         List<String> actualLibs = results.getLibs();
         assertThat("Libs", actualLibs, containsInAnyOrder(expectedLibs.toArray()));

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/CorrectMavenCentralRefs.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/CorrectMavenCentralRefs.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.start.util;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -34,6 +33,8 @@ import org.eclipse.jetty.start.PathFinder;
 import org.eclipse.jetty.start.PathMatchers;
 import org.eclipse.jetty.start.Utils;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
  * Simple utility to scan all of the mod files and correct references
@@ -225,7 +226,7 @@ public class CorrectMavenCentralRefs
     {
         List<String> lines = new ArrayList<>();
 
-        try (BufferedReader reader = Files.newBufferedReader(path, StandardCharsets.UTF_8))
+        try (BufferedReader reader = Files.newBufferedReader(path, UTF_8))
         {
             String line;
             while ((line = reader.readLine()) != null)
@@ -239,7 +240,7 @@ public class CorrectMavenCentralRefs
 
     private void saveLines(Path path, List<String> lines) throws IOException
     {
-        try (BufferedWriter writer = Files.newBufferedWriter(path, StandardCharsets.UTF_8, StandardOpenOption.TRUNCATE_EXISTING))
+        try (BufferedWriter writer = Files.newBufferedWriter(path, UTF_8, StandardOpenOption.TRUNCATE_EXISTING))
         {
             for (String line : lines)
             {

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/CorrectMavenCentralRefs.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/CorrectMavenCentralRefs.java
@@ -33,7 +33,7 @@ import java.util.regex.Pattern;
 import org.eclipse.jetty.start.PathFinder;
 import org.eclipse.jetty.start.PathMatchers;
 import org.eclipse.jetty.start.Utils;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 
 /**
  * Simple utility to scan all of the mod files and correct references
@@ -43,7 +43,7 @@ public class CorrectMavenCentralRefs
 {
     public static void main(String[] args)
     {
-        Path buildRoot = MavenTestingUtils.getProjectDir("..").toPath();
+        Path buildRoot = MavenPaths.projectBase().resolve("../..");
         buildRoot = buildRoot.normalize().toAbsolutePath();
 
         // Test to make sure we are in right directory

--- a/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/RebuildTestResources.java
+++ b/jetty-core/jetty-start/src/test/java/org/eclipse/jetty/start/util/RebuildTestResources.java
@@ -13,7 +13,6 @@
 
 package org.eclipse.jetty.start.util;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.FileSystems;
@@ -24,7 +23,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.regex.Pattern;
 
 import org.eclipse.jetty.toolchain.test.FS;
-import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 
 /**
  * Utility class to rebuild the src/test/resources/dist-home from the active build tree.
@@ -38,8 +37,8 @@ public class RebuildTestResources
 
     public static void main(String[] args)
     {
-        File realDistHome = MavenTestingUtils.getProjectDir("../jetty-home/target/jetty-home");
-        File outputDir = MavenTestingUtils.getTestResourceDir("dist-home");
+        Path realDistHome = MavenPaths.projectBase().resolve("../jetty-home/target/jetty-home");
+        Path outputDir = MavenPaths.findTestResourceDir("dist-home");
         try
         {
             new RebuildTestResources(realDistHome, outputDir).rebuild();
@@ -114,10 +113,10 @@ public class RebuildTestResources
     private final Path destDir;
     private final Path srcDir;
 
-    public RebuildTestResources(File realDistHome, File outputDir) throws IOException
+    public RebuildTestResources(Path realDistHome, Path outputDir) throws IOException
     {
-        this.srcDir = realDistHome.toPath().toRealPath();
-        this.destDir = outputDir.toPath();
+        this.srcDir = realDistHome.toRealPath();
+        this.destDir = outputDir;
     }
 
     private void copyLibs() throws IOException


### PR DESCRIPTION
The `jetty-start` testing hasn't undergone a good cleaning since the Jetty 9.4.x days.
This is a general cleanup, with an eye on proper testing on MS Windows as well.