### PR TITLE
Issue #14984 - Correct VirtualThreadPool used method for max tasks to avoid deprecation warning.

### DIFF
--- a/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-threadpool-virtual.xml
@@ -19,7 +19,7 @@
               <Default><Ref refid="namePrefix" />-virtual-</Default>
             </Property>
           </Set>
-          <Set name="maxThreads"><Property name="jetty.threadPool.virtual.maxConcurrentTasks" deprecated="jetty.threadPool.virtual.maxThreads" default="200" /></Set>
+          <Set name="maxConcurrentTasks"><Property name="jetty.threadPool.virtual.maxConcurrentTasks" deprecated="jetty.threadPool.virtual.maxThreads" default="200" /></Set>
           <Set name="tracking" property="jetty.threadPool.virtual.tracking" />
           <Set name="detailedDump" property="jetty.threadPool.detailedDump" />
         </New>


### PR DESCRIPTION
Use correct method.

Fixes #14984