### PR TITLE
12.1.x: H2 client should abort the active channel's request during close or failure

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/ClientConnectionFactoryOverHTTP2.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.http2.client.transport;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.channels.ClosedChannelException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -106,12 +107,20 @@ public class ClientConnectionFactoryOverHTTP2 extends ContainerLifeCycle impleme
                     // This code is run when the client receives the server preface reply.
                     // Upgrade the connection to setup HTTP/2 frame listeners that will
                     // handle the HTTP/2 response to the upgrade request.
-                    promise.succeeded(connection);
-                    connection.upgrade(context);
-                    // The connection can be used only after the upgrade that
-                    // creates stream #1 corresponding to the HTTP/1.1 upgrade
-                    // request, otherwise other requests can steal id #1.
-                    destination.accept(connection);
+
+                    if (connection.upgrade(context))
+                    {
+                        // The connection can be used only after the upgrade that
+                        // creates stream #1 corresponding to the HTTP/1.1 upgrade
+                        // request, otherwise other requests can steal id #1.
+                        destination.accept(connection);
+                        promise.succeeded(connection);
+                    }
+                    else
+                    {
+                        connection.close();
+                        promise.failed(new ClosedChannelException());
+                    }
                 }
 
                 @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -51,6 +52,7 @@ import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Sweeper;
@@ -315,12 +317,8 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Failure {}", this, failure);
-        try (AutoLock ignored = lock.lock())
-        {
-            if (closed)
-                return;
-            closed = true;
-        }
+        if (ensureClosedOrAbortActiveChannels(() -> failure))
+            return;
         destroy();
         callback.succeeded();
     }
@@ -330,17 +328,37 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         if (LOG.isDebugEnabled())
             LOG.debug("Close {}", this);
-        try (AutoLock ignored = lock.lock())
-        {
-            if (closed)
-                return;
-            closed = true;
-        }
+        if (ensureClosedOrAbortActiveChannels(ClosedChannelException::new))
+            return;
         session.close(ErrorCode.NO_ERROR.code, "close", Callback.from(() ->
         {
             remove();
             destroy();
         }));
+    }
+
+    /**
+     * @return true if already closed, false if not already closed and active channels were aborted.
+     */
+    private boolean ensureClosedOrAbortActiveChannels(Supplier<Throwable> failureSupplier)
+    {
+        Set<HttpChannelOverHTTP2> activeChannels;
+        try (AutoLock ignored = lock.lock())
+        {
+            if (closed)
+                return true;
+            closed = true;
+            activeChannels = Set.copyOf(this.activeChannels);
+            this.activeChannels.clear();
+        }
+        Throwable failure = failureSupplier.get();
+        for (HttpChannel channel : activeChannels)
+        {
+            HttpExchange exchange = channel.getHttpExchange();
+            if (exchange != null)
+                exchange.abort(failure, Promise.noop());
+        }
+        return false;
     }
 
     @Override

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -52,7 +52,6 @@ import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.eclipse.jetty.util.thread.Sweeper;
@@ -165,48 +164,45 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         normalizeRequest(exchange.getRequest());
 
-        HttpChannelOverHTTP2 channel;
-        try (AutoLock ignored = lock.lock())
+        // One connection maps to N channels, so one channel for each exchange.
+        HttpChannelOverHTTP2 channel = acquireHttpChannel();
+        if (channel == null)
         {
-            if (closed)
-            {
-                // The exchange may be retried on a different connection.
-                return new SendFailure(new ClosedChannelException(), true);
-            }
-            // One connection maps to N channels, so one channel for each exchange.
-            channel = acquireHttpChannel();
+            // The exchange may be retried on a different connection.
+            return new SendFailure(new ClosedChannelException(), true);
         }
 
         SendFailure result = send(channel, exchange);
         if (result != null)
-        {
-            try (AutoLock ignored = lock.lock())
-            {
-                activeChannels.remove(channel);
-            }
-            channel.destroy();
-        }
+            destroyHttpChannel(channel);
         return result;
     }
 
