### PR TITLE
Upgrade quiche to version 0.29.0

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,7 +30,7 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.28.0";
+    private static final String EXPECTED_QUICHE_VERSION = "0.29.0";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
     static void initialize()

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -30,7 +30,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.28.0";
+    String EXPECTED_QUICHE_VERSION = "0.29.0";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <jboss.logging.processor.version>3.0.4.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.3.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.28.0</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.29.0</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
There were no relevant API changes to the exported C API: https://github.com/cloudflare/quiche/compare/0.28.0...0.29.0#diff-8677002d221c3e20ec05af5a64f7125a501aade052ab378600fcc3b0a3148c91

Fixes #15118 