### PR TITLE
Changed `/jetty-ee/` Start Modules to use `[environment] <inherit>`

### DIFF
--- a/jetty-ee/jetty-ee-annotations/src/main/config/modules/ee-annotations.mod
+++ b/jetty-ee/jetty-ee-annotations/src/main/config/modules/ee-annotations.mod
@@ -4,7 +4,7 @@
 Enables Annotation scanning for deployed web applications.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 ee-plus

--- a/jetty-ee/jetty-ee-apache-jsp/src/main/config/modules/ee-apache-jsp.mod
+++ b/jetty-ee/jetty-ee-apache-jsp/src/main/config/modules/ee-apache-jsp.mod
@@ -4,7 +4,7 @@
 Enables use of the apache implementation of JSP.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 ee-servlet

--- a/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi-decorate.mod
+++ b/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi-decorate.mod
@@ -5,7 +5,7 @@ Configures Jetty to use the "CdiDecoratingListener" as the default CDI mode.
 This mode that allows a webapp to register it's own CDI decorator.
 
 [environment]
-ee
+<inherit>
 
 [tag]
 cdi

--- a/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi-spi.mod
+++ b/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi-spi.mod
@@ -5,7 +5,7 @@ Configures Jetty to use the "CdiSpiDecorator" as the default CDI mode.
 This mode uses the CDI SPI to integrate an arbitrary CDI implementation.
 
 [environment]
-ee
+<inherit>
 
 [tag]
 cdi

--- a/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi.mod
+++ b/jetty-ee/jetty-ee-cdi/src/main/config/modules/ee-cdi.mod
@@ -14,7 +14,7 @@ CdiDecoratingLister - The webapp may register a decorator on the context attribu
                       "org.eclipse.jetty.ee.cdi.decorator".
 
 [environment]
-ee
+<inherit>
 
 [tag]
 cdi

--- a/jetty-ee/jetty-ee-demos/jetty-ee-demo-jetty-websocket-webapp/src/main/config/modules/ee-demo-jetty-websocket.mod
+++ b/jetty-ee/jetty-ee-demos/jetty-ee-demo-jetty-websocket-webapp/src/main/config/modules/ee-demo-jetty-websocket.mod
@@ -4,7 +4,7 @@
 Demo Jetty WebSocket Webapp
 
 [environment]
-ee
+<inherit>
 
 [tags]
 demo

--- a/jetty-ee/jetty-ee-demos/jetty-ee-demo-proxy-webapp/src/main/config/modules/ee-demo-proxy.mod
+++ b/jetty-ee/jetty-ee-demos/jetty-ee-demo-proxy-webapp/src/main/config/modules/ee-demo-proxy.mod
@@ -4,7 +4,7 @@
 Demo Proxy Webapp
 
 [environment]
-ee
+<inherit>
 
 [tags]
 demo

--- a/jetty-ee/jetty-ee-fcgi-proxy/src/main/config/modules/ee-fcgi-proxy.mod
+++ b/jetty-ee/jetty-ee-fcgi-proxy/src/main/config/modules/ee-fcgi-proxy.mod
@@ -2,7 +2,7 @@
 Enables support for EECommon FastCGI proxying.
 
 [environment]
-ee
+<inherit>
 
 [tags]
 fcgi

--- a/jetty-ee/jetty-ee-glassfish-jstl/src/main/config/modules/ee-glassfish-jstl.mod
+++ b/jetty-ee/jetty-ee-glassfish-jstl/src/main/config/modules/ee-glassfish-jstl.mod
@@ -4,7 +4,7 @@
 Enables the glassfish version of JSTL for all webapps.
 
 [environment]
-ee
+<inherit>
 
 [depends]
 ee-apache-jsp

--- a/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi-default-auth-config-factory.mod
+++ b/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi-default-auth-config-factory.mod
@@ -4,7 +4,7 @@
 Provides a DefaultAuthConfigFactory for jaspi
 
 [environment]
-ee
+<inherit>
 
 [tags]
 security

--- a/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi-demo.mod
+++ b/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi-demo.mod
@@ -4,7 +4,7 @@
 Enables JASPI basic authentication the /test context path.
 
 [environment]
-ee
+<inherit>
 
 [tags]
 security

--- a/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi.mod
+++ b/jetty-ee/jetty-ee-jaspi/src/main/config/modules/ee-jaspi.mod
@@ -4,7 +4,7 @@
 Enables JASPI authentication for deployed web applications.
 
 [environment]
-ee
+<inherit>
 
 [tags]
 security

--- a/jetty-ee/jetty-ee-jndi/src/main/config/modules/ee-jndi.mod
+++ b/jetty-ee/jetty-ee-jndi/src/main/config/modules/ee-jndi.mod
@@ -4,7 +4,7 @@
 Adds the Jetty EECommon JNDI reference factories
 
 [environment]
-ee
+<inherit>
 
 [depend]
 jndi

--- a/jetty-ee/jetty-ee-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/src/base/modules/ee-testmod.mod
+++ b/jetty-ee/jetty-ee-maven-plugin/src/it/jetty-start-distro-mojo-it/jetty-simple-webapp/src/base/modules/ee-testmod.mod
@@ -4,7 +4,7 @@
 Enables test setup
 
 [environment]
