### PR TITLE
Fixes #14564 - Jetty 12.1.x TLS connections hang after several requests

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/NegotiatingClientConnection.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.Promise;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class NegotiatingClientConnection extends AbstractConnection.NonBlocking
+public abstract class NegotiatingClientConnection extends AbstractConnection
 {
     private static final Logger LOG = LoggerFactory.getLogger(NegotiatingClientConnection.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/DetectorConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/DetectorConnectionFactory.java
@@ -137,7 +137,7 @@ public class DetectorConnectionFactory extends AbstractConnectionFactory impleme
         return configure(new DetectorConnection(endPoint, connector), connector, endPoint);
     }
 
-    private class DetectorConnection extends AbstractConnection.NonBlocking implements Connection.UpgradeFrom, Connection.UpgradeTo
+    private class DetectorConnection extends AbstractConnection implements Connection.UpgradeFrom, Connection.UpgradeTo
     {
         private final Connector _connector;
         private final RetainableByteBuffer _buffer;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NegotiatingServerConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/NegotiatingServerConnection.java
@@ -25,7 +25,7 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public abstract class NegotiatingServerConnection extends AbstractConnection.NonBlocking
+public abstract class NegotiatingServerConnection extends AbstractConnection
 {
     private static final Logger LOG = LoggerFactory.getLogger(NegotiatingServerConnection.class);
 

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ProxyConnectionFactory.java
@@ -137,7 +137,7 @@ public class ProxyConnectionFactory extends DetectorConnectionFactory
             return configure(new ProxyProtocolV1Connection(endp, connector, nextConnectionFactory), connector, endp);
         }
 
-        private static class ProxyProtocolV1Connection extends AbstractConnection.NonBlocking implements Connection.UpgradeFrom, Connection.UpgradeTo
+        private static class ProxyProtocolV1Connection extends AbstractConnection implements Connection.UpgradeFrom, Connection.UpgradeTo
         {
             // 0     1 2       3       4 5 6
             // 98765432109876543210987654321
@@ -452,7 +452,7 @@ public class ProxyConnectionFactory extends DetectorConnectionFactory
             return configure(new ProxyProtocolV2Connection(endp, connector, nextConnectionFactory), connector, endp);
         }
 
-        private class ProxyProtocolV2Connection extends AbstractConnection.NonBlocking implements Connection.UpgradeFrom, Connection.UpgradeTo
+        private class ProxyProtocolV2Connection extends AbstractConnection implements Connection.UpgradeFrom, Connection.UpgradeTo
         {
             private static final int HEADER_LENGTH = 16;
 


### PR DESCRIPTION
Fixed connections that are upgrading to other connections to be blocking.

This is necessary for this case:
* Connection A is non-blocking.
* Connection A reads some bytes but not enough to perform the upgrade, so it register itself as read-interested with a non-blocking callback.
* When more data is available, NIO invokes the non-blocking callback in PC mode.
* Connection A reads and it is able to perform the upgrade.
* The upgrade() path is the following: `EndPoint.upgrade()` -> `ConnectionB.onOpen()`.
* Certain ConnectionBs (for example HTTP/2) start production from `onOpen()`, which may produce a blocking task, which may be run in EPC mode.
* Now we have the original thread (coming from NIO thinking to run a PC task) that is blocked in a blocking task run in EPC mode.

The solution is to make the connections that upgrade to other connections blocking by default.