### PR TITLE
Issue #14745 - Use CompletableFuture in HttpChannelState to invoke completeStream

### DIFF
--- a/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
+++ b/jetty-core/jetty-fcgi/jetty-fcgi-server/src/main/java/org/eclipse/jetty/fcgi/server/internal/ServerFCGIConnection.java
@@ -335,6 +335,7 @@ public class ServerFCGIConnection extends AbstractMetaDataConnection implements 
             if (stream != null)
                 throw new UnsupportedOperationException("FastCGI Multiplexing");
             HttpChannel channel = httpChannelFactory.newHttpChannel(ServerFCGIConnection.this);
+            channel.initialize();
             ServerGenerator generator = new ServerGenerator(connector.getByteBufferPool(), isUseOutputDirectByteBuffers(), sendStatus200);
             stream = new HttpStreamOverFCGI(ServerFCGIConnection.this, generator, channel, request);
             channel.setHttpStream(stream);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
@@ -128,6 +129,9 @@ public class HttpChannelState implements HttpChannel, Components
     private Attributes _cache;
     private boolean _expects100Continue;
     private ComplianceViolation.Listener _complianceViolationListener;
+    private CompletableFuture<Void> _lastWriteComplete;
+    private CompletableFuture<Void> _handlerComplete;
+    private CompletableFuture<Void> _callbackComplete;
 
     public HttpChannelState(ConnectionMetaData connectionMetaData)
     {
@@ -147,6 +151,17 @@ public class HttpChannelState implements HttpChannel, Components
             case 1 -> listeners.get(0).initialize();
             default -> new InitializedCompositeComplianceViolationListener(listeners);
         };
+
+        _lastWriteComplete = new CompletableFuture<>();
+        _handlerComplete = new CompletableFuture<>();
+        _callbackComplete = new CompletableFuture<>();
+        CompletableFuture.allOf(_lastWriteComplete, _handlerComplete, _callbackComplete)
+            .whenComplete((ignored, failure) ->
+            {
+                if (failure instanceof CompletionException && failure.getCause() != null)
+                    failure = failure.getCause();
+                completeStream(failure);
+            });
     }
 
     @Override
@@ -186,6 +201,9 @@ public class HttpChannelState implements HttpChannel, Components
             _callbackFailure = null;
             _expects100Continue = false;
             _complianceViolationListener = null;
+            _callbackComplete = null;
+            _handlerComplete = null;
+            _lastWriteComplete = null;
         }
     }
 
@@ -433,6 +451,7 @@ public class HttpChannelState implements HttpChannel, Components
     {
         HttpStream stream;
         Runnable task;
+        boolean completeHandler = false;
         try (AutoLock ignored = _lock.lock())
         {
             if (LOG.isDebugEnabled())
@@ -459,6 +478,7 @@ public class HttpChannelState implements HttpChannel, Components
                     LOG.debug("failing request not yet handled {} {}", _request, this);
                 Callback callback = _request._callback;
                 task = () -> callback.failed(x);
+                completeHandler = true;
             }
             else
             {
@@ -506,6 +526,9 @@ public class HttpChannelState implements HttpChannel, Components
         Throwable unconsumed = stream.consumeAvailable();
         if (unconsumed != null && LOG.isDebugEnabled())
             LOG.debug("consuming content during error {}", unconsumed.toString());
+
+        if (completeHandler)
+            _handlerComplete.completeExceptionally(x);
 
         return task;
     }
@@ -580,15 +603,23 @@ public class HttpChannelState implements HttpChannel, Components
                 ? new IllegalStateException("last already written")
                 : NOTHING_TO_SEND;
 
-            case FAILED -> null;
+            case FAILED -> new IllegalStateException("callback failed", _callbackFailure);
         };
     }
 
-    private void lockedStreamSendCompleted(boolean success)
+    /**
+     * @return true if the {@link #_lastWriteComplete} notification should be triggered.
+     */
+    private boolean lockedStreamSendCompleted(boolean success)
     {
         assert _lock.isHeldByCurrentThread();
         if (_streamSendState == StreamSendState.LAST_SENDING)
+        {
             _streamSendState = success ? StreamSendState.LAST_COMPLETE : StreamSendState.SENDING;
+            return success;
+        }
+
+        return false;
     }
 
     private boolean lockedIsLastStreamSendCompleted()
