### PR TITLE
Issue #14745 - fix race for double call of HttpChannelState.completeStream

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -627,6 +627,16 @@ public class HttpChannelState implements HttpChannel, Components
 
     private void completeStream(HttpStream stream, Throwable failure)
     {
+        ChannelRequest request;
+        ChannelResponse response;
+        long oldIdleTimeout;
+        try (AutoLock ignored = _lock.lock())
+        {
+            request = _request;
+            response = _response;
+            oldIdleTimeout = _oldIdleTimeout;
+        }
+
         try
         {
             RequestLog requestLog = getServer().getRequestLog();
@@ -634,24 +644,23 @@ public class HttpChannelState implements HttpChannel, Components
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("logging {}", HttpChannelState.this);
-
-                requestLog.log(_request.getLoggedRequest(), _response);
+                requestLog.log(request.getLoggedRequest(), response);
             }
 
             // Clean up any multipart tmp files and release any associated resources.
-            MultiPartFormData.Parts parts = MultiPartFormData.getParts(_request);
+            MultiPartFormData.Parts parts = MultiPartFormData.getParts(request);
             if (parts != null)
                 parts.close();
 
             long idleTO = getHttpConfiguration().getIdleTimeout();
-            if (idleTO > 0 && _oldIdleTimeout != idleTO)
-                stream.setIdleTimeout(_oldIdleTimeout);
+            if (idleTO > 0 && oldIdleTimeout != idleTO)
+                stream.setIdleTimeout(oldIdleTimeout);
         }
         finally
         {
             ComplianceViolation.Listener listener = getComplianceViolationListener();
             if (listener != null)
-                listener.onRequestEnd(_request);
+                listener.onRequestEnd(request);
 
             // This is THE ONLY PLACE the stream is succeeded or failed.
             if (failure == null)
@@ -1361,7 +1370,8 @@ public class HttpChannelState implements HttpChannel, Components
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
-                httpChannel.lockedStreamSendCompleted(true);
+                if (!(callback instanceof LastWriteCallback))
+                    httpChannel.lockedStreamSendCompleted(true);
             }
             if (callback != null)
                 httpChannel._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
@@ -1390,7 +1400,8 @@ public class HttpChannelState implements HttpChannel, Components
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
-                httpChannel.lockedStreamSendCompleted(false);
+                if (!(callback instanceof LastWriteCallback))
+                    httpChannel.lockedStreamSendCompleted(false);
             }
             if (callback != null)
                 httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
@@ -1787,7 +1798,7 @@ public class HttpChannelState implements HttpChannel, Components
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("ErrorWrite succeeded: {}", this);
-            boolean needLastWrite;
+            boolean needLastWrite = false;
             MetaData.Response responseMetaData = null;
             HttpChannelState httpChannelState;
             Throwable failure;
@@ -1797,7 +1808,11 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = _failure;
 
                 // Did the ErrorHandler do the last write?
-                needLastWrite = httpChannelState.lockedLastStreamSend();
+                if (httpChannelState._streamSendState == StreamSendState.SENDING)
+                {
+                    needLastWrite = true;
+                    httpChannelState._streamSendState = StreamSendState.LAST_SENDING;
+                }
                 if (needLastWrite && _errorResponse.getResponseHttpFields().commit())
                     responseMetaData = _errorResponse.lockedPrepareResponse(httpChannelState, true);
             }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -1798,7 +1798,7 @@ public class HttpChannelState implements HttpChannel, Components
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("ErrorWrite succeeded: {}", this);
-            boolean needLastWrite = false;
+            boolean needLastWrite;
             MetaData.Response responseMetaData = null;
             HttpChannelState httpChannelState;
             Throwable failure;
@@ -1808,11 +1808,7 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = _failure;
 
                 // Did the ErrorHandler do the last write?
-                if (httpChannelState._streamSendState == StreamSendState.SENDING)
-                {
-                    needLastWrite = true;
-                    httpChannelState._streamSendState = StreamSendState.LAST_SENDING;
-                }
+                needLastWrite = httpChannelState.lockedLastStreamSend();
                 if (needLastWrite && _errorResponse.getResponseHttpFields().commit())
                     responseMetaData = _errorResponse.lockedPrepareResponse(httpChannelState, true);
             }


### PR DESCRIPTION
## Closes #14745


There is a race where `HttpChannelState.completeStream()` can be called twice in certain cases. This can result in NPE as the first call `completeStream()` will recycle the `HttpChannelState`.

I managed to reproduce this sequence of events, but only with carefully placed `Thread.sleep()` calls throughout the code. I don't think writing a test case to reproduce this would currently be possible.

1. **Thread A**: The handler completes the `ChannelCallback`, this triggers a write with `LastWriteCallback`.
1. **Thread B**: The last write completes and`ChannelResponse.succeeded()` sets `_streamSendState=LAST_COMPLETE`.
1. **Thread A**: The handler exits and then the `HandlerInvoker` enters the lock, it sees the callback was completed and `_streamSendState==LAST_COMPLETE`, so decides to call `completeStream()` when the lock exits.
1. **Thread B**: `LastWriteCallback#completeLastWrite` enters the lock and sees that the handler has exited, so it decides to call `completeStream()` after the lock exits.
1. **Thread A**: `HandlerInvoker` calls `completeStream()` which does `recycle()`, so now `_request` is null.
1. **Thread B**: `LastWriteCallback` calls `completeStream()` and gets a NPE trying to clean up multipart with a null request.


The simplest fix is to only transition to state `StreamSendState.LAST_COMPLETE` in the `LastWriteCallback` (if there is a `LastWriteCallback`). 

This way we eliminate the window where both `LastWriteCallback` and `HandlerInvoker` can decide to call `HttpChannelState.completeStream()`.
