### PR TITLE
Added module for OpenRewrite integration

### DIFF
--- a/jetty-integrations/jetty-openrewrite/pom.xml
+++ b/jetty-integrations/jetty-openrewrite/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.eclipse.jetty</groupId>
+    <artifactId>jetty-integrations</artifactId>
+    <version>13.0.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-openrewrite</artifactId>
+  <name>Integrations :: OpenRewrite</name>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.openrewrite.recipe</groupId>
+        <artifactId>rewrite-recipe-bom</artifactId>
+        <version>3.28.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.openrewrite</groupId>
+      <artifactId>rewrite-yaml</artifactId>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/EnterpriseEditionMigration.yaml
+++ b/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/EnterpriseEditionMigration.yaml
@@ -1,0 +1,27 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.eclipse.jetty.EnterpriseEditionMigration
+displayName: Migrate to common EnterpriseEdition
+description: |
+  Migrate applications using EExx names in Java and XML to the new common EE implementation.
+tags:
+  - jetty
+recipeList:
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.eclipse.jetty.ee11
+      newPackageName: org.eclipse.jetty.ee
+      recursive: true
+  - org.openrewrite.text.FindAndReplace:
+      find: org.eclipse.jetty.ee11
+      replace: org.eclipse.jetty.ee
+      regex: false
+      filePattern: "**/!(pom).xml;"
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.eclipse.jetty.ee10
+      newPackageName: org.eclipse.jetty.ee
+      recursive: true
+  - org.openrewrite.text.FindAndReplace:
+      find: org.eclipse.jetty.ee10
+      replace: org.eclipse.jetty.ee
+      regex: false
+      filePattern: "**/!(pom).xml;"

--- a/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/Jetty12to13Migration.yaml
+++ b/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/Jetty12to13Migration.yaml
@@ -1,0 +1,15 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.eclipse.jetty.Jetty12to13Migration
+displayName: Migrate to Jetty 13 from 12
+description: |
+  Migrate applications built on Jetty 12 to the latest Jetty 13 release.
+tags:
+  - jetty
+recipeList:
+  - org.eclipse.jetty.MovedClassesMigration
+  - org.eclipse.jetty.EnterpriseEditionMigration
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.eclipse.jetty*
+      artifactId: jetty*
+      newVersion: 13.X

--- a/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/MovedClassesMigration.yaml
+++ b/jetty-integrations/jetty-openrewrite/src/main/resources/META-INF/rewrite/MovedClassesMigration.yaml
@@ -1,0 +1,15 @@
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.eclipse.jetty.MovedClassesMigration
+displayName: Migrate moved classes
+description: |
+  Migrate applications using classes which have moved to new packages.
+tags:
+  - jetty
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.eclipse.jetty.ee.webapp.WebAppClassLoading
+      newFullyQualifiedTypeName: org.eclipse.jetty.ee.common.WebAppClassLoading
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.eclipse.jetty.ee.webapp.WebAppClassLoader
+      newFullyQualifiedTypeName: org.eclipse.jetty.ee.common.WebAppClassLoader

--- a/jetty-integrations/pom.xml
+++ b/jetty-integrations/pom.xml
@@ -19,6 +19,7 @@
     <module>jetty-infinispan</module>
     <module>jetty-memcached</module>
     <module>jetty-nosql</module>
+    <module>jetty-openrewrite</module>
   </modules>
 
 </project>


### PR DESCRIPTION
This PR adds a module that integrates with OpenRewrite. The first rules added support Jetty 12 to 13 migration, including package changes (deprecation of eexx style packages) and move of some classes from ee.webapp to ee.common package.