-    public void upgrade(Map<String, Object> context)
+    public boolean upgrade(Map<String, Object> context)
     {
         // In case of HTTP/1.1 upgrade to HTTP/2, the request is HTTP/1.1
         // (with upgrade) for a resource, and the response is HTTP/2.
 
+        HttpChannelOverHTTP2 http2Channel = acquireHttpChannel();
+        if (http2Channel == null)
+            return false;
+
         HttpResponse response = (HttpResponse)context.get(HttpResponse.class.getName());
         HttpRequest request = (HttpRequest)response.getRequest();
-
-        HttpChannelOverHTTP2 http2Channel = acquireHttpChannel();
 
         // Create a fake conversation, as the previous exchange received a 101 response.
         // The new exchange simulates a request, but receives the HTTP/2 response.
         HttpExchange exchange = request.getConversation().getExchanges().peekLast();
+        assert exchange != null;
         // Since we reuse the original request (with its response listeners)
         // for the second exchange in the conversation, we use empty response
         // listeners so that they are not notified twice.
         HttpExchange newExchange = new HttpExchange(exchange.getHttpDestination(), request, new ResponseListeners());
-        http2Channel.associate(newExchange);
+        if (!http2Channel.associate(newExchange))
+        {
+            destroyHttpChannel(http2Channel);
+            return false;
+        }
 
         // Create the implicit stream#1 so that it can receive the HTTP/2 response.
         MetaData.Request metaData = new MetaData.Request(request.getMethod(), HttpURI.from(request.getURI()), HttpVersion.HTTP_2, request.getHeaders());
@@ -216,8 +212,8 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         {
             newExchange.requestComplete(failure);
             newExchange.terminateRequest();
-            if (LOG.isDebugEnabled())
-                LOG.debug("Upgrade failed for {}", HttpConnectionOverHTTP2.this);
+            newExchange.responseComplete(failure);
+            newExchange.terminateResponse();
         });
         if (stream != null)
         {
@@ -226,6 +222,15 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             newExchange.terminateRequest();
             if (LOG.isDebugEnabled())
                 LOG.debug("Upgrade succeeded for {}", HttpConnectionOverHTTP2.this);
+            return true;
+        }
+        else
+        {
+            http2Channel.disassociate(newExchange);
+            destroyHttpChannel(http2Channel);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Upgrade failed for {}", HttpConnectionOverHTTP2.this);
+            return false;
         }
     }
 
@@ -275,6 +280,8 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         try (AutoLock ignored = lock.lock())
         {
+            if (closed)
+                return null;
             HttpChannelOverHTTP2 channel = idleChannels.poll();
             if (channel == null)
                 channel = newHttpChannel();
@@ -308,6 +315,15 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         getHttpDestination().release(this);
     }
 
+    private void destroyHttpChannel(HttpChannelOverHTTP2 channel)
+    {
+        try (AutoLock ignored = lock.lock())
+        {
+            activeChannels.remove(channel);
+        }
+        channel.destroy();
+    }
+
     void remove()
     {
         getHttpDestination().remove(this);
@@ -319,6 +335,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             LOG.debug("Failure {}", this, failure);
         if (ensureClosedOrAbortActiveChannels(() -> failure))
             return;
+        remove();
         destroy();
         callback.succeeded();
     }
@@ -342,21 +359,21 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
      */
     private boolean ensureClosedOrAbortActiveChannels(Supplier<Throwable> failureSupplier)
     {
-        Set<HttpChannelOverHTTP2> activeChannels;
+        Set<HttpChannelOverHTTP2> channels;
         try (AutoLock ignored = lock.lock())
         {
             if (closed)
                 return true;
             closed = true;
-            activeChannels = Set.copyOf(this.activeChannels);
-            this.activeChannels.clear();
+            channels = Set.copyOf(activeChannels);
+            activeChannels.clear();
         }
         Throwable failure = failureSupplier.get();
-        for (HttpChannel channel : activeChannels)
+        for (HttpChannel channel : channels)
         {
             HttpExchange exchange = channel.getHttpExchange();
             if (exchange != null)
-                exchange.abort(failure, Promise.noop());
+                exchange.getRequest().abort(failure);
         }
         return false;
     }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -2177,13 +2177,14 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                         closed = CloseState.CLOSING;
                         GoAwayFrame goAwayFrame = newGoAwayFrame(ErrorCode.NO_ERROR.code, reason);
                         zeroStreamsAction = () -> terminate(goAwayFrame);
-                        failure = new ClosedChannelException();
+                        failure = cause = new ClosedChannelException();
                         failStreams = true;
                     }
                     case CLOSING ->
                     {
                         if (failure == null)
                             failure = new ClosedChannelException();
+                        cause = failure;
                         failStreams = true;
                     }
                     default ->

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -1320,7 +1320,7 @@ public class GoAwayTest extends AbstractTest
     }
 
     @ParameterizedTest