-ee
+<inherit>
 
 [depend]
 http

--- a/jetty-ee/jetty-ee-maven-plugin/src/it/jetty-start-war-distro-mojo-it/jetty-simple-webapp/src/base/modules/ee-testmod.mod
+++ b/jetty-ee/jetty-ee-maven-plugin/src/it/jetty-start-war-distro-mojo-it/jetty-simple-webapp/src/base/modules/ee-testmod.mod
@@ -4,7 +4,7 @@
 Enables test setup
 
 [environment]
-ee
+<inherit>
 
 [depend]
 http

--- a/jetty-ee/jetty-ee-maven-plugin/src/main/resources/ee-maven.mod
+++ b/jetty-ee/jetty-ee-maven-plugin/src/main/resources/ee-maven.mod
@@ -4,7 +4,7 @@
 Enables an un-assembled Maven webapp to run in a Jetty distribution.
 
 [environment]
-ee
+<inherit>
 
 [depends]
 server

--- a/jetty-ee/jetty-ee-plus/src/main/config/modules/ee-plus.mod
+++ b/jetty-ee/jetty-ee-plus/src/main/config/modules/ee-plus.mod
@@ -2,7 +2,7 @@
 Enables Servlet resource injection. 
 
 [environment]
-ee
+<inherit>
 
 [depend]
 server

--- a/jetty-ee/jetty-ee-proxy/src/main/config/modules/ee-proxy.mod
+++ b/jetty-ee/jetty-ee-proxy/src/main/config/modules/ee-proxy.mod
@@ -4,7 +4,7 @@
 Enables the Jetty Proxy Servlet.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 client

--- a/jetty-ee/jetty-ee-quickstart/src/main/config/modules/ee-quickstart.mod
+++ b/jetty-ee/jetty-ee-quickstart/src/main/config/modules/ee-quickstart.mod
@@ -4,7 +4,7 @@
 Enables the Jetty Quickstart module for rapid deployment of preconfigured web applications.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 server

--- a/jetty-ee/jetty-ee-servlet/src/main/config/modules/ee-security.mod
+++ b/jetty-ee/jetty-ee-servlet/src/main/config/modules/ee-security.mod
@@ -4,7 +4,7 @@
 Adds servlet standard security handling to the classpath.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 server

--- a/jetty-ee/jetty-ee-servlet/src/main/config/modules/ee-servlet.mod
+++ b/jetty-ee/jetty-ee-servlet/src/main/config/modules/ee-servlet.mod
@@ -4,7 +4,7 @@
 Enables standard Servlet handling.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 server

--- a/jetty-ee/jetty-ee-servlets/src/main/config/modules/ee-servlets.mod
+++ b/jetty-ee/jetty-ee-servlets/src/main/config/modules/ee-servlets.mod
@@ -7,7 +7,7 @@ Puts org.eclipse.jetty.ee.servlets on the server classpath
 for use by all web applications.
 
 [environment]
-ee
+<inherit>
 
 [depend]
 ee-servlet

--- a/jetty-ee/jetty-ee-webapp/src/main/config/modules/ee-deploy.mod
+++ b/jetty-ee/jetty-ee-webapp/src/main/config/modules/ee-deploy.mod
@@ -5,7 +5,7 @@ Scans and deploys `ee` environment web applications.
 deployment
 
 [environment]
-ee
+<inherit>
 
 [before]
 ee10-deploy

--- a/jetty-ee/jetty-ee-webapp/src/main/config/modules/ee-webapp.mod
+++ b/jetty-ee/jetty-ee-webapp/src/main/config/modules/ee-webapp.mod
@@ -4,7 +4,6 @@
 This module enables support for Jakarta EE 11 web applications.
 
 [environment]
-ee
 
 [depend]
 ee-webapp

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-server/src/main/config/modules/ee-websocket-jakarta.mod
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-server/src/main/config/modules/ee-websocket-jakarta.mod
@@ -2,7 +2,7 @@
 Enable jakarta.websocket APIs for deployed web applications.
 
 [environment]
-ee
+<inherit>
 
 [tags]
 websocket

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-client-webapp/src/main/config/modules/ee-websocket-jetty-client-webapp.mod
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-client-webapp/src/main/config/modules/ee-websocket-jetty-client-webapp.mod
@@ -4,7 +4,7 @@
 Expose the Jetty WebSocket Client classes to deployed web applications.
 
 [environment]
-ee
+<inherit>
 
 [tags]
 websocket

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-server/src/main/config/modules/ee-websocket-jetty.mod
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-server/src/main/config/modules/ee-websocket-jetty.mod
@@ -5,7 +5,7 @@ Enable the Jetty WebSocket API support for deployed web applications.
 websocket
 
 [environment]
-ee
+<inherit>
 
 [depend]
 ee-annotations


### PR DESCRIPTION
Change to `/jetty-ee/` tree's Start Modules.

Now they all use ...

```
[environment]
<inherit>
```