### PR TITLE
Issue #11881 - Enforce that SecurityHandler is used within a ContextHandler

### DIFF
--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -310,9 +310,12 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
     }
 
     @Override
-    protected void doStart()
-        throws Exception
+    protected void doStart() throws Exception
     {
+        // LoginAuthenticator and SessionAuthentication rely on being within a ContextHandler.
+        if (ContextHandler.getCurrentContextHandler() == null)
+            throw new IllegalStateException("SecurityHandler must be deployed within a ContextHandler");
+
         // complicated resolution of login and identity service to handle
         // many different ways these can be constructed and injected.
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -251,17 +251,15 @@ public abstract class LoginAuthenticator implements Authenticator
             {
                 LoginService loginService = security.getLoginService();
                 if (loginService != null)
-                    loginService.logout(((Succeeded)this).getUserIdentity());
+                    loginService.logout(getUserIdentity());
                 IdentityService identityService = security.getIdentityService();
                 if (identityService != null)
-                    identityService.onLogout(((Succeeded)this).getUserIdentity());
-
-                Authenticator authenticator = security.getAuthenticator();
+                    identityService.onLogout(getUserIdentity());
 
                 AuthenticationState authenticationState = null;
-                if (authenticator instanceof LoginAuthenticator loginAuthenticator)
+                if (security.getAuthenticator() instanceof LoginAuthenticator loginAuthenticator)
                 {
-                    ((LoginAuthenticator)authenticator).logout(request, response);
+                    loginAuthenticator.logout(request, response);
                     authenticationState = new LoginAuthenticator.LoggedOutAuthentication(loginAuthenticator);
                 }
                 AuthenticationState.setAuthenticationState(request, authenticationState);

--- a/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/DefaultIdentityServiceTest.java
+++ b/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/DefaultIdentityServiceTest.java
@@ -16,6 +16,7 @@ package org.eclipse.jetty.security;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Callback;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +35,7 @@ public class DefaultIdentityServiceTest
 
         try
         {
-            server.setHandler(securityHandler);
+            server.setHandler(new ContextHandler(securityHandler, "/"));
             server.start();
 
             // The DefaultIdentityService should have been created by default.


### PR DESCRIPTION
## Closes #11881

Currently certain things in Jetty security rely that a `SecurityHandler` is used under a `ContextHandler`. 

This is currently  a requirement of  `SessionAuthentication`, `LoginAuthenticator` and `MultiAuthenticator`.

This PR makes it a hard requirement in `SecurityHandler.doStart` instead of having these components silently not work as intended.