### PR TITLE
Disable or fix tests that fail on Windows

### DIFF
--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerMultipleResourceTest.java
@@ -32,10 +32,13 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class AliasCheckerMultipleResourceTest extends AliasCheckerTestBase
 {
     private final List<Path> _toDelete = new ArrayList<>();

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/AliasCheckerSymlinkTest.java
@@ -36,6 +36,8 @@ import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -45,6 +47,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
+@DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
 public class AliasCheckerSymlinkTest extends AliasCheckerTestBase
 {
     private static Server _server;

--- a/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
+++ b/tests/test-integration/src/test/java/org/eclipse/jetty/test/CoreMultiPartTest.java
@@ -66,6 +66,8 @@ import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
@@ -360,6 +362,7 @@ public class CoreMultiPartTest
     }
 
     @Test
+    @DisabledOnOs(value = OS.WINDOWS, disabledReason = "Fails on Windows")
     public void testTempFilesDeletedOnError() throws Exception
     {
         byte[] bytes = new byte[2 * MAX_FILE_SIZE];
@@ -567,8 +570,8 @@ public class CoreMultiPartTest
             .send();
 
         assertEquals(200, response.getStatus());
-        assertThat(response.getContentAsString(), containsString("Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog\n" +
-            "Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog"));
+        assertThat(response.getContentAsString(), containsString(("Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog\n" +
+            "Part: name=myPart, size=88, content=the quick brown fox jumps over the lazy dog, the quick brown fox jumps over the lazy dog").replace("\n", System.lineSeparator())));
     }
 
     @Test


### PR DESCRIPTION
Fixes symlink creation and line separator issues in tests when running on Windows.