### PR TITLE
Issue #9799 - improve exception handling in HpackDecoder

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -267,9 +267,7 @@ public class HpackDecoder
         }
         catch (Throwable t)
         {
-            HpackException.SessionException failure = new HpackException.SessionException("HPACK decoding failure: %s", t.getMessage());
-            failure.initCause(t);
-            throw failure;
+            throw new HpackException.SessionException(t, "HPACK decoding failure: %s", t.getMessage());
         }
     }
 
@@ -289,27 +287,22 @@ public class HpackDecoder
                 // and/or of a type that may be looked up multiple times.
                 switch (header)
                 {
-                    case C_STATUS:
+                    case C_STATUS ->
+                    {
                         if (indexed)
                             field = new HttpField.IntValueHttpField(header, name, value);
                         else
                             field = new HttpField(header, name, value);
-                        break;
-
-                    case C_AUTHORITY:
-                        field = new AuthorityHttpField(value);
-                        break;
-
-                    case CONTENT_LENGTH:
+                    }
+                    case C_AUTHORITY -> field = new AuthorityHttpField(value);
+                    case CONTENT_LENGTH ->
+                    {
                         if ("0".equals(value))
                             field = LOWER_CASE_CONTENT_LENGTH_0;
                         else
                             field = new HttpField.LongValueHttpField(header, name, value);
-                        break;
-
-                    default:
-                        field = new HttpField(header, name, value);
-                        break;
+                    }
+                    default -> field = new HttpField(header, name, value);
                 }
             }
             catch (Throwable t)
