### PR TITLE
Fixes #14972 - Jetty 12.1.8 jetty-home has lib/*-config.jar files

### DIFF
--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -604,6 +604,7 @@
               <excludeGroupIds>org.eclipse.jetty.orbit,org.eclipse.jetty.compression,org.eclipse.jetty.http2,org.eclipse.jetty.http3,org.eclipse.jetty.quic,org.eclipse.jetty.websocket,org.eclipse.jetty.ee8.websocket,org.eclipse.jetty.ee9.websocket,org.eclipse.jetty.ee11.websocket,org.eclipse.jetty.fcgi,org.eclipse.jetty.toolchain,org.apache.taglibs</excludeGroupIds>
               <excludeArtifactIds>jetty-ee8-apache-jsp,jetty-ee9-apache-jsp,jetty-ee10-apache-jsp,jetty-ee11-apache-jsp,jetty-ee8-glassfish-jstl,jetty-ee9-glassfish-jstl,jetty-ee10-glassfish-jstl,jetty-ee11-glassfish-jstl,jetty-start,jetty-slf4j-impl,javadoc</excludeArtifactIds>
               <includeTypes>jar</includeTypes>
+              <excludeClassifiers>config</excludeClassifiers>
               <outputDirectory>${assembly-directory}/lib</outputDirectory>
             </configuration>
           </execution>


### PR DESCRIPTION
The demos are a dependency with the "config" classifier so that the "config" jar can be unpacked in the "unpack-demo-deps" m-dep-p plugin execution.

However, now that they are a dependency, they are also copied by the "copy-jetty-core-deps" m-dep-p execution.

Modified configuration of the "copy-jetty-core-deps" execution to exclude dependencies with the "config" classifier.