### PR TITLE
Issue #14006 - suppress warning logs for pending read in onCompleted

### DIFF
--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/QuietException.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/QuietException.java
@@ -75,27 +75,4 @@ public interface QuietException
             super(cause);
         }
     }
-
-    class IOException extends java.io.IOException implements QuietException
-    {
-        public IOException()
-        {
-            super();
-        }
-
-        public IOException(String message)
-        {
-            super(message);
-        }
-
-        public IOException(String message, Throwable cause)
-        {
-            super(message, cause);
-        }
-
-        public IOException(Throwable cause)
-        {
-            super(cause);
-        }
-    }
 }

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/QuietException.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/QuietException.java
@@ -75,4 +75,27 @@ public interface QuietException
             super(cause);
         }
     }
+
+    class IOException extends java.io.IOException implements QuietException
+    {
+        public IOException()
+        {
+            super();
+        }
+
+        public IOException(String message)
+        {
+            super(message);
+        }
+
+        public IOException(String message, Throwable cause)
+        {
+            super(message, cause);
+        }
+
+        public IOException(Throwable cause)
+        {
+            super(cause);
+        }
+    }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Components;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Context;
@@ -1610,7 +1611,7 @@ public class HttpChannelState implements HttpChannel, Components
                 // Turn pending demand into failure.
                 if (httpChannelState._onContentAvailable != null)
                 {
-                    failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
+                    failure = ExceptionUtil.combine(failure, new QuietException.Exception("demand pending"));
                 }
                 else
                 {

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -50,6 +50,7 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.io.RuntimeIOException;
 import org.eclipse.jetty.io.ssl.SslConnection;
@@ -1496,7 +1497,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("abort due to pending read {} {} ", this, getEndPoint());
-                abort(new IOException("Pending read in onCompleted"));
+                abort(new QuietException.IOException("Pending read in onCompleted"));
                 _httpChannel.recycle();
                 _parser.reset();
                 _generator.reset();

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -1497,7 +1497,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("abort due to pending read {} {} ", this, getEndPoint());
-                abort(new QuietException.IOException("Pending read in onCompleted"));
+                abort(new QuietException.Exception("Pending read in onCompleted"));
                 _httpChannel.recycle();
                 _parser.reset();
                 _generator.reset();


### PR DESCRIPTION
## Issue #14006

Read pending during onCompleted can be a normal error case if there is an idleTimeout while waiting to read content,  so this should not be reported at WARN level in the logs.