@@ -337,9 +330,7 @@ public class HpackDecoder
         }
         catch (EncodingException e)
         {
-            HpackException.CompressionException compressionException = new HpackException.CompressionException(e.getMessage());
-            compressionException.initCause(e);
-            throw compressionException;
+            throw new HpackException.CompressionException(e, e.getMessage());
         }
         finally
         {
@@ -359,9 +350,7 @@ public class HpackDecoder
         }
         catch (EncodingException e)
         {
-            HpackException.CompressionException compressionException = new HpackException.CompressionException(e.getMessage());
-            compressionException.initCause(e);
-            throw compressionException;
+            throw new HpackException.CompressionException(e, e.getMessage());
         }
         finally
         {

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackDecoder.java
@@ -109,188 +109,217 @@ public class HpackDecoder
         if (maxSize > 0 && buffer.remaining() > maxSize)
             throw new HpackException.SessionException("Header fields size too large");
 
-        boolean emitted = false;
-        while (buffer.hasRemaining())
+        try
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("decode {}", BufferUtil.toHexString(buffer));
-
-            byte b = buffer.get();
-            if (b < 0)
+            boolean emitted = false;
+            while (buffer.hasRemaining())
             {
-                // 7.1 indexed if the high bit is set
-                int index = integerDecode(buffer, 7);
-                Entry entry = _context.get(index);
-                if (entry == null)
-                    throw new HpackException.SessionException("Unknown index %d", index);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("decode {}", BufferUtil.toHexString(buffer));
 
-                HttpField field = entry.getHttpField();
-                if (entry.isStatic())
+                byte b = buffer.get();
+                if (b < 0)
                 {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("decode IdxStatic {}", entry);
-                    // emit field
-                    emitted = true;
-                    _builder.emit(field);
+                    // 7.1 indexed if the high bit is set
+                    int index = integerDecode(buffer, 7);
+                    Entry entry = _context.get(index);
+                    if (entry == null)
+                        throw new HpackException.SessionException("Unknown index %d", index);
 
-                    // TODO copy and add to reference set if there is room
-                    // _context.add(entry.getHttpField());
-                }
-                else
-                {
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("decode Idx {}", entry);
-
-                    String name = field.getName();
-                    if (!HttpTokens.isLegalH2H3FieldName(name))
-                        _builder.streamException("Illegal header name %s", name);
-
-                    String value = field.getValue();
-                    if (!HttpTokens.isLegalFieldValue(value))
-                        _builder.streamException("Illegal header value %s", value);
-
-                    // emit
-                    emitted = true;
-                    _builder.emit(field);
-                }
-            }
-            else
-            {
-                // look at the first nibble in detail
-                byte f = (byte)((b & 0xF0) >> 4);
-                String name;
-                HttpHeader header = null;
-                String value;
-
-                boolean indexed;
-                int nameIndex;
-
-                switch (f)
-                {
-                    case 2: // 7.3
-                    case 3: // 7.3
-                        // change table size
-                        int size = integerDecode(buffer, 5);
-                        if (LOG.isDebugEnabled())
-                            LOG.debug("decode resize={}", size);
-                        if (size > getMaxTableCapacity())
-                            throw new HpackException.CompressionException("Dynamic table resize exceeded max limit");
-                        if (emitted)
-                            throw new HpackException.CompressionException("Dynamic table resize after fields");
-                        _context.resize(size);
-                        continue;
-
-                    case 0: // 7.2.2
-                    case 1: // 7.2.3
-                        indexed = false;
-                        nameIndex = integerDecode(buffer, 4);
-                        break;
-
-                    case 4: // 7.2.1
-                    case 5: // 7.2.1
-                    case 6: // 7.2.1
-                    case 7: // 7.2.1
-                        indexed = true;
-                        nameIndex = integerDecode(buffer, 6);
-                        break;
-
-                    default:
-                        throw new IllegalStateException();
-                }
-
-                boolean huffmanName = false;
-
-                // decode the name
-                if (nameIndex > 0)
-                {
-                    Entry nameEntry = _context.get(nameIndex);
-                    name = nameEntry.getHttpField().getName();
-                    header = nameEntry.getHttpField().getHeader();
-                }
-                else
-                {
-                    huffmanName = (buffer.get() & 0x80) == 0x80;
-                    int length = integerDecode(buffer, 7);
-                    if (huffmanName)
-                        name = huffmanDecode(buffer, length);
-                    else
-                        name = toISO88591String(buffer, length);
-                }
-
-                if (!HttpTokens.isLegalH2H3FieldName(name))
-                    _builder.streamException("Illegal header name %s", name);
-                else
-                    header = HttpHeader.CACHE.get(name);
-
-                // decode the value
-                boolean huffmanValue = (buffer.get() & 0x80) == 0x80;
-                int length = integerDecode(buffer, 7);
-                if (huffmanValue)
-                    value = huffmanDecode(buffer, length);
-                else
-                    value = toISO88591String(buffer, length);
-
-                if (!HttpTokens.isLegalFieldValue(value))
-                    _builder.streamException("Illegal header value %s", value);
-
-                // Make the new field
-                HttpField field;
-                if (header == null)
-                {
-                    // just make a normal field and bypass header name lookup
-                    field = new HttpField(null, name, value);
-                }
-                else
-                {
-                    // might be worthwhile to create a value HttpField if it is indexed
-                    // and/or of a type that may be looked up multiple times.
-                    switch (header)
+                    HttpField field = entry.getHttpField();
+                    if (entry.isStatic())
                     {
-                        case C_STATUS:
-                            if (indexed)
-                                field = new HttpField.IntValueHttpField(header, name, value);
-                            else
-                                field = new HttpField(header, name, value);
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("decode IdxStatic {}", entry);
+                        // emit field
+                        emitted = true;
+                        _builder.emit(field);
+
+                        // TODO copy and add to reference set if there is room
+                        // _context.add(entry.getHttpField());
+                    }
+                    else
+                    {
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("decode Idx {}", entry);
+
+                        String name = field.getName();
+                        if (!HttpTokens.isLegalH2H3FieldName(name))
+                            _builder.streamException("Illegal header name %s", name);
+
+                        String value = field.getValue();
+                        if (!HttpTokens.isLegalFieldValue(value))
+                            _builder.streamException("Illegal header value %s", value);
+
+                        // emit
+                        emitted = true;
+                        _builder.emit(field);
+                    }
+                }
+                else
+                {
+                    // look at the first nibble in detail
+                    byte f = (byte)((b & 0xF0) >> 4);
+                    String name;
+                    HttpHeader header = null;
+                    String value;
+
+                    boolean indexed;
+                    int nameIndex;
+
+                    switch (f)
+                    {
+                        case 2: // 7.3
+                        case 3: // 7.3
+                            // change table size
+                            int size = integerDecode(buffer, 5);
+                            if (LOG.isDebugEnabled())
+                                LOG.debug("decode resize={}", size);
+                            if (size > getMaxTableCapacity())
+                                throw new HpackException.CompressionException("Dynamic table resize exceeded max limit");
+                            if (emitted)
+                                throw new HpackException.CompressionException("Dynamic table resize after fields");
+                            _context.resize(size);
+                            continue;
+
+                        case 0: // 7.2.2
+                        case 1: // 7.2.3
+                            indexed = false;
+                            nameIndex = integerDecode(buffer, 4);
                             break;
 
-                        case C_AUTHORITY:
-                            field = new AuthorityHttpField(value);
-                            break;
-
-                        case CONTENT_LENGTH:
-                            if ("0".equals(value))
-                                field = LOWER_CASE_CONTENT_LENGTH_0;
-                            else
-                                field = new HttpField.LongValueHttpField(header, name, value);
+                        case 4: // 7.2.1
+                        case 5: // 7.2.1
+                        case 6: // 7.2.1
+                        case 7: // 7.2.1
+                            indexed = true;
+                            nameIndex = integerDecode(buffer, 6);
                             break;
 
                         default:
-                            field = new HttpField(header, name, value);
-                            break;
+                            throw new IllegalStateException();
+                    }
+
+                    boolean huffmanName = false;
+
+                    // decode the name
+                    if (nameIndex > 0)
+                    {
+                        Entry nameEntry = _context.get(nameIndex);
+                        if (nameEntry == null)
+                            throw new HpackException.CompressionException("Unknown index %d", nameIndex);
+                        name = nameEntry.getHttpField().getName();
+                        header = nameEntry.getHttpField().getHeader();
+                    }
+                    else
+                    {
+                        huffmanName = (buffer.get() & 0x80) == 0x80;
+                        int length = integerDecode(buffer, 7);
+                        if (huffmanName)
+                            name = huffmanDecode(buffer, length);
+                        else
+                            name = toISO88591String(buffer, length);
+                    }
+
+                    boolean illegalName = !HttpTokens.isLegalH2H3FieldName(name);
+                    if (illegalName)
+                        _builder.streamException("Illegal header name %s", name);
+                    else
+                        header = HttpHeader.CACHE.get(name);
+
+                    // decode the value
+                    boolean huffmanValue = (buffer.get() & 0x80) == 0x80;
+                    int length = integerDecode(buffer, 7);
+                    if (huffmanValue)
+                        value = huffmanDecode(buffer, length);
+                    else
+                        value = toISO88591String(buffer, length);
+
+                    boolean illegalValue = !HttpTokens.isLegalFieldValue(value);
+                    if (illegalValue)
+                        _builder.streamException("Illegal header value %s", value);
+
+                    HttpField httpField = processField(header, name, value, indexed);
+                    emitted = true;
+                    _builder.emit(httpField);
+
+                    // If indexed add to dynamic table.
+                    if (indexed)
+                        _context.add(httpField);
+
+                    if (LOG.isDebugEnabled())
+                    {
+                        LOG.debug("decoded '{}' by {}/{}/{}",
+                            httpField,
+                            nameIndex > 0 ? "IdxName" : (huffmanName ? "HuffName" : "LitName"),
+                            huffmanValue ? "HuffVal" : "LitVal",
+                            indexed ? "Idx" : "");
                     }
                 }
+            }
 
-                if (LOG.isDebugEnabled())
+            _builder.setBeginNanoTime(_beginNanoTimeSupplier.getAsLong());
+            return _builder.build();
+        }
+        catch (HpackException x)
+        {
+            throw x;
+        }
+        catch (Throwable t)
+        {
+            HpackException.SessionException failure = new HpackException.SessionException("HPACK decoding failure: %s", t.getMessage());
+            failure.initCause(t);
+            throw failure;
+        }
+    }
+
+    private HttpField processField(HttpHeader header, String name, String value, boolean indexed) throws HpackException.SessionException
+    {
+        HttpField field;
+        if (header == null)
+        {
+            // just make a normal field and bypass header name lookup
+            field = new HttpField(null, name, value);
+        }
+        else
+        {
+            try
+            {
+                // might be worthwhile to create a value HttpField if it is indexed
+                // and/or of a type that may be looked up multiple times.
+                switch (header)
                 {
-                    LOG.debug("decoded '{}' by {}/{}/{}",
-                        field,
-                        nameIndex > 0 ? "IdxName" : (huffmanName ? "HuffName" : "LitName"),
-                        huffmanValue ? "HuffVal" : "LitVal",
-                        indexed ? "Idx" : "");
+                    case C_STATUS:
+                        if (indexed)
+                            field = new HttpField.IntValueHttpField(header, name, value);
+                        else
+                            field = new HttpField(header, name, value);
+                        break;
+
+                    case C_AUTHORITY:
+                        field = new AuthorityHttpField(value);
+                        break;
+
+                    case CONTENT_LENGTH:
+                        if ("0".equals(value))
+                            field = LOWER_CASE_CONTENT_LENGTH_0;
+                        else
+                            field = new HttpField.LongValueHttpField(header, name, value);
+                        break;
+
+                    default:
+                        field = new HttpField(header, name, value);
+                        break;
                 }
-
-                // emit the field
-                emitted = true;
-                _builder.emit(field);
-
-                // if indexed add to dynamic table
-                if (indexed)
-                    _context.add(field);
+            }
+            catch (Throwable t)
+            {
+                _builder.streamException(t);
+                field = new HttpField(header, name, value);
             }
         }
 
-        _builder.setBeginNanoTime(_beginNanoTimeSupplier.getAsLong());
-        return _builder.build();
+        return field;
     }
 
     private int integerDecode(ByteBuffer buffer, int prefix) throws HpackException.CompressionException

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackEncoder.java
@@ -296,9 +296,7 @@ public class HpackEncoder
         }
         catch (Throwable x)
         {
-            HpackException.SessionException failure = new HpackException.SessionException("Could not hpack encode %s", metadata);
-            failure.initCause(x);
-            throw failure;
+            throw new HpackException.SessionException(x, "Could not hpack encode %s", metadata);
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/HpackException.java
@@ -73,6 +73,11 @@ public abstract class HpackException extends Exception
         {
             super(messageFormat, args);
         }
+
+        public SessionException(Throwable cause, String messageFormat, Object... args)
+        {
+            super(cause, messageFormat, args);
+        }
     }
 
     public static class CompressionException extends SessionException
