### PR TITLE
Fixes #15009 - Make processing of RST_STREAM more lenient.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AuthenticationProtocolHandler.java
@@ -129,7 +129,7 @@ public abstract class AuthenticationProtocolHandler implements ProtocolHandler
             // The request may still be sending content, stop it.
             Request request = response.getRequest();
             if (request.getBody() != null)
-                request.abort(new HttpRequestException("Aborting request after receiving a %d response".formatted(response.getStatus()), request));
+                request.fail(new HttpRequestException("Aborting request after receiving a %d response".formatted(response.getStatus()), request));
         }
 
         @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/InputStreamResponseListener.java
@@ -109,7 +109,7 @@ public class InputStreamResponseListener implements Listener, AutoCloseable
                 if (LOG.isDebugEnabled())
                     LOG.debug("Queueing chunk {}", chunk);
                 chunk.retain();
-                chunkCallbacks.add(new ChunkCallback(chunk, demander, response::abort));
+                chunkCallbacks.add(new ChunkCallback(chunk, demander, response::fail));
                 l.signalAll();
                 return;
             }

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RedirectProtocolHandler.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/RedirectProtocolHandler.java
@@ -62,7 +62,7 @@ public class RedirectProtocolHandler implements ProtocolHandler, Response.Listen
         // The request may still be sending content, stop it.
         Request request = response.getRequest();
         if (request.getBody() != null)
-            request.abort(new HttpRequestException("Aborting request after receiving a %d response".formatted(response.getStatus()), request));
+            request.fail(new HttpRequestException("Aborting request after receiving a %d response".formatted(response.getStatus()), request));
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
@@ -532,7 +532,7 @@ public interface Request
     void send(Response.CompleteListener listener);
 
     /**
-     * Attempts to abort the send of this request.
+     * Attempts to abort both the request and the response.
      *
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded
@@ -544,6 +544,17 @@ public interface Request
      * or null if this request has not been aborted
      */
     Throwable getAbortCause();
+
+    /**
+     * Attempts to fail only the request side of the request/response exchange.
+     *
+     * @param cause the fail cause, must not be null
+     * @return whether the fail succeeded
+     */
+    default CompletableFuture<Boolean> fail(Throwable cause)
+    {
+        return CompletableFuture.completedFuture(false);
+    }
 
     /**
      * Common, empty, super-interface for request listeners.

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Request.java
@@ -532,7 +532,7 @@ public interface Request
     void send(Response.CompleteListener listener);
 
     /**
-     * Attempts to abort both the request and the response.
+     * Attempts to fail both the request and the response.
      *
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Response.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Response.java
@@ -78,7 +78,7 @@ public interface Response
     HttpFields getTrailers();
 
     /**
-     * Attempts to abort both the request and the response.
+     * Attempts to fail both the request and the response.
      *
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Response.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/Response.java
@@ -78,12 +78,24 @@ public interface Response
     HttpFields getTrailers();
 
     /**
-     * Attempts to abort the receive of this response.
+     * Attempts to abort both the request and the response.
      *
      * @param cause the abort cause, must not be null
      * @return whether the abort succeeded
+     * @see Request#abort(Throwable)
      */
     CompletableFuture<Boolean> abort(Throwable cause);