@@ -625,8 +656,20 @@ public class HttpChannelState implements HttpChannel, Components
         }
     }
 
-    private void completeStream(HttpStream stream, Throwable failure)
+    private void completeStream(Throwable failure)
     {
+        HttpStream stream;
+        ChannelRequest request;
+        ChannelResponse response;
+        long oldIdleTimeout;
+        try (AutoLock ignored = _lock.lock())
+        {
+            stream = _stream;
+            request = _request;
+            response = _response;
+            oldIdleTimeout = _oldIdleTimeout;
+        }
+
         try
         {
             RequestLog requestLog = getServer().getRequestLog();
@@ -635,23 +678,23 @@ public class HttpChannelState implements HttpChannel, Components
                 if (LOG.isDebugEnabled())
                     LOG.debug("logging {}", HttpChannelState.this);
 
-                requestLog.log(_request.getLoggedRequest(), _response);
+                requestLog.log(request.getLoggedRequest(), response);
             }
 
             // Clean up any multipart tmp files and release any associated resources.
-            MultiPartFormData.Parts parts = MultiPartFormData.getParts(_request);
+            MultiPartFormData.Parts parts = MultiPartFormData.getParts(request);
             if (parts != null)
                 parts.close();
 
             long idleTO = getHttpConfiguration().getIdleTimeout();
-            if (idleTO > 0 && _oldIdleTimeout != idleTO)
-                stream.setIdleTimeout(_oldIdleTimeout);
+            if (idleTO > 0 && oldIdleTimeout != idleTO)
+                stream.setIdleTimeout(oldIdleTimeout);
         }
         finally
         {
             ComplianceViolation.Listener listener = getComplianceViolationListener();
             if (listener != null)
-                listener.onRequestEnd(_request);
+                listener.onRequestEnd(request);
 
             // This is THE ONLY PLACE the stream is succeeded or failed.
             if (failure == null)
@@ -726,35 +769,20 @@ public class HttpChannelState implements HttpChannel, Components
                 request._callback.failed(t);
             }
 
-            HttpStream stream;
             Throwable failure;
-            boolean completeStream;
-            boolean callbackCompleted;
-            boolean lastStreamSendComplete;
-
             try (AutoLock ignored = _lock.lock())
             {
-                stream = _stream;
                 _handling = null;
                 _handled = true;
                 failure = _callbackFailure;
-                callbackCompleted = _callbackCompleted;
-                lastStreamSendComplete = lockedIsLastStreamSendCompleted();
-                completeStream = callbackCompleted && lastStreamSendComplete;
-
                 if (LOG.isDebugEnabled())
-                    LOG.debug("handler invoked: completeStream={} failure={} callbackCompleted={} {}", completeStream, failure, callbackCompleted, HttpChannelState.this);
+                    LOG.debug("handler invoked: stream={}, failure={}, callbackCompleted={} {}", _stream, failure, _callbackCompleted, HttpChannelState.this);
             }
 
-            if (LOG.isDebugEnabled())
-                LOG.debug("stream={}, failure={}, callbackCompleted={}, completeStream={}", stream, failure, callbackCompleted, completeStream);
-
-            if (completeStream)
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("completeStream({}, {})", stream, Objects.toString(failure));
-                completeStream(stream, failure);
-            }
+            if (failure == null)
+                HttpChannelState.this._handlerComplete.complete(null);
+            else
+                HttpChannelState.this._handlerComplete.completeExceptionally(failure);
         }
 
         @Override
@@ -786,18 +814,17 @@ public class HttpChannelState implements HttpChannel, Components
 
         private void completeLastWrite(Throwable failure)
         {
-            HttpStream stream;
-            boolean completeStream;
             try (AutoLock ignored = _lock.lock())
             {
                 assert _callbackCompleted;
-                _streamSendState = StreamSendState.LAST_COMPLETE;
-                completeStream = _handling == null; // if we have not handled yet or have completed handling
-                stream = _stream;
+                _streamSendState = failure == null ? StreamSendState.LAST_COMPLETE : StreamSendState.FAILED;
                 failure = _callbackFailure = ExceptionUtil.combine(_callbackFailure, failure);
             }
-            if (completeStream)
-                completeStream(stream, failure);
+
+            if (failure == null)
+                _lastWriteComplete.complete(null);
+            else
+                _lastWriteComplete.completeExceptionally(failure);
         }
 
         @Override