@@ -80,6 +85,11 @@ public abstract class HpackException extends Exception
         public CompressionException(String messageFormat, Object... args)
         {
             super(messageFormat, args);
+        }
+
+        public CompressionException(Throwable cause, String messageFormat, Object... args)
+        {
+            super(cause, messageFormat, args);
         }
     }
 }

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -24,6 +24,7 @@ import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
 import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.http2.hpack.HpackException.SessionException;
+import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.NanoTime;
 
 public class MetaDataBuilder
@@ -237,14 +238,13 @@ public class MetaDataBuilder
         }
         else
         {
-            streamException = new HpackException.StreamException(_request, _response, t.getMessage());
-            streamException.initCause(t);
+            streamException = new HpackException.StreamException(t, _request, _response, t.getMessage());
         }
 
         if (_streamException == null)
             _streamException = streamException;
         else
-            _streamException.addSuppressed(streamException);
+            ExceptionUtil.addSuppressedIfNotAssociated(_streamException, streamException);
     }
 
     public void streamException(String messageFormat, Object... args)
@@ -253,7 +253,7 @@ public class MetaDataBuilder
         if (_streamException == null)
             _streamException = stream;
         else
-            _streamException.addSuppressed(stream);
+            ExceptionUtil.addSuppressedIfNotAssociated(_streamException, stream);
     }
 
     protected boolean checkPseudoHeader(HttpHeader header, Object value)

--- a/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
+++ b/jetty-core/jetty-http2/jetty-http2-hpack/src/main/java/org/eclipse/jetty/http2/hpack/internal/MetaDataBuilder.java
@@ -228,6 +228,25 @@ public class MetaDataBuilder
         }
     }
 
+    public void streamException(Throwable t)
+    {
+        HpackException.StreamException streamException;
+        if (t instanceof HpackException.StreamException stream)
+        {
+            streamException = stream;
+        }
+        else
+        {
+            streamException = new HpackException.StreamException(_request, _response, t.getMessage());
+            streamException.initCause(t);
+        }
+
+        if (_streamException == null)
+            _streamException = streamException;
+        else
+            _streamException.addSuppressed(streamException);
+    }
+
     public void streamException(String messageFormat, Object... args)
     {
         HpackException.StreamException stream = new HpackException.StreamException(_request, _response, messageFormat, args);


### PR DESCRIPTION
## Closes #9799 

- Ensure that exceptions thrown while decoding are caught and wrapped as `HpackException` inside `HpackDecoder#decode` and not relying on the upper layers to catch throwable.
- Errors when processing the name/value pair into an `HttpField` should be `StreamException` instead of `SessionException`.