### PR TITLE
Issue #14528 - fix race between WebSocketConnection.fillAndParse exit and demand

### DIFF
--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -505,11 +505,13 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                         if (meetDemand())
                             onFrame(frame);
 
+                        // If there is no more demand we need to break into the outermost loop not return.
                         moreDemand = moreDemand();
                         if (!moreDemand)
                             break;
                     }
 
+                    // Continue to fill the network buffer only if there is more demand.
                     if  (!moreDemand)
                     {
                         if (LOG.isDebugEnabled())
@@ -520,7 +522,6 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                     // buffer must be empty here because parser is fully consuming
                     assert (!networkBuffer.hasRemaining());
 
-                    // If there is more demand we can fill the network buffer.
                     if (!getEndPoint().isOpen())
                     {
                         releaseNetworkBuffer();

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/WebSocketConnection.java
@@ -347,6 +347,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
 
     private void releaseNetworkBuffer()
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("releaseNetworkBuffer() released buffer {}", networkBuffer);
         if (networkBuffer == null)
             throw new IllegalStateException();
 
@@ -460,6 +462,8 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
     {
         try (AutoLock ignored = lock.lock())
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("fillAndParse() {} {}", state, this);
             switch (state)
             {
                 case IDLE -> state = State.FILLING_AND_PARSING;
@@ -487,9 +491,12 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                 while (true)
                 {
                     // Parse and handle frames
+                    boolean moreDemand = true;
                     while (networkBuffer.hasRemaining())
                     {
                         Frame.Parsed frame = parser.parse(networkBuffer.getByteBuffer());
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("fillAndParse() parsed frame: {}", frame);
                         if (frame == null)
                             break;
 
@@ -498,16 +505,26 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                         if (meetDemand())
                             onFrame(frame);
 
-                        if (!moreDemand())
-                            return;
+                        moreDemand = moreDemand();
+                        if (!moreDemand)
+                            break;
+                    }
+
+                    if  (!moreDemand)
+                    {
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("fillAndParse() no more demand, breaking out of parsing loop");
+                        break;
                     }
 
                     // buffer must be empty here because parser is fully consuming
                     assert (!networkBuffer.hasRemaining());
 
+                    // If there is more demand we can fill the network buffer.
                     if (!getEndPoint().isOpen())
                     {
                         releaseNetworkBuffer();
+                        coreSession.onEof();
                         return;
                     }
 
@@ -582,6 +599,9 @@ public class WebSocketConnection extends AbstractConnection implements Connectio
                         }
                         default -> throw new IllegalStateException(state.name());
                     }
+
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("fillAndParse() finally block state={}, fillingAndParsing={}, close={}, registerFillInterested={}, {}", state, fillingAndParsing, close, registerFillInterested, this);
                 }
                 if (close)
                     doOnClose(closeCause);

--- a/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/MessageOutputStream.java
+++ b/jetty-core/jetty-websocket/jetty-websocket-core-common/src/main/java/org/eclipse/jetty/websocket/core/messages/MessageOutputStream.java
@@ -19,6 +19,7 @@ import java.nio.ByteBuffer;
 
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FutureCallback;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -124,6 +125,9 @@ public class MessageOutputStream extends OutputStream
     {
         try (AutoLock ignored = lock.lock())
         {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Flushing {} bytes (fin={})", buffer.remaining(), fin);
+
             if (closed)
                 throw new IOException("Stream is closed");
 
@@ -149,6 +153,9 @@ public class MessageOutputStream extends OutputStream
         {
             if (closed)
                 throw new IOException("Stream is closed");
+
+            if (LOG.isDebugEnabled())
+                LOG.debug("send() data={}, buffer={}", BufferUtil.toDetailString(data), BufferUtil.toDetailString(buffer.getByteBuffer()));
 
             while (!buffer.asMutable().append(data))
                 flush(false);

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/WebSocketTester.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/WebSocketTester.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebSocketTester implements AutoCloseable
@@ -79,9 +80,9 @@ public class WebSocketTester implements AutoCloseable
         this.client.start();
         this.generator = new UnitGenerator(Behavior.CLIENT);
 
-        CompletableFuture<CoreSession> futureHandler = this.client.connect(upgradeRequest);
-        CompletableFuture<FrameCapture> futureCapture = futureHandler.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
-        this.frameCapture = futureCapture.get(10, TimeUnit.SECONDS);
+        CompletableFuture<CoreSession> futureCoreSession = this.client.connect(upgradeRequest);
+        CompletableFuture<FrameCapture> futureFrameCapture = futureCoreSession.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
+        this.frameCapture = futureFrameCapture.get(10, TimeUnit.SECONDS);
     }
 
     public ByteBuffer asNetworkBuffer(List<Frame> frames)
@@ -212,13 +213,15 @@ public class WebSocketTester implements AutoCloseable
 
         try
         {
-            Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
+            Frame frame = framesQueue.poll(10, TimeUnit.SECONDS);
+            assertNotNull(frame);
             assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
 
             actualPayload.put(frame.getPayload());
             while (!frame.isFin())
             {
-                frame = framesQueue.poll(5, TimeUnit.SECONDS);
+                frame = framesQueue.poll(10, TimeUnit.SECONDS);
+                assertNotNull(frame);
                 assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
                 actualPayload.put(frame.getPayload());
             }
@@ -242,7 +245,7 @@ public class WebSocketTester implements AutoCloseable
             prefix = "Frame[" + i + "]";
 
             Frame expected = expect.get(i);
-            Frame actual = framesQueue.poll(5, TimeUnit.SECONDS);
+            Frame actual = framesQueue.poll(10, TimeUnit.SECONDS);
             assertThat(prefix + ".poll", actual, notNullValue());
 
             if (LOG.isDebugEnabled())

--- a/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/StreamTest.java
+++ b/jetty-ee10/jetty-ee10-websocket/jetty-ee10-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee10/websocket/jakarta/tests/server/StreamTest.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +57,6 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 public class StreamTest
 {
@@ -111,7 +109,7 @@ public class StreamTest
     @Test
     public void testUploadLargest() throws Exception
     {
-        assertTimeout(Duration.ofMillis(60000), () -> upload("largest.jpg"));
+        upload("largest.jpg");
     }
 
     private void upload(String filename) throws Exception
@@ -156,8 +154,8 @@ public class StreamTest
     @ClientEndpoint
     public static class ClientSocket
     {
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
         private Session session;
-        private CountDownLatch closeLatch = new CountDownLatch(1);
 
         @OnOpen
         public void onOpen(Session session)
@@ -178,7 +176,7 @@ public class StreamTest
 
         public void awaitClose() throws InterruptedException
         {
-            assertThat("Wait for ClientSocket close success", closeLatch.await(5, TimeUnit.SECONDS), is(true));
+            assertThat("Wait for ClientSocket close success", closeLatch.await(10, TimeUnit.SECONDS), is(true));
         }
 
         @OnError

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/WebSocketTester.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/WebSocketTester.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebSocketTester implements AutoCloseable
@@ -79,9 +80,9 @@ public class WebSocketTester implements AutoCloseable
         this.client.start();
         this.generator = new UnitGenerator(Behavior.CLIENT);
 
-        CompletableFuture<CoreSession> futureHandler = this.client.connect(upgradeRequest);
-        CompletableFuture<FrameCapture> futureCapture = futureHandler.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
-        this.frameCapture = futureCapture.get(10, TimeUnit.SECONDS);
+        CompletableFuture<CoreSession> futureCoreSession = this.client.connect(upgradeRequest);
+        CompletableFuture<FrameCapture> futureFrameCapture = futureCoreSession.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
+        this.frameCapture = futureFrameCapture.get(10, TimeUnit.SECONDS);
     }
 
     public ByteBuffer asNetworkBuffer(List<Frame> frames)
@@ -212,13 +213,15 @@ public class WebSocketTester implements AutoCloseable
 
         try
         {
-            Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
+            Frame frame = framesQueue.poll(10, TimeUnit.SECONDS);
+            assertNotNull(frame);
             assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
 
             actualPayload.put(frame.getPayload());
             while (!frame.isFin())
             {
-                frame = framesQueue.poll(5, TimeUnit.SECONDS);
+                frame = framesQueue.poll(10, TimeUnit.SECONDS);
+                assertNotNull(frame);
                 assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
                 actualPayload.put(frame.getPayload());
             }
@@ -242,7 +245,7 @@ public class WebSocketTester implements AutoCloseable
             prefix = "Frame[" + i + "]";
 
             Frame expected = expect.get(i);
-            Frame actual = framesQueue.poll(5, TimeUnit.SECONDS);
+            Frame actual = framesQueue.poll(10, TimeUnit.SECONDS);
             assertThat(prefix + ".poll", actual, notNullValue());
 
             if (LOG.isDebugEnabled())

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/StreamTest.java
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee11/websocket/jakarta/tests/server/StreamTest.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +57,6 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 public class StreamTest
 {
@@ -111,7 +109,7 @@ public class StreamTest
     @Test
     public void testUploadLargest() throws Exception
     {
-        assertTimeout(Duration.ofMillis(60000), () -> upload("largest.jpg"));
+        upload("largest.jpg");
     }
 
     private void upload(String filename) throws Exception
@@ -156,8 +154,8 @@ public class StreamTest
     @ClientEndpoint
     public static class ClientSocket
     {
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
         private Session session;
-        private CountDownLatch closeLatch = new CountDownLatch(1);
 
         @OnOpen
         public void onOpen(Session session)
@@ -178,7 +176,7 @@ public class StreamTest
 
         public void awaitClose() throws InterruptedException
         {
-            assertThat("Wait for ClientSocket close success", closeLatch.await(5, TimeUnit.SECONDS), is(true));
+            assertThat("Wait for ClientSocket close success", closeLatch.await(10, TimeUnit.SECONDS), is(true));
         }
 
         @OnError

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/WebSocketTester.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/main/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/WebSocketTester.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class WebSocketTester implements AutoCloseable
@@ -79,9 +80,9 @@ public class WebSocketTester implements AutoCloseable
         this.client.start();
         this.generator = new UnitGenerator(Behavior.CLIENT);
 
-        CompletableFuture<CoreSession> futureHandler = this.client.connect(upgradeRequest);
-        CompletableFuture<FrameCapture> futureCapture = futureHandler.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
-        this.frameCapture = futureCapture.get(10, TimeUnit.SECONDS);
+        CompletableFuture<CoreSession> futureCoreSession = this.client.connect(upgradeRequest);
+        CompletableFuture<FrameCapture> futureFrameCapture = futureCoreSession.thenCombine(upgradeRequest.getFuture(), (session, capture) -> capture);
+        this.frameCapture = futureFrameCapture.get(10, TimeUnit.SECONDS);
     }
 
     public ByteBuffer asNetworkBuffer(List<Frame> frames)
@@ -210,13 +211,15 @@ public class WebSocketTester implements AutoCloseable
     {
         ByteBuffer actualPayload = ByteBuffer.allocate(expectedMessage.remaining());
 
-        Frame frame = framesQueue.poll(5, TimeUnit.SECONDS);
+        Frame frame = framesQueue.poll(10, TimeUnit.SECONDS);
+        assertNotNull(frame);
         assertThat("Initial Frame.opCode", frame.getOpCode(), is(expectedDataOp));
 
         actualPayload.put(frame.getPayload());
         while (!frame.isFin())
         {
-            frame = framesQueue.poll(5, TimeUnit.SECONDS);
+            frame = framesQueue.poll(10, TimeUnit.SECONDS);
+            assertNotNull(frame);
             assertThat("Frame.opCode", frame.getOpCode(), is(OpCode.CONTINUATION));
             actualPayload.put(frame.getPayload());
         }
@@ -234,7 +237,7 @@ public class WebSocketTester implements AutoCloseable
             prefix = "Frame[" + i + "]";
 
             Frame expected = expect.get(i);
-            Frame actual = framesQueue.poll(5, TimeUnit.SECONDS);
+            Frame actual = framesQueue.poll(10, TimeUnit.SECONDS);
             assertThat(prefix + ".poll", actual, notNullValue());
 
             if (LOG.isDebugEnabled())

--- a/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/StreamTest.java
+++ b/jetty-ee9/jetty-ee9-websocket/jetty-ee9-websocket-jakarta-tests/src/test/java/org/eclipse/jetty/ee9/websocket/jakarta/tests/server/StreamTest.java
@@ -21,7 +21,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -58,7 +57,6 @@ import org.slf4j.LoggerFactory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertTimeout;
 
 public class StreamTest
 {
@@ -111,7 +109,7 @@ public class StreamTest
     @Test
     public void testUploadLargest() throws Exception
     {
-        assertTimeout(Duration.ofMillis(60000), () -> upload("largest.jpg"));
+        upload("largest.jpg");
     }
 
     private void upload(String filename) throws Exception
@@ -156,8 +154,8 @@ public class StreamTest
     @ClientEndpoint
     public static class ClientSocket
     {
+        private final CountDownLatch closeLatch = new CountDownLatch(1);
         private Session session;
-        private CountDownLatch closeLatch = new CountDownLatch(1);
 
         @OnOpen
         public void onOpen(Session session)
@@ -178,7 +176,7 @@ public class StreamTest
 
         public void awaitClose() throws InterruptedException
         {
-            assertThat("Wait for ClientSocket close success", closeLatch.await(5, TimeUnit.SECONDS), is(true));
+            assertThat("Wait for ClientSocket close success", closeLatch.await(10, TimeUnit.SECONDS), is(true));
         }
 
         @OnError


### PR DESCRIPTION
If `WebSocketConnection.fillAndParse` decides to exit because there is no more demand, and demand is called by a different thread before the exit block, then it will not loop around to continue to `fillAndParse()` and it will not call `fillInterested()`. So no progress will be made until the connection hits the idle timeout.


- Closes #14528
- Closes #14903 
- Closes #14902