@@ -1356,15 +1383,18 @@ public class HttpChannelState implements HttpChannel, Components
                 LOG.debug("write succeeded {}", this);
             Callback callback;
             HttpChannelState httpChannel;
+            boolean lastWriteComplete;
             try (AutoLock ignored = _request._lock.lock())
             {
                 callback = _writeCallback;
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
-                httpChannel.lockedStreamSendCompleted(true);
+                lastWriteComplete = httpChannel.lockedStreamSendCompleted(true) && callback != httpChannel._lastWriteCallback;
             }
             if (callback != null)
                 httpChannel._writeInvoker.run(new ReadyTask(callback.getInvocationType(), callback::succeeded));
+            if (lastWriteComplete)
+                httpChannel._lastWriteComplete.complete(null);
         }
 
         /**
@@ -1384,6 +1414,7 @@ public class HttpChannelState implements HttpChannel, Components
                 LOG.debug("write failed {}", this, x);
             Callback callback;
             HttpChannelState httpChannel;
+            boolean lastWriteComplete;
             try (AutoLock ignored = _request._lock.lock())
             {
                 _writeFailure = x;
@@ -1391,9 +1422,12 @@ public class HttpChannelState implements HttpChannel, Components
                 _writeCallback = null;
                 httpChannel = _request.lockedGetHttpChannelState();
                 httpChannel.lockedStreamSendCompleted(false);
+                lastWriteComplete = httpChannel.lockedStreamSendCompleted(true)  && callback != httpChannel._lastWriteCallback;
             }
             if (callback != null)
                 httpChannel._writeInvoker.run(() -> HttpChannelState.failed(callback, x));
+            if (lastWriteComplete)
+                httpChannel._lastWriteComplete.completeExceptionally(x);
         }
 
         @Override
@@ -1551,9 +1585,9 @@ public class HttpChannelState implements HttpChannel, Components
             ChannelRequest request;
             ChannelResponse response;
             MetaData.Response responseMetaData = null;
-            boolean completeStream = false;
             ErrorResponse errorResponse = null;
             Callback failedCallback = null;
+            Throwable failLastWrite = null;
 
             try (AutoLock ignored = _request._lock.lock())
             {
@@ -1605,70 +1639,58 @@ public class HttpChannelState implements HttpChannel, Components
                         failure = ExceptionUtil.combine(failure, new IOException("content-length %d != %d written".formatted(committedContentLength, totalWritten)));
                 }
 
-                // If we are still not failing, is a last stream send needed or can we complete?
                 if (failure == null)
                 {
-                    doLastStreamSend = httpChannelState.lockedLastStreamSend();
-                    if (doLastStreamSend)
-                        response._writeCallback = httpChannelState._lastWriteCallback;
-                    // or complete the stream if everything is done.
-                    else if (httpChannelState.lockedIsLastStreamSendCompleted())
-                        completeStream = httpChannelState._handled;
+                    switch (httpChannelState._streamSendState)
+                    {
+                        case SENDING ->
+                        {
+                            // We should send the last write.
+                            doLastStreamSend = true;
+                            httpChannelState._streamSendState = StreamSendState.LAST_SENDING;
+                            response._writeCallback = httpChannelState._lastWriteCallback;
+                        }
+                        case LAST_SENDING ->
+                        {
+                            // Last write is sending, so ensure the LastWriteCallback after it is completed after.
+                            response._writeCallback = Callback.from(response._writeCallback, httpChannelState._lastWriteCallback);
+                        }
+                    }
                 }
                 else
                 {
-                    // We are failing...
+                    // We are failing.
                     httpChannelState._callbackFailure = failure;
 
-                    // Can we and should we generate an error response?
-                    if (!stream.isCommitted() && !ExceptionUtil.hasAssociated(failure, Request.Handler.AbortException.class))
+                    // We must ensure the last stream send is completed.
+                    if (!httpChannelState.lockedIsLastStreamSendCompleted())
                     {
-                        // We are not committed, so we can send an error response.
-                        errorResponse = new ErrorResponse(request);
-                    }
-                    else if (httpChannelState._handled)
-                    {
-                        // Callback and handling are completed, so it is just a matter of the last write
-                        if (httpChannelState.lockedIsLastStreamSendCompleted())
+                        if (!stream.isCommitted() && !ExceptionUtil.hasAssociated(failure, Request.Handler.AbortException.class))
                         {
-                            // We are committed, handling completed, and last write completed, so complete the stream now.
-                            completeStream = true;
-                        }
-                        else if (response.lockedIsWriting())
-                        {
-                            // We are currently writing so fail the app callback now and let the write completion handle the failure
-                            Runnable task = response.lockedFailWrite(failure);
-                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
+                            // We are not committed, so we can send an error response.
+                            errorResponse = new ErrorResponse(request);
                         }
                         else
                         {
-                            // There has been no last write, but we will just fail the stream instead.
-                            httpChannelState._streamSendState = StreamSendState.FAILED;
-                            completeStream = true;
-                        }
-                    }
-                    else
-                    {
-                        // We are still handling, so for the most part let the HandlerInvoker deal with completion
-
-                        // But if we are writing
-                        if (response.lockedIsWriting())
-                        {
-                            // We are currently writing so fail the app callback now and let the write completion handle the failure
-                            Runnable task = response.lockedFailWrite(failure);
-                            failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
-                        }
-                        else if (!httpChannelState.lockedIsLastStreamSendCompleted())
-                        {
-                            // last write it is not going to happen after failure, so we can just fail anyway
-                            httpChannelState._streamSendState = StreamSendState.FAILED;
+                            if (response.lockedIsWriting())
+                            {
+                                // We are currently writing so fail the app callback now and let the write completion handle the failure.
+                                Runnable task = response.lockedFailWrite(failure);
+                                failedCallback = Callback.from(task, httpChannelState._lastWriteCallback);
+                            }
+                            else
+                            {
+                                // Manually set the stream state to failed and fail the last write CompletableFuture.
+                                httpChannelState._streamSendState = StreamSendState.FAILED;
+                                failLastWrite = failure;
+                            }
                         }
                     }
                 }
             }
 
             if (LOG.isDebugEnabled())
-                LOG.debug("succeeded: failure={} doLastStreamSend={} {}", failure, doLastStreamSend, this);
+                LOG.debug("succeeded: failure={} doLastStreamSend={}, failedCallback={}, errorResponse={}{}", failure, doLastStreamSend, failedCallback, errorResponse, this);
 
             if (failedCallback != null)
                 failedCallback.failed(Objects.requireNonNullElseGet(failure, IOException::new));
@@ -1676,10 +1698,15 @@ public class HttpChannelState implements HttpChannel, Components
                 Response.writeError(request, errorResponse, new ErrorCallback(request, errorResponse, stream, failure), failure);
             else if (doLastStreamSend)
                 stream.send(_request._metaData, responseMetaData, true, null, response);
-            else if (completeStream)
-                httpChannelState.completeStream(stream, failure);
+            else if (failLastWrite != null)
+                httpChannelState._lastWriteComplete.completeExceptionally(failLastWrite);
             else if (LOG.isDebugEnabled())
                 LOG.debug("No action on succeeded {}", this);
+
+            if (failure == null)
+                httpChannelState._callbackComplete.complete(null);
+            else
+                httpChannelState._callbackComplete.completeExceptionally(failure);
         }
 
         private boolean lockedCompleteCallback()
@@ -1787,7 +1814,8 @@ public class HttpChannelState implements HttpChannel, Components
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("ErrorWrite succeeded: {}", this);
-            boolean needLastWrite;
+            boolean needLastWrite = false;
+            boolean completeLastWrite = false;
             MetaData.Response responseMetaData = null;
             HttpChannelState httpChannelState;
             Throwable failure;
@@ -1797,7 +1825,25 @@ public class HttpChannelState implements HttpChannel, Components
                 failure = _failure;
 
                 // Did the ErrorHandler do the last write?
-                needLastWrite = httpChannelState.lockedLastStreamSend();
+                switch (httpChannelState._streamSendState)
+                {
+                    case SENDING ->
+                    {
+                        // Last write still needs to be sent.
+                        needLastWrite = true;
+                    }
+                    case LAST_SENDING ->
+                    {
+                        // We are the completion of the last write.
+                        httpChannelState._streamSendState = StreamSendState.LAST_COMPLETE;
+                        completeLastWrite = true;
+                    }
+                    case FAILED, LAST_COMPLETE ->
+                    {
+                        // Nothing to do.
+                    }
+                }
+
                 if (needLastWrite && _errorResponse.getResponseHttpFields().commit())
                     responseMetaData = _errorResponse.lockedPrepareResponse(httpChannelState, true);
             }
@@ -1812,7 +1858,7 @@ public class HttpChannelState implements HttpChannel, Components
                             httpChannelState._lastWriteCallback.failed(failure);
                         }));
             }
-            else
+            else if (completeLastWrite)
             {
                 HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
             }
@@ -1830,14 +1876,20 @@ public class HttpChannelState implements HttpChannel, Components
                 LOG.debug("ErrorWrite failed: {}", this, x);
             Throwable failure;
             HttpChannelState httpChannelState;
+            boolean failLastWriteCallback;
             try (AutoLock ignored = _request._lock.lock())
             {
                 failure = _failure;
                 httpChannelState = _request.lockedGetHttpChannelState();
                 httpChannelState._response._status = _errorResponse._status;
+                failLastWriteCallback = !httpChannelState.lockedIsLastStreamSendCompleted();
             }
-            ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
-            HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
+
+            if (failLastWriteCallback)
+            {
+                ExceptionUtil.addSuppressedIfNotAssociated(failure, x);
+                HttpChannelState.failed(httpChannelState._lastWriteCallback, failure);
+            }
         }
 
         @Override

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpChannelTest.java
@@ -100,6 +100,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -134,6 +135,7 @@ public class HttpChannelTest
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
         assertThat(stream.isComplete(), is(false));
@@ -204,6 +206,7 @@ public class HttpChannelTest
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -232,6 +235,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/?read=10"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable todo = channel.onRequest(request);
         new Thread(todo).start(); // handling will block for content
 
@@ -283,6 +287,7 @@ public class HttpChannelTest
         stream.addContent(body, true);
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable todo = channel.onRequest(request);
         todo.run();
 
@@ -326,6 +331,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -368,6 +374,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         if (task != null)
             task.run();
@@ -419,6 +426,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -450,6 +458,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         try (StacklessLogging ignored = new StacklessLogging(Response.class))
@@ -489,6 +498,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         try (StacklessLogging ignored = new StacklessLogging(SerializedInvoker.class))
@@ -530,6 +540,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         try (StacklessLogging ignored = new StacklessLogging(SerializedInvoker.class))
@@ -563,6 +574,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         task.run();
@@ -639,6 +651,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -671,6 +684,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         try (StacklessLogging ignored = new StacklessLogging(Response.class))
         {
@@ -750,6 +764,7 @@ public class HttpChannelTest
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
         stream.addContent(body, true);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -792,6 +807,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -835,6 +851,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -870,6 +887,7 @@ public class HttpChannelTest
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
         assertThat(stream.addContent(body, true), nullValue());
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -884,6 +902,7 @@ public class HttpChannelTest
         fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
         stream = new MockHttpStream(channel);
+        channel.initialize();
         task = channel.onRequest(request);
         task.run();
 
@@ -933,6 +952,7 @@ public class HttpChannelTest
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
         assertThat(stream.addContent(BufferUtil.toBuffer(parts[0]), false), nullValue());
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         List<String> history = new ArrayList<>();
@@ -1074,6 +1094,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
 
+        channel.initialize();
         Runnable onRequest = channel.onRequest(request);
         onRequest.run();
 
@@ -1158,6 +1179,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields);
 
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -1194,6 +1216,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 10);
+        channel.initialize();
         Runnable onRequest = channel.onRequest(request);
         onRequest.run();
 
@@ -1264,6 +1287,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable onRequest = channel.onRequest(request);
         onRequest.run();
 
@@ -1362,6 +1386,7 @@ public class HttpChannelTest
             .asImmutable();
         MetaData.Request request = new MetaData.Request("POST", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields);
 
+        channel.initialize();
         Runnable todo = channel.onRequest(request);
         todo.run();
         assertFalse(stream.isComplete());
@@ -1484,6 +1509,7 @@ public class HttpChannelTest
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
 
         // Process the request

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -162,6 +162,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -318,6 +319,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -354,6 +356,7 @@ public class ContextHandlerTest
         MockHttpStream stream = new MockHttpStream(channel);
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from(requestUri), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         Runnable task = channel.onRequest(request);
         task.run();
 
@@ -372,6 +375,7 @@ public class ContextHandlerTest
         stream = new MockHttpStream(channel);
         fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         request = new MetaData.Request("GET", HttpURI.from(requestUri), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         task = channel.onRequest(request);
         task.run();
 
@@ -395,6 +399,7 @@ public class ContextHandlerTest
         MockHttpStream stream = new MockHttpStream(channel);
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
         MetaData.Request request = new MetaData.Request("GET", HttpURI.from("http://localhost/ctx/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         channel.onRequest(request).run();
 
         assertThat(stream.getResponse().getStatus(), equalTo(200));
@@ -405,6 +410,7 @@ public class ContextHandlerTest
 
         stream = new MockHttpStream(channel);
         request = new MetaData.Request("GET", HttpURI.from("http://localhost/ctx/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         channel.onRequest(request).run();
 
         assertThat(stream.getResponse().getStatus(), equalTo(503));
@@ -415,6 +421,7 @@ public class ContextHandlerTest
 
         stream = new MockHttpStream(channel);
         request = new MetaData.Request("GET", HttpURI.from("http://localhost/ctx/"), HttpVersion.HTTP_1_1, fields, 0);
+        channel.initialize();
         channel.onRequest(request).run();
 
         assertThat(stream.getResponse().getStatus(), equalTo(200));
@@ -464,6 +471,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -490,11 +498,6 @@ public class ContextHandlerTest
             {
                 assertInContext(request);
                 scopeListener.assertInContext(request.getContext(), request);
-                Request.addCompletionListener(request, x ->
-                {
-                    assertInContext(request);
-                    scopeListener.assertInContext(request.getContext(), request);
-                });
 
                 request.demand(() ->
                 {
@@ -526,6 +529,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         AtomicReference<Callback> sendCB = new AtomicReference<>();
         MockHttpStream stream = new MockHttpStream(channel, false)
         {
@@ -545,7 +549,8 @@ public class ContextHandlerTest
         todo = stream.addContent(BufferUtil.toBuffer("Hello"), true);
         todo.run();
 
-        sendCB.getAndSet(null).succeeded();
+        Callback cb = sendCB.getAndSet(null);
+        cb.succeeded();
 
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getFailure(), nullValue());
@@ -591,6 +596,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel, false);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -643,6 +649,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -685,42 +692,50 @@ public class ContextHandlerTest
         HttpChannel channel = new HttpChannelState(connectionMetaData);
         HttpFields fields = HttpFields.build().asImmutable();
 
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("/ctx/"), HttpVersion.HTTP_1_0, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(404));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://localhost/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(404));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://nope.example.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(404));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://example.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(200));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://wild.org/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(404));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://match.wild.org/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(200));
 
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://acme.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
         assertThat(stream.getResponse().getStatus(), equalTo(404));
 
         connectorName.set("special");
+        channel.initialize();
         stream = new MockHttpStream(channel);
         channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://acme.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
         assertThat(stream.isComplete(), is(true));
@@ -753,6 +768,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();
@@ -812,6 +828,7 @@ public class ContextHandlerTest
 
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(new MockConnector(_server));
         HttpChannel channel = new HttpChannelState(connectionMetaData);
+        channel.initialize();
         MockHttpStream stream = new MockHttpStream(channel);
 
         HttpFields fields = HttpFields.build().add(HttpHeader.HOST, "localhost").asImmutable();


### PR DESCRIPTION
## Issue #14745

This works as a potential replacement of PR https://github.com/jetty/jetty.project/pull/14918.

It uses a combination `CompletableFuture`s to invoke the `HttpChannelState.completeStream()` method. 

So that `completeStream()` is only invoked once all these are completed:
 - The callback is completed.
 - The handler exits.
 - The last write completes.


I'm putting this up for comparison to the other PR, however I think this is too much of a risky change for `12.0.x` or `12.1.x`. So potentially something we consider for Jetty 13.