+
+    /**
+     * Attempts to fail only the response side of the request/response exchange.
+     *
+     * @param cause the fail cause, must not be null
+     * @return whether the fail succeeded
+     */
+    default CompletableFuture<Boolean> fail(Throwable cause)
+    {
+        return CompletableFuture.completedFuture(false);
+    }
 
     /**
      * Common, empty, super-interface for response listeners

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/HttpContentResponse.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/internal/HttpContentResponse.java
@@ -82,6 +82,12 @@ public class HttpContentResponse implements ContentResponse
     }
 
     @Override
+    public CompletableFuture<Boolean> fail(Throwable cause)
+    {
+        return response.fail(cause);
+    }
+
+    @Override
     public String getMediaType()
     {
         return mediaType;

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpChannel.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpChannel.java
@@ -136,6 +136,11 @@ public abstract class HttpChannel implements CyclicTimeouts.Expirable
 
     protected abstract HttpReceiver getHttpReceiver();
 
+    public boolean isLastDataReceived()
+    {
+        return false;
+    }
+
     public void send()
     {
         HttpExchange exchange = getHttpExchange();

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConversation.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConversation.java
@@ -176,6 +176,24 @@ public class HttpConversation extends Attributes.Lazy
             promise.succeeded(false);
     }
 
+    void abortRequest(Throwable cause, Promise<Boolean> promise)
+    {
+        HttpExchange exchange = exchanges.peekLast();
+        if (exchange != null)
+            exchange.abortRequest(cause, promise);
+        else
+            promise.succeeded(false);
+    }
+
+    void abortResponse(Throwable cause, Promise<Boolean> promise)
+    {
+        HttpExchange exchange = exchanges.peekLast();
+        if (exchange != null)
+            exchange.abortResponse(cause, promise);
+        else
+            promise.succeeded(false);
+    }
+
     @Override
     public String toString()
     {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
@@ -286,8 +286,6 @@ public class HttpExchange implements CyclicTimeouts.Expirable
             return;
         }
 
-        Throwable failure = Objects.requireNonNullElse(requestFailure, responseFailure);
-
         if (LOG.isDebugEnabled())
             LOG.debug("Failing {}: req={}/rsp={}", this, abortRequest, abortResponse);
 
@@ -309,7 +307,7 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Aborting while queued {}", this);
-            notifyFailureComplete(failure);
+            notifyFailureComplete(Objects.requireNonNullElse(requestFailure, responseFailure));
             promise.succeeded(true);
             return;
         }
@@ -319,7 +317,7 @@ public class HttpExchange implements CyclicTimeouts.Expirable
             // Case #2: exchange was not yet associated.
             if (LOG.isDebugEnabled())
                 LOG.debug("Aborting before association {}", this);
-            notifyFailureComplete(failure);
+            notifyFailureComplete(requestFailure);
             promise.succeeded(true);
             return;
         }
@@ -327,7 +325,7 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         // Case #3: exchange was already associated.
         if (LOG.isDebugEnabled())
             LOG.debug("Aborting while active {}", this);
-        channel.abort(this, requestFailure, responseFailure, promise);
+        channel.abort(this, abortRequest ? requestFailure : null, abortResponse ? responseFailure : null, promise);
     }
 
     private void notifyFailureComplete(Throwable failure)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpExchange.java
@@ -13,6 +13,8 @@
 
 package org.eclipse.jetty.client.transport;
 
+import java.util.Objects;
+
 import org.eclipse.jetty.client.Request;
 import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.io.CyclicTimeouts;
@@ -245,6 +247,27 @@ public class HttpExchange implements CyclicTimeouts.Expirable
 
     public void abort(Throwable failure, Promise<Boolean> promise)
     {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Failing {}", this, failure);
+        abort(failure, failure, promise);
+    }
+
+    void abortRequest(Throwable failure, Promise<Boolean> promise)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Failing {}", getRequest(), failure);
+        abort(failure, null, promise);
+    }
+
+    void abortResponse(Throwable failure, Promise<Boolean> promise)
+    {
+        if (LOG.isDebugEnabled())
+            LOG.debug("Failing {}", getResponse(), failure);
+        abort(null, failure, promise);
+    }
+
+    private void abort(Throwable requestFailure, Throwable responseFailure, Promise<Boolean> promise)
+    {
         // Atomically change the state of this exchange to be completed.
         // This will avoid that this exchange can be associated to a channel.
         HttpChannel channel;
@@ -253,8 +276,8 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         try (AutoLock ignored = lock.lock())
         {
             channel = _channel;
-            abortRequest = lockedCompleteRequest(failure);
-            abortResponse = lockedCompleteResponse(failure);
+            abortRequest = requestFailure != null && lockedCompleteRequest(requestFailure);
+            abortResponse = responseFailure != null && lockedCompleteResponse(responseFailure);
         }
 
         if (!abortRequest && !abortResponse)
@@ -263,8 +286,10 @@ public class HttpExchange implements CyclicTimeouts.Expirable
             return;
         }
 
+        Throwable failure = Objects.requireNonNullElse(requestFailure, responseFailure);
+
         if (LOG.isDebugEnabled())
-            LOG.debug("Failed {}: req={}/rsp={}", this, abortRequest, abortResponse, failure);
+            LOG.debug("Failing {}: req={}/rsp={}", this, abortRequest, abortResponse);
 
         // We failed this exchange, deal with it.
 
@@ -276,14 +301,14 @@ public class HttpExchange implements CyclicTimeouts.Expirable
             // This may eventually complete the request,
             // and if the response is already completed
             // also invoke the Response.CompleteListeners.
-            body.fail(failure);
+            body.fail(requestFailure);
         }
 
         // Case #1: exchange was in the destination queue.
         if (destination.remove(this))
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Aborting while queued {}", this, failure);
+                LOG.debug("Aborting while queued {}", this);
             notifyFailureComplete(failure);
             promise.succeeded(true);
             return;
@@ -293,7 +318,7 @@ public class HttpExchange implements CyclicTimeouts.Expirable
         {
             // Case #2: exchange was not yet associated.
             if (LOG.isDebugEnabled())
-                LOG.debug("Aborting before association {}", this, failure);
+                LOG.debug("Aborting before association {}", this);
             notifyFailureComplete(failure);
             promise.succeeded(true);
             return;
@@ -301,8 +326,8 @@ public class HttpExchange implements CyclicTimeouts.Expirable
 
         // Case #3: exchange was already associated.
         if (LOG.isDebugEnabled())
-            LOG.debug("Aborting while active {}", this, failure);
-        channel.abort(this, abortRequest ? failure : null, abortResponse ? failure : null, promise);
+            LOG.debug("Aborting while active {}", this);
+        channel.abort(this, requestFailure, responseFailure, promise);
     }
 
     private void notifyFailureComplete(Throwable failure)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -75,6 +75,7 @@ public class HttpRequest implements Request
     private final Fields params = new Fields(true);
     private final ResponseListeners responseListeners = new ResponseListeners();
     private final AtomicReference<Throwable> aborted = new AtomicReference<>();
+    private final AtomicReference<Throwable> failed = new AtomicReference<>();
     private final HttpClient client;
     private final HttpConversation conversation;
     private Connection connection;
@@ -865,6 +866,18 @@ public class HttpRequest implements Request
         {
             Promise.Completable<Boolean> promise = new Promise.Completable<>();
             conversation.abort(cause, promise);
+            return promise;
+        }
+        return CompletableFuture.completedFuture(false);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> fail(Throwable cause)
+    {
+        if (failed.compareAndSet(null, Objects.requireNonNull(cause)))
+        {
+            Promise.Completable<Boolean> promise = new Promise.Completable<>();
+            conversation.abortRequest(cause, promise);
             return promise;
         }
         return CompletableFuture.completedFuture(false);

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpResponse.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpResponse.java
@@ -13,7 +13,9 @@
 
 package org.eclipse.jetty.client.transport;
 
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.eclipse.jetty.client.Request;
@@ -21,9 +23,11 @@ import org.eclipse.jetty.client.Response;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.util.Promise;
 
 public class HttpResponse implements Response
 {
+    private final AtomicReference<Throwable> failed = new AtomicReference<>();
     private final HttpFields.Mutable headers = HttpFields.build();
     private final Request request;
     private HttpVersion version;
@@ -119,6 +123,18 @@ public class HttpResponse implements Response
     public CompletableFuture<Boolean> abort(Throwable cause)
     {
         return request.abort(cause);
+    }
+
+    @Override
+    public CompletableFuture<Boolean> fail(Throwable cause)
+    {
+        if (failed.compareAndSet(null, Objects.requireNonNull(cause)))
+        {
+            Promise.Completable<Boolean> promise = new Promise.Completable<>();
+            ((HttpRequest)request).getConversation().abortResponse(cause, promise);
+            return promise;
+        }
+        return CompletableFuture.completedFuture(false);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpSender.java
@@ -263,7 +263,7 @@ public abstract class HttpSender
         {
             if (failure != null)
             {
-                if (exchange.responseComplete(failure))
+                if (!getHttpChannel().isLastDataReceived() && exchange.responseComplete(failure))
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("Response failure from request {} {}", request, exchange);

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -91,6 +91,13 @@ public class HttpChannelOverHTTP2 extends HttpChannel
         return receiver;
     }
 
+    @Override
+    public boolean isLastDataReceived()
+    {
+        HTTP2Stream http2Stream = (HTTP2Stream)stream;
+        return http2Stream != null && http2Stream.isLastDataReceived();
+    }
+
     public Stream getStream()
     {
         return stream;

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpReceiverOverHTTP2.java
@@ -86,7 +86,12 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
 
         data.release();
 
-        if (stream.isReset())
+        if (getHttpChannel().isLastDataReceived())
+        {
+            responseSuccess(null);
+            return Content.Chunk.EOF;
+        }
+        else if (stream.isReset())
         {
             Throwable failure = new EOFException("Stream has been reset");
             responseFailure(failure, Promise.noop());
@@ -94,8 +99,7 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
         }
         else
         {
-            responseSuccess(null);
-            return Content.Chunk.EOF;
+            return Content.Chunk.from(new IllegalStateException("Last data mismatch"));
         }
     }
 
@@ -256,7 +260,13 @@ public class HttpReceiverOverHTTP2 extends HttpReceiver implements HTTP2Channel.
 
         int error = frame.getError();
         IOException failure = new IOException(ErrorCode.toString(error, "reset_code_" + error));
-        Runnable task = () -> callback.completeWith(exchange.getRequest().abort(failure));
+
+        boolean lastDataReceived = getHttpChannel().isLastDataReceived();
+        Runnable task = () ->
+        {
+            var completable = lastDataReceived ? exchange.getRequest().fail(failure) : exchange.getRequest().abort(failure);
+            callback.completeWith(completable);
+        };
         return Invocable.from(getHttpConnection().getInvocationType(), task);
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2201,7 +2201,7 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 {
                     // Since nothing else will arrive from the other peer, reset
                     // the streams for which the other peer did not send all frames.
-                    Predicate<Stream> failIf = stream -> !stream.isRemotelyClosed();
+                    Predicate<Stream> failIf = stream -> !((HTTP2Stream)stream).isLastDataReceived();
                     failStreams(failIf, reason, false, Callback.from(this::tryRunZeroStreamsAction));
                 }));
             }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -63,7 +63,6 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     private final Deque<Data> dataQueue = new ArrayDeque<>(1);
     private final AtomicReference<Object> attachment = new AtomicReference<>();
     private final AtomicReference<ConcurrentMap<String, Object>> attributes = new AtomicReference<>();
-    private final AtomicReference<CloseState> closeState = new AtomicReference<>(CloseState.NOT_CLOSED);
     private final AtomicInteger sendWindow = new AtomicInteger();
     private final AtomicInteger recvWindow = new AtomicInteger();
     private final long creationNanoTime = NanoTime.now();
@@ -71,6 +70,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     private final int streamId;
     private final MetaData.Request request;
     private final boolean local;
+    private CloseState closeState = CloseState.NOT_CLOSED;
     private Callback sendCallback;
     private Throwable failure;
     private boolean localReset;
@@ -79,6 +79,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     private long dataLength;
     private boolean dataDemand;
     private boolean dataStalled;
+    private boolean dataLast;
     private boolean committed;
     private long idleTimeout;
     private long expireNanoTime = Long.MAX_VALUE;
@@ -267,19 +268,39 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     @Override
     public boolean isClosed()
     {
-        return closeState.get() == CloseState.CLOSED;
+        try (AutoLock ignored = lock.lock())
+        {
+            return closeState == CloseState.CLOSED;
+        }
     }
 
     @Override
     public boolean isRemotelyClosed()
     {
-        CloseState state = closeState.get();
-        return state == CloseState.REMOTELY_CLOSED || state == CloseState.CLOSING || state == CloseState.CLOSED;
+        try (AutoLock ignored = lock.lock())
+        {
+            return switch (closeState)
+            {
+                case REMOTELY_CLOSED, CLOSING, CLOSED -> true;
+                default -> false;
+            };
+        }
     }
 
     public boolean isLocallyClosed()
     {
-        return closeState.get() == CloseState.LOCALLY_CLOSED;
+        try (AutoLock ignored = lock.lock())
+        {
+            return closeState == CloseState.LOCALLY_CLOSED;
+        }
+    }
+
+    public boolean isLastDataReceived()
+    {
+        try (AutoLock ignored = lock.lock())
+        {
+            return dataLast;
+        }
     }
 
     public void commit()
@@ -465,7 +486,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
         DataFrame frame = data.frame();
 
         // SPEC: remotely closed streams must be replied with a reset.
-        if (isRemotelyClosed())
+        if (isLastDataReceived())
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("Data {} for already closed {}", data, this);
@@ -505,6 +526,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
                 // Retain the data because it is stored for later use.
                 data.retain();
                 dataQueue.offer(data);
+                dataLast = data.frame().isEndStream();
                 if (LOG.isDebugEnabled())
                     LOG.debug("Data {} notifying onDataAvailable() {} for {}", data, process, this);
                 return process;
@@ -621,20 +643,47 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     private void onReset(ResetFrame frame, Callback callback)
     {
-        int flowControlLength;
+        boolean reset = false;
+        boolean closed = false;
+        int flowControlLength = 0;
         try (AutoLock ignored = lock.lock())
         {
-            remoteReset = true;
-            failure = new EofException("reset");
-            flowControlLength = drain();
+            boolean lastDataReceived = isLastDataReceived();
+            if (remoteReset || closeState == CloseState.CLOSED ||
+                (isLocallyClosed() && lastDataReceived))
+            {
+                // Ignore the reset if already reset/closed,
+                // or all the data has been sent and received.
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Reset ignored {} for {}", frame, this);
+            }
+            else
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Reset {} for {}", frame, this);
+                reset = remoteReset = true;
+                failure = new EofException("reset");
+                if (!lastDataReceived)
+                    flowControlLength = drain();
+                closed = doClose();
+            }
         }
-        close();
-        boolean removed = session.removeStream(this);
-        session.dataConsumed(this, flowControlLength);
-        if (removed)
-            notifyReset(frame, callback);
-        else
-            callback.succeeded();
+
+        if (closed)
+            onClose();
+
+        if (reset)
+        {
+            boolean removed = session.removeStream(this);
+            session.dataConsumed(this, flowControlLength);
+            if (removed)
+            {
+                notifyReset(frame, callback);
+                return;
+            }
+        }
+
+        callback.succeeded();
     }
 
     private void onPush(PushPromiseFrame frame, Callback callback)
@@ -712,88 +761,67 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
 
     private boolean updateCloseAfterReceived()
     {
-        while (true)
+        boolean closed;
+        try (AutoLock ignored = lock.lock())
         {
-            CloseState current = closeState.get();
-            switch (current)
+            closed = switch (closeState)
             {
                 case NOT_CLOSED ->
                 {
-                    if (closeState.compareAndSet(current, CloseState.REMOTELY_CLOSED))
-                        return false;
+                    closeState = CloseState.REMOTELY_CLOSED;
+                    yield false;
                 }
                 case LOCALLY_CLOSING ->
                 {
-                    if (closeState.compareAndSet(current, CloseState.CLOSING))
-                    {
-                        updateStreamCount(0, 1);
-                        return false;
-                    }
+                    closeState = CloseState.CLOSING;
+                    updateStreamCount(0, 1);
+                    yield false;
                 }
-                case LOCALLY_CLOSED ->
-                {
-                    close();
-                    return true;
-                }
-                default ->
-                {
-                    return false;
-                }
-            }
+                case LOCALLY_CLOSED -> doClose();
+                default -> false;
+            };
         }
+        if (closed)
+            onClose();
+        return closed;
     }
 
     private boolean updateCloseBeforeSend()
     {
-        while (true)
+        try (AutoLock ignored = lock.lock())
         {
-            CloseState current = closeState.get();
-            switch (current)
+            switch (closeState)
             {
-                case NOT_CLOSED ->
-                {
-                    if (closeState.compareAndSet(current, CloseState.LOCALLY_CLOSING))
-                        return false;
-                }
+                case NOT_CLOSED -> closeState = CloseState.LOCALLY_CLOSING;
                 case REMOTELY_CLOSED ->
                 {
-                    if (closeState.compareAndSet(current, CloseState.CLOSING))
-                    {
-                        updateStreamCount(0, 1);
-                        return false;
-                    }
-                }
-                default ->
-                {
-                    return false;
+                    closeState = CloseState.CLOSING;
+                    updateStreamCount(0, 1);
                 }
             }
+            return false;
         }
     }
 
     private boolean updateCloseAfterSend()
     {
-        while (true)
+        boolean closed;
+        try (AutoLock ignored = lock.lock())
         {
-            CloseState current = closeState.get();
-            switch (current)
+            closed = switch (closeState)
             {
                 case NOT_CLOSED, LOCALLY_CLOSING ->
                 {
-                    if (closeState.compareAndSet(current, CloseState.LOCALLY_CLOSED))
-                        return false;
+                    closeState = CloseState.LOCALLY_CLOSED;
+                    yield false;
                 }
-                case REMOTELY_CLOSED, CLOSING ->
-                {
-                    close();
-                    return true;
-                }
-                default ->
-                {
-                    return false;
-                }
-            }
+                case REMOTELY_CLOSED, CLOSING -> doClose();
+                default -> false;
+            };
         }
+        if (closed)
+            onClose();
+        return closed;
     }
 
     public int getSendWindow()
@@ -821,12 +849,23 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Close for {}", this);
-        CloseState oldState = closeState.getAndSet(CloseState.CLOSED);
-        if (oldState != CloseState.CLOSED)
-        {
-            int deltaClosing = oldState == CloseState.CLOSING ? -1 : 0;
-            updateStreamCount(-1, deltaClosing);
+        if (doClose())
             onClose();
+    }
+
+    private boolean doClose()
+    {
+        try (AutoLock ignored = lock.lock())
+        {
+            CloseState oldState = closeState;
+            closeState = CloseState.CLOSED;
+            boolean closed = oldState != CloseState.CLOSED;
+            if (closed)
+            {
+                int deltaClosing = oldState == CloseState.CLOSING ? -1 : 0;
+                updateStreamCount(-1, deltaClosing);
+            }
+            return closed;
         }
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Stream.java
@@ -485,7 +485,7 @@ public class HTTP2Stream implements Stream, Attachable, Closeable, Callback, Dum
     {
         DataFrame frame = data.frame();
 
-        // SPEC: remotely closed streams must be replied with a reset.
+        // SPEC: data received after the last data must be replied with a reset.
         if (isLastDataReceived())
         {
             if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -680,7 +680,7 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     @Override
     public void failed(Throwable x)
     {
-        if (HttpMethod.CONNECT.is(_requestMetaData.getMethod()))
+        if (_requestMetaData != null && HttpMethod.CONNECT.is(_requestMetaData.getMethod()))
         {
             // It was a tunnel attempt, but it failed.
             if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.http2.tests;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -416,7 +417,7 @@ public class GoAwayTest extends AbstractTest
                     @Override
                     public void onDataAvailable(Stream stream)
                     {
-                        // Send the response, but do not read.
+                        // Send the response, but do not read right now.
                         MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
                         stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
                     }
@@ -511,10 +512,26 @@ public class GoAwayTest extends AbstractTest
 
         assertTrue(clientGoAwayLatch.await(5, TimeUnit.SECONDS));
         assertTrue(serverGoAwayLatch.await(5, TimeUnit.SECONDS));
+
+        // Consume the data of the first stream, otherwise the server session
+        // won't be closed, waiting for the application to complete this stream.
+        HTTP2Session serverSession = (HTTP2Session)serverSessionRef.get();
+        Collection<Stream> serverStreams = serverSession.getStreams();
+        assertEquals(1, serverStreams.size());
+        Stream serverStream = serverStreams.iterator().next();
+        while (true)
+        {
+            Stream.Data data = serverStream.readData();
+            assertNotNull(data);
+            data.release();
+            if (data.frame().isEndStream())
+                break;
+        }
+
         assertTrue(serverCloseLatch.await(5, TimeUnit.SECONDS));
         assertTrue(clientCloseLatch.await(5, TimeUnit.SECONDS));
 
-        assertFalse(((HTTP2Session)serverSessionRef.get()).getEndPoint().isOpen());
+        assertFalse(serverSession.getEndPoint().isOpen());
         assertFalse(((HTTP2Session)clientSession).getEndPoint().isOpen());
     }
 

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -866,13 +866,13 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         AtomicReference<Throwable> onContentSourceErrorRef = new AtomicReference<>();
         AtomicReference<Result> resultRef = new AtomicReference<>();
 
-        org.eclipse.jetty.client.Request jettyRequest = httpClient.newRequest("localhost", connector.getLocalPort());
-        jettyRequest.send(new Response.Listener()
+        var clientRequest = httpClient.newRequest("localhost", connector.getLocalPort());
+        clientRequest.send(new Response.Listener()
         {
             @Override
             public void onBegin(Response response)
             {
-                response.abort(new ArrayStoreException("nothing is ever going to throw ArrayStoreException in our code"));
+                response.abort(new ArrayStoreException());
             }
 
             @Override

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -88,6 +88,8 @@ import org.eclipse.jetty.io.Transport;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.util.Blocker;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -107,6 +109,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -843,8 +846,18 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         start(new Handler.Abstract()
         {
             @Override
-            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
             {
+                // Flush the response headers.
+                try (Blocker.Callback cb = Blocker.callback())
+                {
+                    response.write(false, BufferUtil.EMPTY_BUFFER, cb);
+                    cb.block(5, TimeUnit.SECONDS);
+                }
+
+                // Wait for the client to process the response headers.
+                Thread.sleep(1000);
+
                 callback.succeeded();
                 return true;
             }
@@ -920,17 +933,18 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
     }
 
     @Test
-    public void testUnreadRequestContentDrainsResponseContent() throws Exception
+    public void testUnreadRequestContentDoesNotDrainResponseContent() throws Exception
     {
+        int length = 1024;
         start(new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
                 // Do not read the request content,
-                // the server will reset the stream,
-                // then send a response with content.
-                ByteBuffer content = ByteBuffer.allocate(1024);
+                // the server will send a response
+                // with content then reset the stream.
+                ByteBuffer content = ByteBuffer.allocate(length);
                 response.getHeaders().put(HttpHeader.CONTENT_LENGTH, content.remaining());
                 response.write(true, content, callback);
                 return true;
@@ -938,33 +952,48 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         });
 
         AtomicReference<Content.Source> contentSourceRef = new AtomicReference<>();
-        AtomicReference<Content.Chunk> chunkRef = new AtomicReference<>();
-        CountDownLatch responseFailureLatch = new CountDownLatch(1);
+        CountDownLatch requestFailureLatch = new CountDownLatch(1);
+        CountDownLatch responseSuccessLatch = new CountDownLatch(1);
         AtomicReference<Result> resultRef = new AtomicReference<>();
         httpClient.newRequest("localhost", connector.getLocalPort())
             .method(HttpMethod.POST)
-            .body(new AsyncRequestContent(ByteBuffer.allocate(1024)))
+            .body(new AsyncRequestContent(ByteBuffer.allocate(512)))
             .onResponseContentSource((response, contentSource) -> contentSourceRef.set(contentSource))
-            // The request is failed before the response, verify that
-            // reading at the request failure event yields a failure chunk.
-            .onRequestFailure((request, failure) -> chunkRef.set(contentSourceRef.get().read()))
-            .onResponseFailure((response, failure) -> responseFailureLatch.countDown())
+            .onRequestFailure((request, failure) -> requestFailureLatch.countDown())
+            .onResponseSuccess(response -> responseSuccessLatch.countDown())
             .send(resultRef::set);
 
-        // Wait for the RST_STREAM to arrive and drain the response content.
-        assertTrue(responseFailureLatch.await(5, TimeUnit.SECONDS));
+        // Wait for the request to fail.
+        assertTrue(requestFailureLatch.await(5, TimeUnit.SECONDS));
 
-        // Verify that the chunk read at the request failure event is a failure chunk.
-        Content.Chunk chunk = chunkRef.get();
-        assertTrue(Content.Chunk.isFailure(chunk, true));
-        // Reading more also yields a failure chunk.
-        chunk = contentSourceRef.get().read();
-        assertTrue(Content.Chunk.isFailure(chunk, true));
+        // Verify that we can fully read the response.
+        int received = 0;
+        try (Blocker.Runnable task = Blocker.runnable())
+        {
+            Content.Source source = contentSourceRef.get();
+            while (true)
+            {
+                Content.Chunk chunk = source.read();
+                if (chunk == null)
+                {
+                    source.demand(task);
+                    task.block(5, TimeUnit.SECONDS);
+                    continue;
+                }
+                received += chunk.remaining();
+                chunk.release();
+                if (chunk.isLast())
+                    break;
+            }
+        }
+
+        assertEquals(length, received);
+        assertTrue(responseSuccessLatch.await(5, TimeUnit.SECONDS));
 
         Result result = await().atMost(5, TimeUnit.SECONDS).until(resultRef::get, notNullValue());
         assertEquals(HttpStatus.OK_200, result.getResponse().getStatus());
         assertNotNull(result.getRequestFailure());
-        assertNotNull(result.getResponseFailure());
+        assertNull(result.getResponseFailure());
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -720,7 +720,8 @@ public class IdleTimeoutTest extends AbstractTest
                 public void onHeaders(Stream stream, HeadersFrame frame)
                 {
                     responses.incrementAndGet();
-                }
+                    // Read the response body to avoid leaks.
+                    Stream.Listener.super.onHeaders(stream, frame);                }
             });
             Stream stream = promise.get(5, TimeUnit.SECONDS);
             ByteBuffer data = ByteBuffer.allocate(10);
@@ -742,6 +743,8 @@ public class IdleTimeoutTest extends AbstractTest
             {
                 responses.incrementAndGet();
                 extraLatch.countDown();
+                // Read the response body to avoid leaks.
+                Stream.Listener.super.onHeaders(stream, frame);
             }
         });
         Stream stream = promise.get(5, TimeUnit.SECONDS);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/IdleTimeoutTest.java
@@ -721,7 +721,8 @@ public class IdleTimeoutTest extends AbstractTest
                 {
                     responses.incrementAndGet();
                     // Read the response body to avoid leaks.
-                    Stream.Listener.super.onHeaders(stream, frame);                }
+                    Stream.Listener.super.onHeaders(stream, frame);
+                }
             });
             Stream stream = promise.get(5, TimeUnit.SECONDS);
             ByteBuffer data = ByteBuffer.allocate(10);

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/StreamResetTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -1263,6 +1264,127 @@ public class StreamResetTest extends AbstractTest
         // Verify that we only sent 1 RST_STREAM frame.
         await().during(1, TimeUnit.SECONDS).atMost(5, TimeUnit.SECONDS).untilAsserted(() ->
             assertEquals(1L, outFrames.stream().filter(f -> f instanceof ResetFrame).count(), outFrames.toString()));
+    }
+
+    @Test
+    public void testResetAfterLastDataDoesNotDiscardData() throws Exception
+    {
+        int length1 = 128;
+        int length2 = 256;
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                stream.data(new DataFrame(stream.getId(), ByteBuffer.allocate(length1), false))
+                    .thenCompose(s -> s.data(new DataFrame(s.getId(), ByteBuffer.allocate(length2), true)))
+                    .thenAccept(s -> s.reset(new ResetFrame(s.getId(), ErrorCode.STREAM_CLOSED_ERROR.code)));
+                return null;
+            }
+        });
+
+        Session client = newClientSession(new Session.Listener() {});
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        HeadersFrame requestFrame = new HeadersFrame(request, null, true);
+        CountDownLatch clientResetLatch = new CountDownLatch(1);
+        Stream clientStream = client.newStream(requestFrame, new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                // Do not demand.
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                clientResetLatch.countDown();
+            }
+        }).get(5, TimeUnit.SECONDS);
+
+        // The reset is ignored by the implementation, since all data has been received.
+        assertFalse(clientResetLatch.await(1, TimeUnit.SECONDS));
+        // The data must not be discarded.
+        assertEquals(length1 + length2, ((HTTP2Stream)clientStream).getDataLength());
+
+        // Read and discard the data.
+        clientStream.demand();
+
+        await().atMost(5, TimeUnit.SECONDS).until(clientStream::isClosed, is(true));
+    }
+
+    @Test
+    public void testResetAfterLastDataDoesNotDiscardDataButStopsRequestContentUpload() throws Exception
+    {
+        int length1 = 128;
+        int length2 = 256;
+        AtomicInteger dataCount = new AtomicInteger();
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                stream.demand();
+                return new Stream.Listener()
+                {
+                    @Override
+                    public void onDataAvailable(Stream stream)
+                    {
+                        dataCount.incrementAndGet();
+                        Stream.Data data = stream.readData();
+                        if (data == null)
+                        {
+                            stream.demand();
+                            return;
+                        }
+                        data.release();
+                        stream.data(new DataFrame(stream.getId(), ByteBuffer.allocate(length1), false))
+                            .thenCompose(s -> s.data(new DataFrame(s.getId(), ByteBuffer.allocate(length2), true)))
+                            .thenAccept(s -> s.reset(new ResetFrame(s.getId(), ErrorCode.STREAM_CLOSED_ERROR.code)));
+                        stream.demand();
+                    }
+                };
+            }
+        });
+
+        Session client = newClientSession(new Session.Listener() {});
+        MetaData.Request request = newRequest("GET", HttpFields.EMPTY);
+        HeadersFrame requestFrame = new HeadersFrame(request, null, false);
+        CountDownLatch clientResetLatch = new CountDownLatch(1);
+        Stream clientStream = client.newStream(requestFrame, new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                // Do not demand.
+            }
+
+            @Override
+            public void onReset(Stream stream, ResetFrame frame, Callback callback)
+            {
+                clientResetLatch.countDown();
+            }
+        }).get(5, TimeUnit.SECONDS);
+
+        // Do not send the whole request body.
+        clientStream.data(new DataFrame(clientStream.getId(), ByteBuffer.allocate(length1), false));
+
+        // The reset is notified because the request content is not complete.
+        assertTrue(clientResetLatch.await(5, TimeUnit.SECONDS));
+        // The response content must not be discarded.
+        assertEquals(length1 + length2, ((HTTP2Stream)clientStream).getDataLength());
+
+        // Finish to send the request content, it must not be sent.
+        CompletableFuture<Stream> cfData2 = clientStream.data(new DataFrame(clientStream.getId(), ByteBuffer.allocate(length2), true));
+        assertTrue(cfData2.isCompletedExceptionally());
+
+        // Read and discard the data.
+        clientStream.demand();
+
+        await().atMost(5, TimeUnit.SECONDS).until(clientStream::isClosed, is(true));
+
+        // The second request content chunk must not arrive to the server.
+        assertEquals(1, dataCount.get());
     }
 
     private void waitUntilTCPCongested(Supplier<SelectableChannelEndPoint> selectableChannelEndPointRef)


### PR DESCRIPTION
* Modified the HTTP2 implementation to discard RST_STREAM frames if the stream is already "closed" (i.e. all data has been sent and received).
* Modified the upper layer implementation to handle separately request-only failures and response-only failures, so that an HTTP2 reset now may only act on the request side, but not on the response side if the last data has been received (but not read the application yet).