-    @ValueSource(ints = {1, 4})
+    @ValueSource(ints = {1000})
     public void testImmediateGoAwayAndDisconnectDoesNotLeakClientConnections(int maxConnections) throws Exception
     {
         int maxConcurrent = 16;
@@ -1355,7 +1355,7 @@ public class GoAwayTest extends AbstractTest
         }
 
         // All the requests should fail, since the server is always closing the connection.
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
+        assertTrue(latch.await(15, TimeUnit.SECONDS));
 
         List<Destination> destinations = httpClient.getDestinations();
         assertThat(destinations.size(), equalTo(1));

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -15,11 +15,11 @@ package org.eclipse.jetty.http3.client.transport.internal;
 
 import java.net.SocketAddress;
 import java.nio.channels.AsynchronousCloseException;
+import java.nio.channels.ClosedChannelException;
 import java.security.cert.X509Certificate;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.eclipse.jetty.client.ConnectionPool;
 import org.eclipse.jetty.client.Destination;
@@ -34,6 +34,7 @@ import org.eclipse.jetty.http3.client.HTTP3SessionClient;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.quic.api.Session;
 import org.eclipse.jetty.util.Promise;
+import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,10 +43,11 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpConnectionOverHTTP3.class);
 
-    private final Set<HttpChannel> activeChannels = ConcurrentHashMap.newKeySet();
-    private final AtomicBoolean closed = new AtomicBoolean();
+    private final AutoLock lock = new AutoLock();
+    private final Set<HttpChannelOverHTTP3> activeChannels = new HashSet<>();
     private final HTTP3SessionClient session;
     private final InvocationType invocationType;
+    private boolean closed;
 
     public HttpConnectionOverHTTP3(Destination destination, HTTP3SessionClient session)
     {
@@ -115,7 +117,12 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     @Override
     protected Iterator<HttpChannel> getHttpChannels()
     {
-        return activeChannels.iterator();
+        Set<HttpChannel> channels;
+        try (var ignored = lock.lock())
+        {
+            channels = Set.copyOf(activeChannels);
+        }
+        return channels.iterator();
     }
 
     @Override
@@ -127,12 +134,20 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
 
         // One connection maps to N channels, so one channel for each exchange.
         HttpChannelOverHTTP3 channel = newHttpChannel();
-        activeChannels.add(channel);
+        try (var ignored = lock.lock())
+        {
+            if (closed)
+                return new SendFailure(new ClosedChannelException(), true);
+            activeChannels.add(channel);
+        }
 
         SendFailure result = send(channel, exchange);
         if (result != null)
         {
-            activeChannels.remove(channel);
+            try (var ignored = lock.lock())
+            {
+                activeChannels.remove(channel);
+            }
             channel.destroy();
         }
         return result;
@@ -145,7 +160,11 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
 
     public void release(HttpChannelOverHTTP3 channel)
     {
-        boolean removed = activeChannels.remove(channel);
+        boolean removed;
+        try (var ignored = lock.lock())
+        {
+            removed = activeChannels.remove(channel);
+        }
         if (LOG.isDebugEnabled())
             LOG.debug("released {} {}", removed, channel);
         if (removed)
@@ -157,7 +176,10 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
     @Override
     public boolean isClosed()
     {
-        return closed.get();
+        try (var ignored = lock.lock())
+        {
+            return closed;
+        }
     }
 
     @Override
@@ -168,24 +190,31 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
 
     public void close(Throwable failure)
     {
-        if (closed.compareAndSet(false, true))
-        {
-            getHttpDestination().remove(this);
-            abort(failure);
-            destroy();
-            session.goAway(false, Promise.Invocable.noop());
-        }
+        if (abort(failure))
+            return;
+        getHttpDestination().remove(this);
+        session.goAway(false, Promise.Invocable.noop());
+        destroy();
     }
 
-    private void abort(Throwable failure)
+    private boolean abort(Throwable failure)
     {
-        for (HttpChannel channel : activeChannels)
+        Set<HttpChannelOverHTTP3> channels;
+        try (var ignored = lock.lock())
+        {
+            if (closed)
+                return true;
+            closed = true;
+            channels = Set.copyOf(activeChannels);
+            activeChannels.clear();
+        }
+        for (HttpChannel channel : channels)
         {
             HttpExchange exchange = channel.getHttpExchange();
             if (exchange != null)
                 exchange.getRequest().abort(failure);
         }
-        activeChannels.clear();
+        return false;
     }
 
     @Override


### PR DESCRIPTION
Make sure the `HttpConnectionOverHTTP2.activeChannels` set is cleared and the channels are aborted when the connection is failed or gets closed.

Fixes #14654