### PR TITLE
Fixes #15136 - Refresh Digest authentication implementation.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/DigestAuthentication.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/DigestAuthentication.java
@@ -14,6 +14,11 @@
 package org.eclipse.jetty.client;
 
 import java.net.URI;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.Charset;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -28,21 +33,22 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.util.Attributes;
 import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.TypeUtil;
 
 /**
- * Implementation of the HTTP "Digest" authentication defined in RFC 2617.
- * <p>
- * Applications should create objects of this class and add them to the
+ * <p>Implementation of the HTTP "Digest" authentication defined in RFC 7616.</p>
+ * <p>Applications should create objects of this class and add them to the
  * {@link AuthenticationStore} retrieved from the {@link HttpClient}
- * via {@link HttpClient#getAuthenticationStore()}.
+ * via {@link HttpClient#getAuthenticationStore()}.</p>
  */
 public class DigestAuthentication extends AbstractAuthentication
 {
     private final Random random;
     private final String user;
     private final String password;
+    private boolean userHashing;
 
-    /** Construct a DigestAuthentication with a {@link SecureRandom} nonce.
+    /**
      * @param uri the URI to match for the authentication
      * @param realm the realm to match for the authentication
      * @param user the user that wants to authenticate
@@ -75,10 +81,26 @@ public class DigestAuthentication extends AbstractAuthentication
         return "Digest";
     }
 
+    /**
+     * @return whether hashing of the username is supported
+     */
+    public boolean isUserHashing()
+    {
+        return userHashing;
+    }
+
+    /**
+     * @param userHashing whether hashing of the username is supported
+     */
+    public void setUserHashing(boolean userHashing)
+    {
+        this.userHashing = userHashing;
+    }
+
     @Override
     public boolean matches(String type, URI uri, String realm)
     {
-        // digest authenication requires a realm
+        // Digest authentication requires a realm.
         if (realm == null)
             return false;
 
@@ -90,9 +112,9 @@ public class DigestAuthentication extends AbstractAuthentication
     {
         Map<String, String> params = headerInfo.getParameters();
         String nonce = params.get("nonce");
-        if (nonce == null || nonce.length() == 0)
+        if (nonce == null || nonce.isEmpty())
             return null;
-        final String opaque = params.get("opaque");
+        String opaque = params.get("opaque");
         String algorithm = params.get("algorithm");
         if (algorithm == null)
             algorithm = "MD5";
@@ -109,11 +131,17 @@ public class DigestAuthentication extends AbstractAuthentication
             else if (serverQOPValues.contains("auth-int"))
                 clientQOP = "auth-int";
         }
+        String charsetName = params.get("charset");
+        Charset charset = StringUtil.isBlank(charsetName) ? null : Charset.forName(charsetName);
+        if (!"UTF-8".equals(charsetName))
+            charset = null;
+        boolean userHash = Boolean.parseBoolean(params.get("userhash"));
 
         String realm = getRealm();
         if (ANY_REALM.equals(realm))
             realm = headerInfo.getRealm();
-        return new DigestResult(headerInfo.getHeader(), response.getContent(), realm, user, password, algorithm, nonce, clientQOP, opaque);
+
+        return new DigestResult(headerInfo.getHeader(), realm, user, password, algorithm, nonce, clientQOP, opaque, charset, userHash);
     }
 
     private MessageDigest getMessageDigest(String algorithm)
@@ -132,7 +160,6 @@ public class DigestAuthentication extends AbstractAuthentication
     {
         private final AtomicInteger nonceCount = new AtomicInteger();
         private final HttpHeader header;
-        private final byte[] content;
         private final String realm;
         private final String user;
         private final String password;
@@ -140,11 +167,12 @@ public class DigestAuthentication extends AbstractAuthentication
         private final String nonce;
         private final String qop;
         private final String opaque;
+        private final Charset charset;
+        private final boolean userHash;
 
-        public DigestResult(HttpHeader header, byte[] content, String realm, String user, String password, String algorithm, String nonce, String qop, String opaque)
+        private DigestResult(HttpHeader header, String realm, String user, String password, String algorithm, String nonce, String qop, String opaque, Charset charset, boolean userHash)
         {
             this.header = header;
-            this.content = content;
             this.realm = realm;
             this.user = user;
             this.password = password;
@@ -152,6 +180,8 @@ public class DigestAuthentication extends AbstractAuthentication
             this.nonce = nonce;
             this.qop = qop;
             this.opaque = opaque;
+            this.charset = charset;
+            this.userHash = userHash;
         }
 
         @Override
@@ -165,72 +195,130 @@ public class DigestAuthentication extends AbstractAuthentication
         {
             MessageDigest digester = getMessageDigest(algorithm);
             if (digester == null)
-                return;
+                throw new IllegalArgumentException("Unsupported digest algorithm: " + algorithm);
+            if (!"auth".equals(qop))
+                throw new IllegalArgumentException("Unsupported quality of protection: " + qop);
+
+            // Retain ISO-8859-1 for old servers that don't send the charset parameter.
+            Charset cs = Objects.requireNonNullElse(charset, StandardCharsets.ISO_8859_1);
 
             String a1 = user + ":" + realm + ":" + password;
-            String hashA1 = toHexString(digester.digest(a1.getBytes(StandardCharsets.ISO_8859_1)));
+            String hashA1 = toHexString(digester.digest(strictEncode(cs, a1)));
 
             String query = request.getQuery();
             String path = request.getPath();
             String uri = (query == null) ? path : path + "?" + query;
             String a2 = request.getMethod() + ":" + uri;
-            if ("auth-int".equals(qop))
-                a2 += ":" + toHexString(digester.digest(content));
-            String hashA2 = toHexString(digester.digest(a2.getBytes(StandardCharsets.ISO_8859_1)));
+            String hashA2 = toHexString(digester.digest(strictEncode(cs, a2)));
 
             String nonceCount;
             String clientNonce;
-            String a3;
-            if (qop != null)
+            nonceCount = nextNonceCount();
+            clientNonce = newClientNonce();
+            String a3 = hashA1 + ":" + nonce + ":" + nonceCount + ":" + clientNonce + ":" + qop + ":" + hashA2;
+            String hashA3 = toHexString(digester.digest(strictEncode(cs, a3)));
+
+            // RFC-7616[3.4]: only username, realm, nonce, uri, response, cnonce, and opaque must be quoted.
+            // Parameters algorithm, username*, qop, and nc must not be quoted.
+            String digest = "Digest";
+            if (isUserHashing() && userHash)
             {
-                nonceCount = nextNonceCount();
-                clientNonce = newClientNonce();
-                a3 = hashA1 + ":" + nonce + ":" + nonceCount + ":" + clientNonce + ":" + qop + ":" + hashA2;
+                digest += " username=\"%s\"".formatted(toHexString(digester.digest(strictEncode(cs, user + ":" + realm))));
+                digest += ", userhash=true";
+            }
+            else if (userNameNeedsEncoding(user))
+            {
+                if (charset != null)
+                    digest += " username*=%s".formatted(encodeUserName(user, charset));
+                else
+                    throw new IllegalArgumentException("Unsupported username: " + user);
             }
             else
             {
-                nonceCount = null;
-                clientNonce = null;
-                a3 = hashA1 + ":" + nonce + ":" + hashA2;
+                digest += " username=\"%s\"".formatted(user);
             }
-            final String hashA3 = toHexString(digester.digest(a3.getBytes(StandardCharsets.ISO_8859_1)));
-
-            StringBuilder value = new StringBuilder("Digest");
-            value.append(" username=\"").append(user).append("\"");
-            value.append(", realm=\"").append(realm).append("\"");
-            value.append(", nonce=\"").append(nonce).append("\"");
+            digest += ", realm=\"%s\"".formatted(realm);
+            digest += ", nonce=\"%s\"".formatted(nonce);
             if (opaque != null)
-                value.append(", opaque=\"").append(opaque).append("\"");
-            value.append(", algorithm=\"").append(algorithm).append("\"");
-            value.append(", uri=\"").append(uri).append("\"");
-            if (qop != null)
-            {
-                value.append(", qop=\"").append(qop).append("\"");
-                value.append(", nc=\"").append(nonceCount).append("\"");
-                value.append(", cnonce=\"").append(clientNonce).append("\"");
-            }
-            value.append(", response=\"").append(hashA3).append("\"");
+                digest += ", opaque=\"%s\"".formatted(opaque);
+            digest += ", algorithm=%s".formatted(algorithm);
+            digest += ", uri=\"%s\"".formatted(uri);
+            digest += ", qop=%s".formatted(qop);
+            digest += ", nc=%s".formatted(nonceCount);
+            digest += ", cnonce=\"%s\"".formatted(clientNonce);
+            digest += ", response=\"%s\"".formatted(hashA3);
+            String value = digest;
 
-            request.headers(headers -> headers.add(header, value.toString()));
+            request.headers(headers -> headers.add(header, value));
+        }
+
+        private static byte[] strictEncode(Charset charset, String value)
+        {
+            try
+            {
+                ByteBuffer byteBuffer = charset.newEncoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .encode(CharBuffer.wrap(value));
+                byte[] bytes = new byte[byteBuffer.remaining()];
+                byteBuffer.get(bytes);
+                return bytes;
+            }
+            catch (CharacterCodingException x)
+            {
+                throw new RuntimeException(x);
+            }
+        }
+
+        private static boolean userNameNeedsEncoding(String user)
+        {
+            // Should be RFC 9110 quoted-string,
+            // but use here a simplified version.
+            for (int i = 0; i < user.length(); ++i)
+            {
+                char c = user.charAt(i);
+                if (c < 0x20 || c > 0x7E || c == '"' || c == '\\')
+                    return true;
+            }
+            return false;
+        }
+
+        private static String encodeUserName(String user, Charset charset)
+        {
+            byte[] bytes = strictEncode(charset, user);
+            StringBuilder builder = new StringBuilder(charset.name()).append("''");
+            for (byte b : bytes)
+            {
+                int c = b & 0xFF;
+                boolean unreserved = (c >= 'A' && c <= 'Z') ||
+                        (c >= 'a' && c <= 'z') ||
+                        (c >= '0' && c <= '9') ||
+                        c == '-' || c == '.' || c == '_' || c == '~';
+                if (unreserved)
+                    builder.append((char)c);
+                else
+                    builder.append(String.format("%%%02X", c));
+            }
+            return builder.toString();
         }
 
         private String nextNonceCount()
         {
             String padding = "00000000";
-            String next = Integer.toHexString(nonceCount.incrementAndGet()).toLowerCase(Locale.ENGLISH);
+            String next = Integer.toHexString(nonceCount.incrementAndGet()).toLowerCase(Locale.ROOT);
             return padding.substring(0, padding.length() - next.length()) + next;
         }
 
         private String newClientNonce()
         {
-            byte[] bytes = new byte[8];
+            byte[] bytes = new byte[16];
             random.nextBytes(bytes);
             return toHexString(bytes);
         }
 
         private String toHexString(byte[] bytes)
         {
-            return StringUtil.toHexString(bytes).toLowerCase(Locale.ENGLISH);
+            return TypeUtil.toString(bytes, 16);
         }
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -167,6 +167,16 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         testAuthentication(scenario, new DigestAuthentication(uri, ANY_REALM, "digest", "digest"));
     }
 
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testDigestCharset(Scenario scenario) throws Exception
+    {
+        startDigest(scenario, new EmptyServerHandler());
+        URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
+        // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
+        testAuthentication(scenario, new DigestAuthentication(uri, ANY_REALM, "digest_utf8", "€"));
+    }
+
     private void testAuthentication(Scenario scenario, Authentication authentication) throws Exception
     {
         AuthenticationStore authenticationStore = client.getAuthenticationStore();

--- a/jetty-core/jetty-client/src/test/resources/realm.properties
+++ b/jetty-core/jetty-client/src/test/resources/realm.properties
@@ -2,4 +2,5 @@
 basic:basic
 basic_utf8:\u20AC
 digest:digest
+digest_utf8:\u20AC
 spnego_client:,admin

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/DigestAuthenticator.java
@@ -14,17 +14,21 @@
 package org.eclipse.jetty.security.authentication;
 
 import java.io.Serial;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.BitSet;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
@@ -41,6 +45,8 @@ import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * The nonce max age in ms can be set with the {@link SecurityHandler#setParameter(String, String)}
  * using the name "maxNonceAge".  The nonce max count can be set with {@link SecurityHandler#setParameter(String, String)}
@@ -52,22 +58,20 @@ public class DigestAuthenticator extends LoginAuthenticator
     private static final QuotedStringTokenizer TOKENIZER = QuotedStringTokenizer.builder().delimiters("=, ").returnDelimiters().allowEmbeddedQuotes().build();
 
     private final SecureRandom _random = new SecureRandom();
-    private final Queue<Nonce> _nonceQueue = new ConcurrentLinkedQueue<>();
-    private final ConcurrentMap<String, Nonce> _nonceMap = new ConcurrentHashMap<>();
+    private final Map<String, Nonce> _nonces = new ConcurrentHashMap<>();
+    private final SecretKey _secretKey;
     private long _maxNonceAgeMs = 60 * 1000;
-    private int _maxNC = 1024;
-    private String _algorithm = "MD5";
+    private int _maxNonceCount = 1024;
+    private String _algorithm = "SHA-256";
+    private boolean _userHashing;
 
-    public void setAlgorithm(String algorithm)
+    public DigestAuthenticator()
     {
-        _algorithm = algorithm;
+        byte[] bytes = new byte[32];
+        _random.nextBytes(bytes);
+        _secretKey = new SecretKeySpec(bytes, "HmacSHA256");
     }
 
-    public String getAlgorithm()
-    {
-        return _algorithm;
-    }
-    
     @Override
     public void setConfiguration(Configuration configuration)
     {
@@ -81,24 +85,68 @@ public class DigestAuthenticator extends LoginAuthenticator
             setMaxNonceCount(Integer.parseInt(mnc));
     }
 
+    /**
+     * @return the max number of times a nonce is used
+     */
     public int getMaxNonceCount()
     {
-        return _maxNC;
+        return _maxNonceCount;
     }
 
-    public void setMaxNonceCount(int maxNC)
+    /**
+     * @param maxNonceCount the max number of times a nonce is used
+     */
+    public void setMaxNonceCount(int maxNonceCount)
     {
-        _maxNC = maxNC;
+        _maxNonceCount = maxNonceCount;
     }
 
+    /**
+     * @return the max age of a nonce in milliseconds
+     */
     public long getMaxNonceAge()
     {
         return _maxNonceAgeMs;
     }
 
+    /**
+     * @param maxNonceAgeInMillis the max age of a nonce in milliseconds
+     */
     public void setMaxNonceAge(long maxNonceAgeInMillis)
     {
         _maxNonceAgeMs = maxNonceAgeInMillis;
+    }
+
+    /**
+     * @return the {@link MessageDigest} algorithm
+     */
+    public String getAlgorithm()
+    {
+        return _algorithm;
+    }
+
+    /**
+     * @param algorithm the {@link MessageDigest} algorithm
+     */
+    public void setAlgorithm(String algorithm)
+    {
+        _algorithm = Objects.requireNonNull(algorithm);
+    }
+
+    /**
+     * @return whether the username is hashed
+     */
+    public boolean isUserHashing()
+    {
+        return _userHashing;
+    }
+
+    /**
+     * @param userHashing whether the username is hashed
+     */
+    public void setUserHashing(boolean userHashing)
+    {
+        _userHashing = userHashing;
     }
 
     @Override
@@ -115,87 +163,187 @@ public class DigestAuthenticator extends LoginAuthenticator
         boolean stale = false;
         if (credentials != null)
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("Credentials: {}", credentials);
-            final Digest digest = new Digest(req.getMethod(), getAlgorithm());
-            String last = null;
-            String name = null;
+            Digest digest = parseDigest(req.getMethod(), credentials);
+            if (digest != null)
+            {
+                if (verifyOpaque(digest))
+                {
+                    int n = checkNonce(digest);
+                    if (n > 0)
+                    {
+                        // Nonce correctness is a prerequisite for trusting digest.uri.
+                        // Check that the request URI matches the credential's URI.
+                        if (Objects.equals(digest.uri, req.getHttpURI().getPathQuery()))
+                        {
+                            UserIdentity user = login(digest.resolvedUserName, digest, req, res);
+                            if (user != null)
+                                return new UserAuthenticationSucceeded(getAuthenticationType(), user);
+                        }
+                    }
+                    else if (n == 0)
+                    {
+                        // Only good nonces can be stale.
+                        stale = true;
+                    }
+                }
+            }
+        }
 
-            for (Iterator<String> i = TOKENIZER.tokenize(credentials); i.hasNext();)
+        if (AuthenticationState.Deferred.isDeferred(res))
+            return null;
+
+        // Requests that don't have the Authorization header
+        // or that have it but it's invalid (e.g. missing/bad
+        // nonce, bad opaque, etc.) are replied with 401.
+
+        String domain = req.getContext().getContextPath();
+        if (domain == null)
+            domain = "/";
+
+        // RFC 7616[3.3]: only realm, domain, nonce, opaque, and qop must be quoted.
+        // Parameters stale and algorithm must not be quoted.
+        String value = "Digest realm=\"%s\"".formatted(_loginService.getName());
+        if (!isProxyMode())
+            value += ", domain=\"%s\"".formatted(domain);
+        String nonce = newNonce(req);
+        value += ", nonce=\"%s\"".formatted(nonce);
+        value += ", opaque=\"%s\"".formatted(newOpaque(nonce));
+        value += ", stale=%s".formatted(stale);
+        value += ", algorithm=%s".formatted(getAlgorithm());
+        value += ", qop=\"auth\"";
+        value += ", charset=UTF-8";
+        value += ", userhash=%s".formatted(isUserHashing());
+
+        res.getHeaders().put(getChallengeHeader(), value);
+
+        // Don't use AuthenticationState.writeError(), to avoid possibility of doing a Servlet error dispatch.
+        Response.writeError(req, res, callback, getUnauthorizedStatusCode());
+        return AuthenticationState.CHALLENGE;
+    }
+
+    private Digest parseDigest(String method, String credentials)
+    {
+        try
+        {
+            String name = null;
+            String value = null;
+            Digest digest = new Digest(method, getAlgorithm());
+            Iterator<String> i = TOKENIZER.tokenize(credentials);
+            while (i.hasNext())
             {
                 String tok = i.next();
                 char c = (tok.length() == 1) ? tok.charAt(0) : '\0';
-
                 switch (c)
                 {
-                    case '=':
-                        name = last;
-                        last = tok;
-                        break;
-                    case ',':
-                        name = null;
-                        break;
-                    case ' ':
-                        break;
-
-                    default:
-                        last = tok;
+                    case '=' -> name = value;
+                    case ',' -> name = null;
+                    case ' ' ->
+                    {
+                    }
+                    default ->
+                    {
+                        value = tok;
                         if (name != null)
                         {
-                            if ("username".equalsIgnoreCase(name))
-                                digest.username = tok;
-                            else if ("realm".equalsIgnoreCase(name))
-                                digest.realm = tok;
-                            else if ("nonce".equalsIgnoreCase(name))
-                                digest.nonce = tok;
-                            else if ("nc".equalsIgnoreCase(name))
-                                digest.nc = tok;
-                            else if ("cnonce".equalsIgnoreCase(name))
-                                digest.cnonce = tok;
-                            else if ("qop".equalsIgnoreCase(name))
-                                digest.qop = tok;
-                            else if ("uri".equalsIgnoreCase(name))
-                                digest.uri = tok;
-                            else if ("response".equalsIgnoreCase(name))
-                                digest.response = tok;
+                            switch (name.toLowerCase(Locale.ROOT))
+                            {
+                                case "response" -> digest.response = tok;
+                                case "username" -> digest.username = tok;
+                                case "userhash" -> digest.userhash = Boolean.parseBoolean(tok);
+                                case "username*" -> digest.usernameStar = tok;
+                                case "realm" -> digest.realm = tok;
+                                case "uri" -> digest.uri = tok;
+                                case "algorithm" -> digest.algorithm = tok;
+                                case "qop" -> digest.qop = tok;
+                                case "nonce" -> digest.nonce = tok;
+                                case "cnonce" -> digest.cnonce = tok;
+                                case "nc" -> digest.nc = tok;
+                                case "opaque" -> digest.opaque = tok;
+                            }
                             name = null;
                         }
+                    }
                 }
             }
 
-            int n = checkNonce(digest, req);
+            if (digest.username != null && digest.usernameStar != null)
+                return null;
 
-            if (n > 0)
+            if (digest.nc == null || digest.nc.length() != 8)
+                return null;
+
+            if (!getAlgorithm().equalsIgnoreCase(digest.algorithm))
+                return null;
+
+            if (!"auth".equalsIgnoreCase(digest.qop))
+                return null;
+
+            String resolvedUserName;
+            if (digest.userhash && isUserHashing())
             {
-                //UserIdentity user = _loginService.login(digest.username,digest);
-                UserIdentity user = login(digest.username, digest, req, res);
-                if (user != null)
-                {
-                    return new UserAuthenticationSucceeded(getAuthenticationType(), user);
-                }
+                if (digest.username == null)
+                    return null;
+                resolvedUserName = resolveHashedUserName(digest.username);
             }
-            else if (n == 0)
-                stale = true;
-        }
+            else if (digest.usernameStar != null)
+            {
+                resolvedUserName = resolveEncodedUserName(digest.usernameStar);
+            }
+            else
+            {
+                resolvedUserName = digest.username;
+            }
+            digest.resolvedUserName = resolvedUserName;
 
-        if (!AuthenticationState.Deferred.isDeferred(res))
+            return digest;
+        }
+        catch (Throwable x)
         {
-            String domain = req.getContext().getContextPath();
-            if (domain == null)
-                domain = "/";
-            res.getHeaders().put(getChallengeHeader().asString(), "Digest realm=\"" + _loginService.getName() +
-                    "\", domain=\"" + domain +
-                    "\", nonce=\"" + newNonce(req) +
-                    "\", algorithm=" + getAlgorithm() +
-                    ", qop=\"auth\"" +
-                    ", stale=" + stale);
-
-            // Don't use AuthenticationState.writeError, to avoid possibility of doing a Servlet error dispatch.
-            Response.writeError(req, res, callback, getUnauthorizedStatusCode());
-            return AuthenticationState.CHALLENGE;
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to parse digest", x);
+            return null;
         }
+    }
 
-        return null;
+    /**
+     * <p>Resolves the hashed username received in the {@code Authorization} header.</p>
+     * <p>This method should look up the plain username from the username hash.</p>
+     * <p>By default, this method throws {@link UnsupportedOperationException}.</p>
+     *
+     * @param hashedUserName the hashed username
+     * @return the plain username
+     */
+    protected String resolveHashedUserName(String hashedUserName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * <p>Resolves the encoded username received in the {@code Authorization} header.</p>
+     * <p>The username is encoded with RFC-5987 and this method should decode it.</p>
+     * <p>By default, this method only decodes RFC-5987 usernames encoded with UTF-8
+     * and no language; for example username: {@code UTF-8''caf%E2%82%AC} is decoded
+     * as {@code caf€}.</p>
+     *
+     * @param encodedUserName the encoded username
+     * @return the decoded username
+     */
+    protected String resolveEncodedUserName(String encodedUserName)
+    {
+        try
+        {
+            if (encodedUserName == null)
+                return null;
+            String encodedPrefix = "UTF-8''";
+            if (encodedUserName.startsWith(encodedPrefix))
+                return URI.create("scheme:" + encodedUserName.substring(encodedPrefix.length())).getSchemeSpecificPart();
+            return encodedUserName;
+        }
+        catch (Throwable x)
+        {
+            // Likely badly encoded username.
+            return null;
+        }
     }
 
     @Override
@@ -209,115 +357,199 @@ public class DigestAuthenticator extends LoginAuthenticator
 
     public String newNonce(Request request)
     {
-        Nonce nonce;
-
-        do
+        try
         {
-            byte[] nounce = new byte[24];
-            _random.nextBytes(nounce);
-
-            nonce = new Nonce(Base64.getEncoder().encodeToString(nounce), Request.getTimeStamp(request), getMaxNonceCount());
+            // The format of the nonce is such that it does
+            // not need server-side storage to be checked.
+            // nonce = base64(timestamp | random | hmac(timestamp | random))
+            Mac mac = newMac();
+            int dataLength = 2 * Long.BYTES;
+            byte[] bytes = new byte[dataLength + mac.getMacLength()];
+            ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+            byteBuffer.putLong(Request.getTimeStamp(request)).putLong(_random.nextLong());
+            mac.update(bytes, 0, dataLength);
+            mac.doFinal(bytes, dataLength);
+            return Base64.getEncoder().encodeToString(bytes);
         }
-        while (_nonceMap.putIfAbsent(nonce._nonce, nonce) != null);
-        _nonceQueue.add(nonce);
-
-        return nonce._nonce;
+        catch (GeneralSecurityException x)
+        {
+            throw new RuntimeException(x);
+        }
     }
 
     /**
      * @param digest the digest data to check
-     * @param request the request object
-     * @return -1 for a bad nonce, 0 for a stale none, 1 for a good nonce
+     * @return -1 for a bad nonce, 0 for a stale nonce, 1 for a good nonce
      */
-    private int checkNonce(Digest digest, Request request)
+    private int checkNonce(Digest digest)
     {
-        // firstly let's expire old nonces
-        long expired = Request.getTimeStamp(request) - getMaxNonceAge();
-        Nonce nonce = _nonceQueue.peek();
-        while (nonce != null && nonce._ts < expired)
-        {
-            _nonceQueue.remove(nonce);
-            _nonceMap.remove(nonce._nonce);
-            nonce = _nonceQueue.peek();
-        }
-
-        // Now check the requested nonce
         try
         {
-            nonce = _nonceMap.get(digest.nonce);
+            String nonce = digest.nonce;
             if (nonce == null)
+                return -1;
+
+            String nc = digest.nc;
+            if (nc == null)
+                return -1;
+            long nonceNumber = Long.parseLong(digest.nc, 16);
+            if (nonceNumber >= getMaxNonceCount())
                 return 0;
 
-            long count = Long.parseLong(digest.nc, 16);
-            if (count >= _maxNC)
+            byte[] nonceBytes = Base64.getDecoder().decode(nonce);
+            ByteBuffer byteBuffer = ByteBuffer.wrap(nonceBytes);
+
+            long timestamp = byteBuffer.getLong();
+            long random = byteBuffer.getLong();
+
+            Mac mac = newMac();
+            int dataLength = 2 * Long.BYTES;
+            byte[] expected = new byte[dataLength + mac.getMacLength()];
+            ByteBuffer.wrap(expected).putLong(timestamp).putLong(random);
+            mac.update(expected, 0, dataLength);
+            mac.doFinal(expected, dataLength);
+
+            if (!MessageDigest.isEqual(expected, nonceBytes))
+                return -1;
+
+            long elapsed = System.currentTimeMillis() - timestamp;
+            if (elapsed < 0)
+                return -1;
+
+            if (elapsed > getMaxNonceAge())
                 return 0;
 
-            if (nonce.seen((int)count))
+            // Store the nonce to keep track of digest.nc, the nonce count.
+
+            // First, expire old nonces.
+            Iterator<Nonce> iterator = _nonces.values().iterator();
+            while (iterator.hasNext())
+            {
+                Nonce n = iterator.next();
+                elapsed = System.currentTimeMillis() - n._timestamp;
+                if (elapsed > getMaxNonceAge())
+                    iterator.remove();
+            }
+            // Store the used nonce.
+            Nonce n = _nonces.computeIfAbsent(nonce, k -> new Nonce(timestamp, getMaxNonceCount()));
+            // Check the nonce number to counter replay attacks.
+            if (n.seen((int)nonceNumber))
                 return -1;
 
             return 1;
         }
-        catch (Exception e)
+        catch (Throwable x)
         {
-            if (LOG.isTraceEnabled())
-                LOG.trace("IGNORED", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to verify nonce", x);
+            return -1;
         }
-        return -1;
+    }
+
+    private String newOpaque(String nonce)
+    {
+        // The format of the opaque parameter is tied to the nonce:
+        // opaque = base64(hmac(nonce))
+        byte[] bytes = Base64.getDecoder().decode(nonce);
+        Mac mac = newMac();
+        byte[] macBytes = mac.doFinal(bytes);
+        return Base64.getEncoder().encodeToString(macBytes);
+    }
+
+    private boolean verifyOpaque(Digest digest)
+    {
+        try
+        {
+            // RFC-7616[3.3]: the opaque parameter SHOULD
+            // be sent by the client, but it may not.
+            if (digest.opaque == null)
+                return true;
+
+            String nonce = digest.nonce;
+            if (nonce == null)
+                return false;
+
+            Mac mac = newMac();
+            byte[] expected = mac.doFinal(Base64.getDecoder().decode(nonce));
+
+            byte[] actual = Base64.getDecoder().decode(digest.opaque);
+            return MessageDigest.isEqual(expected, actual);
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to verify opaque", x);
+            return false;
+        }
+    }
+
+    private Mac newMac()
+    {
+        try
+        {
+            Mac mac = Mac.getInstance(_secretKey.getAlgorithm());
+            mac.init(_secretKey);
+            return mac;
+        }
+        catch (Throwable x)
+        {
+            throw new RuntimeException(x);
+        }
     }
 
     private static class Nonce
     {
         private final AutoLock _lock = new AutoLock();
-        final String _nonce;
-        final long _ts;
-        final BitSet _seen;
+        private final long _timestamp;
+        private final BitSet _seen;
 
-        public Nonce(String nonce, long ts, int size)
+        private Nonce(long timestamp, int size)
         {
-            _nonce = nonce;
-            _ts = ts;
+            _timestamp = timestamp;
             _seen = new BitSet(size);
         }
 
-        public boolean seen(int count)
+        private boolean seen(int number)
         {
             try (AutoLock ignored = _lock.lock())
             {
-                if (count >= _seen.size())
+                if (number >= _seen.size())
                     return true;
-                boolean s = _seen.get(count);
-                _seen.set(count);
+                boolean s = _seen.get(number);
+                _seen.set(number);
                 return s;
             }
         }
     }
 
+    // This class must remain {@code static} to avoid the hidden
+    // reference to the outer class, that would make it non-serializable.
     private static class Digest extends Credential
     {
         @Serial
         private static final long serialVersionUID = -2484639019549527724L;
-        private String algorithm;
-        final String method;
-        String username = "";
-        String realm = "";
-        String nonce = "";
-        String nc = "";
-        String cnonce = "";
-        String qop = "";
-        String uri = "";
-        String response = "";
 
-        Digest(String m)
-        {
-            this(m, "MD5");
-        }
-        
-        Digest(String method, String algorithm)
+        private final String method;
+        private String algorithm;
+        private String username;
+        private String usernameStar;
+        private String resolvedUserName;
+        private String realm;
+        private String nonce;
+        private String nc;
+        private String cnonce;
+        private String qop;
+        private String uri;
+        private String response;
+        private boolean userhash;
+        private String opaque;
+
+        private Digest(String method, String algorithm)
         {
             this.method = method;
             this.algorithm = algorithm;
         }
-        
+
         private String getAlgorithm()
         {
             return algorithm;
@@ -332,67 +564,47 @@ public class DigestAuthenticator extends LoginAuthenticator
 
             try
             {
-                // MD5 required by the specification
                 MessageDigest md = MessageDigest.getInstance(getAlgorithm());
                 byte[] ha1;
-                if (credentials instanceof MD5)
+                if (credentials instanceof MD5 md5)
                 {
                     // Credentials are already a MD5 digest - assume it's in
                     // form user:realm:password (we have no way to know since
                     // it's a digest, alright?)
-                    ha1 = ((MD5)credentials).getDigest();
+                    ha1 = md5.getDigest();
                 }
                 else
                 {
-                    // calc A1 digest
-                    md.update(username.getBytes(StandardCharsets.ISO_8859_1));
-                    md.update((byte)':');
-                    md.update(realm.getBytes(StandardCharsets.ISO_8859_1));
-                    md.update((byte)':');
-                    md.update(password.getBytes(StandardCharsets.ISO_8859_1));
-                    ha1 = md.digest();
+                    // Calculate H(A1).
+                    String a1 = resolvedUserName + ":" + realm + ":" + password;
+                    ha1 = md.digest(a1.getBytes(UTF_8));
                 }
-                // calc A2 digest
-                md.reset();
-                md.update(method.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(uri.getBytes(StandardCharsets.ISO_8859_1));
-                byte[] ha2 = md.digest();
 
-                // calc digest
-                // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":"
-                // nc-value ":" unq(cnonce-value) ":" unq(qop-value) ":" H(A2) )
-                // <">
-                // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":" H(A2)
-                // ) > <">
+                // Calculate H(A2).
+                String a2 = method + ":" + uri;
+                byte[] ha2 = md.digest(a2.getBytes(UTF_8));
 
-                md.update(TypeUtil.toString(ha1, 16).getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(nonce.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(nc.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(cnonce.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(qop.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(TypeUtil.toString(ha2, 16).getBytes(StandardCharsets.ISO_8859_1));
-                
-                // check digest
-                return stringEquals(TypeUtil.toString(md.digest(), 16).toLowerCase(), response == null ? null : response.toLowerCase());
+                // Calculate response, must match what the client sent.
+                String expected = TypeUtil.toString(ha1, 16) + ":" +
+                    nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" +
+                    TypeUtil.toString(ha2, 16);
+                expected = TypeUtil.toString(md.digest(expected.getBytes(UTF_8)), 16);
+
+                // Check digest.
+                return stringEquals(expected, response == null ? null : response.toLowerCase(Locale.ROOT));
             }
-            catch (Exception e)
+            catch (Throwable x)
             {
-                LOG.warn("Unable to process digest", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to process digest", x);
+                return false;
             }
-
-            return false;
         }
 
         @Override
         public String toString()
         {
-            return username + "," + response;
+            return "%s@%x[u=%s]".formatted(TypeUtil.toShortName(getClass()), hashCode(), resolvedUserName);
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/ConstraintTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/ConstraintTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -496,7 +497,7 @@ public class ConstraintTest
         assertEquals(1, mappings.size());
         ConstraintMapping mapping = mappings.get(0);
         Constraint constraint = mapping.getConstraint();
-        assertSame(constraint.getAuthorization(), Constraint.Authorization.FORBIDDEN);
+        assertSame(Constraint.Authorization.FORBIDDEN, constraint.getAuthorization());
     }
 
     /**
@@ -514,7 +515,7 @@ public class ConstraintTest
         assertFalse(mappings.isEmpty());
         assertEquals(1, mappings.size());
         ConstraintMapping mapping = mappings.get(0);
-        assertNotSame(mapping.getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mapping.getConstraint().getAuthorization());
         assertNotNull(mapping.getConstraint().getRoles());
         assertEquals("R1", mapping.getConstraint().getRoles().stream().findFirst().orElse(null));
         assertThat(mapping.getConstraint().getTransport(), not(is(Constraint.Transport.SECURE)));
@@ -566,7 +567,7 @@ public class ConstraintTest
         assertEquals(2, mappings.size());
         assertNotNull(mappings.get(0).getMethodOmissions());
         assertEquals("GET", mappings.get(0).getMethodOmissions()[0]);
-        assertNotSame(mappings.get(0).getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mappings.get(0).getConstraint().getAuthorization());
         assertEquals("R1", mappings.get(0).getConstraint().getRoles().stream().findFirst().orElse(null));
         assertEquals("GET", mappings.get(1).getMethod());
         assertNull(mappings.get(1).getMethodOmissions());
@@ -593,13 +594,13 @@ public class ConstraintTest
         assertEquals(2, mappings.size());
         assertNotNull(mappings.get(0).getMethodOmissions());
         assertEquals("TRACE", mappings.get(0).getMethodOmissions()[0]);
-        assertNotSame(mappings.get(0).getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mappings.get(0).getConstraint().getAuthorization());
         assertEquals("R1", mappings.get(0).getConstraint().getRoles().stream().findFirst().orElse(null));
         assertEquals("TRACE", mappings.get(1).getMethod());
         assertNull(mappings.get(1).getMethodOmissions());
         assertThat(mappings.get(1).getConstraint().getTransport(), not(is(Constraint.Transport.SECURE)));
         Constraint constraint = mappings.get(1).getConstraint();
-        assertSame(constraint.getAuthorization(), Constraint.Authorization.FORBIDDEN);
+        assertSame(Constraint.Authorization.FORBIDDEN, constraint.getAuthorization());
     }
 
     @Test
@@ -924,45 +925,20 @@ public class ConstraintTest
 
     private String digest(String nonce, String password, String nc) throws Exception
     {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] ha1;
-        // calc A1 digest
-        md.update("user".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("TestRealm".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(password.getBytes(ISO_8859_1));
-        ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update("GET".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("/ctx/auth/info".getBytes(ISO_8859_1));
-        byte[] ha2 = md.digest();
+        DigestAuthenticator authenticator = (DigestAuthenticator)_security.getAuthenticator();
+        MessageDigest md = MessageDigest.getInstance(authenticator.getAlgorithm());
 
-        // calc digest
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":"
-        // nc-value ":" unq(cnonce-value) ":" unq(qop-value) ":" H(A2) )
-        // <">
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":" H(A2)
-        // ) > <">
+        // Calculate A1 digest.
+        String a1 = "user:TestRealm:" + password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
 
-        md.update(TypeUtil.toString(ha1, 16).getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nc.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        String cnonce = "1234567890";
-        md.update(cnonce.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("auth".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(ISO_8859_1));
-        byte[] digest = md.digest();
+        // Calculate A2 digest.
+        String a2 = "GET:/ctx/auth/info";
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
 
-        // check digest
-        return TypeUtil.toString(digest, 16);
+        String rsp = TypeUtil.toString(ha1, 16) + ":" + nonce + ":" + nc +
+            ":1234567890:auth:" + TypeUtil.toString(ha2, 16);
+        return TypeUtil.toString(md.digest(rsp.getBytes(UTF_8)), 16);
     }
 
     @Test
@@ -988,61 +964,61 @@ public class ConstraintTest
         assertTrue(matcher.find());
         String nonce = matcher.group(1);
 
-        //wrong password
-        String digest = digest(nonce, "WRONG", "1");
+        // Wrong password.
+        String digest = digest(nonce, "WRONG", "00000001");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=1, " +
+            "nc=00000001, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // right password
-        digest = digest(nonce, "password", "2");
+        // Right password.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // once only
-        digest = digest(nonce, "password", "2");
+        // Replay of request with nc=00000002.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // increasing
-        digest = digest(nonce, "password", "4");
+        // Next request.
+        digest = digest(nonce, "password", "00000004");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=4, " +
+            "nc=00000004, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // out of order
-        digest = digest(nonce, "password", "3");
+        // Out of order request.
+        digest = digest(nonce, "password", "00000003");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=3, " +
+            "nc=00000003, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // stale
-        digest = digest(nonce, "password", "5");
+        // Beyond max nonce count.
+        digest = digest(nonce, "password", "00000006");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=5, " +
+            "nc=00000006, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/DigestPostTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/DigestPostTest.java
@@ -13,11 +13,12 @@
 
 package org.eclipse.jetty.ee10.test;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,62 +26,344 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.AuthenticationStore;
-import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.DigestAuthentication;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.PathRequestContent;
 import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.security.authentication.DigestAuthenticator;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.util.security.Password;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DigestPostTest
 {
-    private static final String NC = "00000001";
+    private static final String MESSAGE = """
+        0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789
+        9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210
+        1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890
+        0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321
+        abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
+        ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ
+        Now is the time for all good men to come to the aid of the party.
+        How now brown cow.
+        The quick brown fox jumped over the lazy dog.
+        """;
 
-    public static final String __message =
-        "0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 \n" +
-            "9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 \n" +
-            "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 \n" +
-            "0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 \n" +
-            "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz \n" +
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ \n" +
-            "Now is the time for all good men to come to the aid of the party.\n" +
-            "How now brown cow.\n" +
-            "The quick brown fox jumped over the lazy dog.\n";
+    private final String _user = "testuser";
+    private final String _password = "password";
+    private final String _realm = "testrealm";
+    private final String nc = "00000001";
+    private final String cnonce = "CLIENT_NONCE";
+    private Server _server;
+    private ServerConnector _connector;
+    private PostServlet _servlet;
+    private DigestAuthenticator _authenticator;
 
-    public static volatile String _received = null;
-    private static Server _server;
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
+        context.setContextPath("/test");
+        _servlet = new PostServlet();
+        context.addServlet(_servlet, "/");
+
+        TestLoginService realm = new TestLoginService(_realm);
+        realm.putUser(_user, new Password(_password), new String[]{"testRole"});
+        _server.addBean(realm);
+
+        ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
+        _authenticator = new DigestAuthenticator();
+        security.setAuthenticator(_authenticator);
+        security.setLoginService(realm);
+
+        Constraint constraint = new Constraint.Builder()
+            .name("SecureTest")
+            .roles("testRole")
+            .build();
+        ConstraintMapping mapping = new ConstraintMapping();
+        mapping.setConstraint(constraint);
+        mapping.setPathSpec("/*");
+
+        security.setConstraintMappings(Collections.singletonList(mapping));
+
+        _server.setHandler(new Handler.Sequence(context, new DefaultHandler()));
+
+        _server.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        _server.stop();
+    }
+
+    @Test
+    public void testServerDirectlyHTTP10() throws Exception
+    {
+        try (SocketChannel socket1 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.0
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket1.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket1);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            try (SocketChannel socket2 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+            {
+                _servlet._received = null;
+                request = """
+                    POST /test/ HTTP/1.0
+                    Host: localhost
+                    Content-Length: %d
+                    Authorization: %s
+                    
+                    %s\
+                    """.formatted(MESSAGE.length(), digest, MESSAGE);
+                socket2.write(UTF_8.encode(request));
+
+                response = HttpTester.parseResponse(socket2);
+
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(MESSAGE, _servlet._received);
+            }
+        }
+    }
+
+    @Test
+    public void testServerDirectlyHTTP11() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testUserStar() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String encodedUser = "UTF-8''" + _user.replace("e", "%65");
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username*="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(encodedUser, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientStringContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new StringRequestContent(MESSAGE))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(MESSAGE, _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientPathContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            Path path = MavenPaths.findTestResourceFile("message.txt");
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new PathRequestContent(path))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(Files.readString(path), _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    private String newResponse(String method, String uri, String nonce) throws Exception
+    {
+        MessageDigest md = MessageDigest.getInstance(_authenticator.getAlgorithm());
+
+        // Calculate A1 digest.
+        String a1 = _user + ":" + _realm + ":" + _password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
+
+        // Calculate A2 digest.
+        String a2 = method + ":" + uri;
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
+
+        String rsp = TypeUtil.toString(ha1, 16) + ":" + nonce + ":" + nc +
+            ":" + cnonce + ":auth:" + TypeUtil.toString(ha2, 16);
+        return TypeUtil.toString(md.digest(rsp.getBytes(UTF_8)), 16);
+    }
+
+    private String nonceFrom(String authenticate)
+    {
+        Pattern pattern = Pattern.compile("nonce=\"([^\"]+)\"");
+        Matcher matcher = pattern.matcher(authenticate);
+        if (matcher.find())
+            return matcher.group(1);
+        return null;
+    }
+
+    public static class PostServlet extends HttpServlet
+    {
+        public String _received;
+
+        @Override
+        public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
+        {
+            String received = IO.toString(request.getInputStream());
+            _received = received;
+
+            response.setStatus(200);
+            response.getWriter().println("Received " + received.length() + " bytes");
+        }
+    }
 
     public static class TestLoginService extends AbstractLoginService
     {
@@ -92,12 +375,12 @@ public class DigestPostTest
             setName(name);
         }
 
-        public void putUser(String username, Credential credential, String[] rolenames)
+        public void putUser(String username, Credential credential, String[] roleNames)
         {
             UserPrincipal userPrincipal = new UserPrincipal(username, credential);
             users.put(username, userPrincipal);
-            if (rolenames != null)
-                roles.put(username, Arrays.stream(rolenames).map(RolePrincipal::new).collect(Collectors.toList()));
+            if (roleNames != null)
+                roles.put(username, Arrays.stream(roleNames).map(RolePrincipal::new).toList());
         }
 
         @Override
@@ -111,264 +394,5 @@ public class DigestPostTest
         {
             return users.get(username);
         }
-    }
-
-    @BeforeAll
-    public static void setUpServer()
-    {
-        try
-        {
-            _server = new Server();
-            _server.setConnectors(new Connector[]{new ServerConnector(_server)});
-
-            ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
-            context.setContextPath("/test");
-            context.addServlet(PostServlet.class, "/");
-
-            TestLoginService realm = new TestLoginService("test");
-            realm.putUser("testuser", new Password("password"), new String[]{"test"});
-            _server.addBean(realm);
-
-            ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
-            security.setAuthenticator(new DigestAuthenticator());
-            security.setLoginService(realm);
-
-            Constraint constraint = new Constraint.Builder()
-                .name("SecureTest")
-                .roles("test")
-                .build();
-            ConstraintMapping mapping = new ConstraintMapping();
-            mapping.setConstraint(constraint);
-            mapping.setPathSpec("/*");
-
-            security.setConstraintMappings(Collections.singletonList(mapping));
-
-            _server.setHandler(new Handler.Sequence(context, new DefaultHandler()));
-
-            _server.start();
-        }
-        catch (final Exception e)
-        {
-            e.printStackTrace();
-        }
-    }
-
-    @AfterAll
-    public static void tearDownServer() throws Exception
-    {
-        _server.stop();
-    }
-
-    @Test
-    public void testServerDirectlyHTTP10() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        String result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerDirectlyHTTP11() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.1\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        Thread.sleep(100);
-
-        byte[] buf = new byte[4096];
-        int len = socket.getInputStream().read(buf);
-        String result = new String(buf, 0, len, StandardCharsets.UTF_8);
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerWithHttpClientStringContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new BytesRequestContent(__message.getBytes(StandardCharsets.UTF_8)));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-            assertEquals(__message, _received);
-            assertEquals(200, response.getStatus());
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    @Test
-    public void testServerWithHttpClientStreamContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            String sent = IO.toString(new FileInputStream("src/test/resources/message.txt"));
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new StringRequestContent(sent));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-
-            assertEquals(200, response.getStatus());
-            assertEquals(sent, _received);
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    public static class PostServlet extends HttpServlet
-    {
-        @Override
-        public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException
-        {
-            String received = IO.toString(request.getInputStream());
-            _received = received;
-
-            response.setStatus(200);
-            response.getWriter().println("Received " + received.length() + " bytes");
-        }
-    }
-
-    protected String newResponse(String method, String uri, String cnonce, String principal, String realm, String credentials, String nonce, String qop)
-        throws Exception
-    {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-
-        // calc A1 digest
-        md.update(principal.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(realm.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(credentials.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update(method.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(uri.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha2 = md.digest();
-
-        md.update(TypeUtil.toString(ha1, 16).getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(NC.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(cnonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(qop.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(StandardCharsets.ISO_8859_1));
-        byte[] digest = md.digest();
-
-        // check digest
-        return encode(digest);
-    }
-
-    private static String encode(byte[] data)
-    {
-        StringBuilder buffer = new StringBuilder();
-        for (byte datum : data)
-        {
-            buffer.append(Integer.toHexString((datum & 0xf0) >>> 4));
-            buffer.append(Integer.toHexString(datum & 0x0f));
-        }
-        return buffer.toString();
     }
 }

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/ConstraintTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/ConstraintTest.java
@@ -67,6 +67,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -496,7 +497,7 @@ public class ConstraintTest
         assertEquals(1, mappings.size());
         ConstraintMapping mapping = mappings.get(0);
         Constraint constraint = mapping.getConstraint();
-        assertSame(constraint.getAuthorization(), Constraint.Authorization.FORBIDDEN);
+        assertSame(Constraint.Authorization.FORBIDDEN, constraint.getAuthorization());
     }
 
     /**
@@ -514,7 +515,7 @@ public class ConstraintTest
         assertFalse(mappings.isEmpty());
         assertEquals(1, mappings.size());
         ConstraintMapping mapping = mappings.get(0);
-        assertNotSame(mapping.getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mapping.getConstraint().getAuthorization());
         assertNotNull(mapping.getConstraint().getRoles());
         assertEquals("R1", mapping.getConstraint().getRoles().stream().findFirst().orElse(null));
         assertThat(mapping.getConstraint().getTransport(), not(is(Constraint.Transport.SECURE)));
@@ -566,7 +567,7 @@ public class ConstraintTest
         assertEquals(2, mappings.size());
         assertNotNull(mappings.get(0).getMethodOmissions());
         assertEquals("GET", mappings.get(0).getMethodOmissions()[0]);
-        assertNotSame(mappings.get(0).getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mappings.get(0).getConstraint().getAuthorization());
         assertEquals("R1", mappings.get(0).getConstraint().getRoles().stream().findFirst().orElse(null));
         assertEquals("GET", mappings.get(1).getMethod());
         assertNull(mappings.get(1).getMethodOmissions());
@@ -593,13 +594,13 @@ public class ConstraintTest
         assertEquals(2, mappings.size());
         assertNotNull(mappings.get(0).getMethodOmissions());
         assertEquals("TRACE", mappings.get(0).getMethodOmissions()[0]);
-        assertNotSame(mappings.get(0).getConstraint().getAuthorization(), Constraint.Authorization.ALLOWED);
+        assertNotSame(Constraint.Authorization.ALLOWED, mappings.get(0).getConstraint().getAuthorization());
         assertEquals("R1", mappings.get(0).getConstraint().getRoles().stream().findFirst().orElse(null));
         assertEquals("TRACE", mappings.get(1).getMethod());
         assertNull(mappings.get(1).getMethodOmissions());
         assertThat(mappings.get(1).getConstraint().getTransport(), not(is(Constraint.Transport.SECURE)));
         Constraint constraint = mappings.get(1).getConstraint();
-        assertSame(constraint.getAuthorization(), Constraint.Authorization.FORBIDDEN);
+        assertSame(Constraint.Authorization.FORBIDDEN, constraint.getAuthorization());
     }
 
     @Test
@@ -924,45 +925,20 @@ public class ConstraintTest
 
     private String digest(String nonce, String password, String nc) throws Exception
     {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] ha1;
-        // calc A1 digest
-        md.update("user".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("TestRealm".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(password.getBytes(ISO_8859_1));
-        ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update("GET".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("/ctx/auth/info".getBytes(ISO_8859_1));
-        byte[] ha2 = md.digest();
+        DigestAuthenticator authenticator = (DigestAuthenticator)_security.getAuthenticator();
+        MessageDigest md = MessageDigest.getInstance(authenticator.getAlgorithm());
 
-        // calc digest
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":"
-        // nc-value ":" unq(cnonce-value) ":" unq(qop-value) ":" H(A2) )
-        // <">
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":" H(A2)
-        // ) > <">
+        // Calculate A1 digest.
+        String a1 = "user:TestRealm:" + password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
 
-        md.update(TypeUtil.toString(ha1, 16).getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nc.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        String cnonce = "1234567890";
-        md.update(cnonce.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("auth".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(ISO_8859_1));
-        byte[] digest = md.digest();
+        // Calculate A2 digest.
+        String a2 = "GET:/ctx/auth/info";
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
 
-        // check digest
-        return TypeUtil.toString(digest, 16);
+        String rsp = TypeUtil.toString(ha1, 16) + ":" + nonce + ":" + nc +
+            ":1234567890:auth:" + TypeUtil.toString(ha2, 16);
+        return TypeUtil.toString(md.digest(rsp.getBytes(UTF_8)), 16);
     }
 
     @Test
@@ -988,61 +964,61 @@ public class ConstraintTest
         assertTrue(matcher.find());
         String nonce = matcher.group(1);
 
-        //wrong password
-        String digest = digest(nonce, "WRONG", "1");
+        // Wrong password.
+        String digest = digest(nonce, "WRONG", "00000001");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=1, " +
+            "nc=00000001, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // right password
-        digest = digest(nonce, "password", "2");
+        // Right password.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // once only
-        digest = digest(nonce, "password", "2");
+        // Replay of request with nc=00000002.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // increasing
-        digest = digest(nonce, "password", "4");
+        // Next request.
+        digest = digest(nonce, "password", "00000004");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=4, " +
+            "nc=00000004, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // out of order
-        digest = digest(nonce, "password", "3");
+        // Out of order request.
+        digest = digest(nonce, "password", "00000003");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=3, " +
+            "nc=00000003, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // stale
-        digest = digest(nonce, "password", "5");
+        // Beyond max nonce count.
+        digest = digest(nonce, "password", "00000006");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=5, " +
+            "nc=00000006, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/DigestPostTest.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/src/test/java/org/eclipse/jetty/ee11/test/DigestPostTest.java
@@ -13,11 +13,12 @@
 
 package org.eclipse.jetty.ee11.test;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
@@ -25,62 +26,344 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.AuthenticationStore;
-import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.DigestAuthentication;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.PathRequestContent;
 import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.UserPrincipal;
 import org.eclipse.jetty.security.authentication.DigestAuthenticator;
-import org.eclipse.jetty.server.Connector;
 import org.eclipse.jetty.server.Handler;
-import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.handler.DefaultHandler;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.util.security.Password;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DigestPostTest
 {
-    private static final String NC = "00000001";
+    private static final String MESSAGE = """
+        0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789
+        9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210
+        1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890
+        0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321
+        abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
+        ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ
+        Now is the time for all good men to come to the aid of the party.
+        How now brown cow.
+        The quick brown fox jumped over the lazy dog.
+        """;
 
-    public static final String __message =
-        "0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 \n" +
-            "9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 \n" +
-            "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 \n" +
-            "0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 \n" +
-            "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz \n" +
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ \n" +
-            "Now is the time for all good men to come to the aid of the party.\n" +
-            "How now brown cow.\n" +
-            "The quick brown fox jumped over the lazy dog.\n";
+    private final String _user = "testuser";
+    private final String _password = "password";
+    private final String _realm = "testrealm";
+    private final String nc = "00000001";
+    private final String cnonce = "CLIENT_NONCE";
+    private Server _server;
+    private ServerConnector _connector;
+    private PostServlet _servlet;
+    private DigestAuthenticator _authenticator;
 
-    public static volatile String _received = null;
-    private static Server _server;
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
+        context.setContextPath("/test");
+        _servlet = new PostServlet();
+        context.addServlet(_servlet, "/");
+
+        TestLoginService realm = new TestLoginService(_realm);
+        realm.putUser(_user, new Password(_password), new String[]{"testRole"});
+        _server.addBean(realm);
+
+        ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
+        _authenticator = new DigestAuthenticator();
+        security.setAuthenticator(_authenticator);
+        security.setLoginService(realm);
+
+        Constraint constraint = new Constraint.Builder()
+            .name("SecureTest")
+            .roles("testRole")
+            .build();
+        ConstraintMapping mapping = new ConstraintMapping();
+        mapping.setConstraint(constraint);
+        mapping.setPathSpec("/*");
+
+        security.setConstraintMappings(Collections.singletonList(mapping));
+
+        _server.setHandler(new Handler.Sequence(context, new DefaultHandler()));
+
+        _server.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        _server.stop();
+    }
+
+    @Test
+    public void testServerDirectlyHTTP10() throws Exception
+    {
+        try (SocketChannel socket1 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.0
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket1.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket1);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+            
+            try (SocketChannel socket2 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+            {
+                _servlet._received = null;
+                request = """
+                    POST /test/ HTTP/1.0
+                    Host: localhost
+                    Content-Length: %d
+                    Authorization: %s
+                    
+                    %s\
+                    """.formatted(MESSAGE.length(), digest, MESSAGE);
+                socket2.write(UTF_8.encode(request));
+
+                response = HttpTester.parseResponse(socket2);
+
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(MESSAGE, _servlet._received);
+            }
+        }
+    }
+
+    @Test
+    public void testServerDirectlyHTTP11() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testUserStar() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String encodedUser = "UTF-8''" + _user.replace("e", "%65");
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username*="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(encodedUser, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientStringContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new StringRequestContent(MESSAGE))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(MESSAGE, _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientPathContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            Path path = MavenPaths.findTestResourceFile("message.txt");
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new PathRequestContent(path))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(Files.readString(path), _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    private String newResponse(String method, String uri, String nonce) throws Exception
+    {
+        MessageDigest md = MessageDigest.getInstance(_authenticator.getAlgorithm());
+
+        // Calculate A1 digest.
+        String a1 = _user + ":" + _realm + ":" + _password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
+
+        // Calculate A2 digest.
+        String a2 = method + ":" + uri;
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
+
+        String rsp = TypeUtil.toString(ha1, 16) + ":" + nonce + ":" + nc +
+            ":" + cnonce + ":auth:" + TypeUtil.toString(ha2, 16);
+        return TypeUtil.toString(md.digest(rsp.getBytes(UTF_8)), 16);
+    }
+
+    private String nonceFrom(String authenticate)
+    {
+        Pattern pattern = Pattern.compile("nonce=\"([^\"]+)\"");
+        Matcher matcher = pattern.matcher(authenticate);
+        if (matcher.find())
+            return matcher.group(1);
+        return null;
+    }
+
+    public static class PostServlet extends HttpServlet
+    {
+        public String _received;
+
+        @Override
+        public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
+        {
+            String received = IO.toString(request.getInputStream());
+            _received = received;
+
+            response.setStatus(200);
+            response.getWriter().println("Received " + received.length() + " bytes");
+        }
+    }
 
     public static class TestLoginService extends AbstractLoginService
     {
@@ -92,12 +375,12 @@ public class DigestPostTest
             setName(name);
         }
 
-        public void putUser(String username, Credential credential, String[] rolenames)
+        public void putUser(String username, Credential credential, String[] roleNames)
         {
             UserPrincipal userPrincipal = new UserPrincipal(username, credential);
             users.put(username, userPrincipal);
-            if (rolenames != null)
-                roles.put(username, Arrays.stream(rolenames).map(RolePrincipal::new).collect(Collectors.toList()));
+            if (roleNames != null)
+                roles.put(username, Arrays.stream(roleNames).map(RolePrincipal::new).toList());
         }
 
         @Override
@@ -111,264 +394,5 @@ public class DigestPostTest
         {
             return users.get(username);
         }
-    }
-
-    @BeforeAll
-    public static void setUpServer()
-    {
-        try
-        {
-            _server = new Server();
-            _server.setConnectors(new Connector[]{new ServerConnector(_server)});
-
-            ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
-            context.setContextPath("/test");
-            context.addServlet(PostServlet.class, "/");
-
-            TestLoginService realm = new TestLoginService("test");
-            realm.putUser("testuser", new Password("password"), new String[]{"test"});
-            _server.addBean(realm);
-
-            ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
-            security.setAuthenticator(new DigestAuthenticator());
-            security.setLoginService(realm);
-
-            Constraint constraint = new Constraint.Builder()
-                .name("SecureTest")
-                .roles("test")
-                .build();
-            ConstraintMapping mapping = new ConstraintMapping();
-            mapping.setConstraint(constraint);
-            mapping.setPathSpec("/*");
-
-            security.setConstraintMappings(Collections.singletonList(mapping));
-
-            _server.setHandler(new Handler.Sequence(context, new DefaultHandler()));
-
-            _server.start();
-        }
-        catch (final Exception e)
-        {
-            e.printStackTrace();
-        }
-    }
-
-    @AfterAll
-    public static void tearDownServer() throws Exception
-    {
-        _server.stop();
-    }
-
-    @Test
-    public void testServerDirectlyHTTP10() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        String result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerDirectlyHTTP11() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.1\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        Thread.sleep(100);
-
-        byte[] buf = new byte[4096];
-        int len = socket.getInputStream().read(buf);
-        String result = new String(buf, 0, len, StandardCharsets.UTF_8);
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(TimeUnit.NANOSECONDS.toMillis(System.nanoTime())).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerWithHttpClientStringContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new BytesRequestContent(__message.getBytes(StandardCharsets.UTF_8)));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-            assertEquals(__message, _received);
-            assertEquals(200, response.getStatus());
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    @Test
-    public void testServerWithHttpClientStreamContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            String sent = IO.toString(new FileInputStream("src/test/resources/message.txt"));
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new StringRequestContent(sent));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-
-            assertEquals(200, response.getStatus());
-            assertEquals(sent, _received);
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    public static class PostServlet extends HttpServlet
-    {
-        @Override
-        public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException
-        {
-            String received = IO.toString(request.getInputStream());
-            _received = received;
-
-            response.setStatus(200);
-            response.getWriter().println("Received " + received.length() + " bytes");
-        }
-    }
-
-    protected String newResponse(String method, String uri, String cnonce, String principal, String realm, String credentials, String nonce, String qop)
-        throws Exception
-    {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-
-        // calc A1 digest
-        md.update(principal.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(realm.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(credentials.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update(method.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(uri.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha2 = md.digest();
-
-        md.update(TypeUtil.toString(ha1, 16).getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(NC.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(cnonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(qop.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(StandardCharsets.ISO_8859_1));
-        byte[] digest = md.digest();
-
-        // check digest
-        return encode(digest);
-    }
-
-    private static String encode(byte[] data)
-    {
-        StringBuilder buffer = new StringBuilder();
-        for (byte datum : data)
-        {
-            buffer.append(Integer.toHexString((datum & 0xf0) >>> 4));
-            buffer.append(Integer.toHexString(datum & 0x0f));
-        }
-        return buffer.toString();
     }
 }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/DigestAuthenticator.java
@@ -15,17 +15,21 @@ package org.eclipse.jetty.ee9.security.authentication;
 
 import java.io.IOException;
 import java.io.Serial;
-import java.nio.charset.StandardCharsets;
+import java.net.URI;
+import java.nio.ByteBuffer;
+import java.security.GeneralSecurityException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Base64;
 import java.util.BitSet;
 import java.util.Iterator;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
-import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ConcurrentMap;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
@@ -45,6 +49,8 @@ import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 /**
  * The nonce max age in ms can be set with the {@link SecurityHandler#setInitParameter(String, String)}
  * using the name "maxNonceAge".  The nonce max count can be set with {@link SecurityHandler#setInitParameter(String, String)}
@@ -56,22 +62,20 @@ public class DigestAuthenticator extends LoginAuthenticator
     private static final QuotedStringTokenizer TOKENIZER = QuotedStringTokenizer.builder().delimiters("=, ").returnDelimiters().allowEmbeddedQuotes().build();
 
     private final SecureRandom _random = new SecureRandom();
-    private final ConcurrentMap<String, Nonce> _nonceMap = new ConcurrentHashMap<>();
-    private final Queue<Nonce> _nonceQueue = new ConcurrentLinkedQueue<>();
+    private final Map<String, Nonce> _nonces = new ConcurrentHashMap<>();
+    private final SecretKey _secretKey;
     private long _maxNonceAgeMs = 60 * 1000;
-    private int _maxNC = 1024;
-    private String _algorithm = "MD5";
-    
-    public void setAlgorithm(String algorithm)
+    private int _maxNonceCount = 1024;
+    private String _algorithm = "SHA-256";
+    private boolean _userHashing;
+
+    public DigestAuthenticator()
     {
-        _algorithm = algorithm;
+        byte[] bytes = new byte[32];
+        _random.nextBytes(bytes);
+        _secretKey = new SecretKeySpec(bytes, "HmacSHA256");
     }
 
-    public String getAlgorithm()
-    {
-        return _algorithm;
-    }
-    
     @Override
     public void setConfiguration(AuthConfiguration configuration)
     {
@@ -85,24 +89,68 @@ public class DigestAuthenticator extends LoginAuthenticator
             setMaxNonceCount(Integer.parseInt(mnc));
     }
 
+    /**
+     * @return the max number of times a nonce is used
+     */
     public int getMaxNonceCount()
     {
-        return _maxNC;
+        return _maxNonceCount;
     }
 
-    public void setMaxNonceCount(int maxNC)
+    /**
+     * @param maxNonceCount the max number of times a nonce is used
+     */
+    public void setMaxNonceCount(int maxNonceCount)
     {
-        _maxNC = maxNC;
+        _maxNonceCount = maxNonceCount;
     }
 
+    /**
+     * @return the max age of a nonce in milliseconds
+     */
     public long getMaxNonceAge()
     {
         return _maxNonceAgeMs;
     }
 
+    /**
+     * @param maxNonceAgeInMillis the max age of a nonce in milliseconds
+     */
     public void setMaxNonceAge(long maxNonceAgeInMillis)
     {
         _maxNonceAgeMs = maxNonceAgeInMillis;
+    }
+
+    /**
+     * @return the {@link MessageDigest} algorithm
+     */
+    public String getAlgorithm()
+    {
+        return _algorithm;
+    }
+
+    /**
+     * @param algorithm the {@link MessageDigest} algorithm
+     */
+    public void setAlgorithm(String algorithm)
+    {
+        _algorithm = Objects.requireNonNull(algorithm);
+    }
+
+    /**
+     * @return whether the username is hashed
+     */
+    public boolean isUserHashing()
+    {
+        return _userHashing;
+    }
+
+    /**
+     * @param userHashing whether the username is hashed
+     */
+    public void setUserHashing(boolean userHashing)
+    {
+        _userHashing = userHashing;
     }
 
     @Override
@@ -136,90 +184,189 @@ public class DigestAuthenticator extends LoginAuthenticator
             boolean stale = false;
             if (credentials != null)
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Credentials: {}", credentials);
-                final Digest digest = new Digest(request.getMethod(), getAlgorithm());
-                String last = null;
-                String name = null;
-
-                for (Iterator<String> i = TOKENIZER.tokenize(credentials); i.hasNext();)
+                Digest digest = parseDigest(request.getMethod(), credentials);
+                if (digest != null)
                 {
-                    String tok = i.next();
-                    char c = (tok.length() == 1) ? tok.charAt(0) : '\0';
-
-                    switch (c)
+                    if (verifyOpaque(digest))
                     {
-                        case '=':
-                            name = last;
-                            last = tok;
-                            break;
-                        case ',':
-                            name = null;
-                            break;
-                        case ' ':
-                            break;
-
-                        default:
-                            last = tok;
-                            if (name != null)
+                        int n = checkNonce(digest);
+                        if (n > 0)
+                        {
+                            // Nonce correctness is a prerequisite for trusting digest.uri.
+                            // Check that the request URI matches the credential's URI.
+                            if (Objects.equals(digest.uri, baseRequest.getHttpURI().getPathQuery()))
                             {
-                                if ("username".equalsIgnoreCase(name))
-                                    digest.username = tok;
-                                else if ("realm".equalsIgnoreCase(name))
-                                    digest.realm = tok;
-                                else if ("nonce".equalsIgnoreCase(name))
-                                    digest.nonce = tok;
-                                else if ("nc".equalsIgnoreCase(name))
-                                    digest.nc = tok;
-                                else if ("cnonce".equalsIgnoreCase(name))
-                                    digest.cnonce = tok;
-                                else if ("qop".equalsIgnoreCase(name))
-                                    digest.qop = tok;
-                                else if ("uri".equalsIgnoreCase(name))
-                                    digest.uri = tok;
-                                else if ("response".equalsIgnoreCase(name))
-                                    digest.response = tok;
-                                name = null;
+                                UserIdentity user = login(digest.resolvedUserName, digest, request);
+                                if (user != null)
+                                    return new UserAuthentication(getAuthMethod(), user);
                             }
+                        }
+                        else if (n == 0)
+                        {
+                            // Only good nonces can be stale.
+                            stale = true;
+                        }
                     }
                 }
-
-                int n = checkNonce(digest, baseRequest);
-
-                if (n > 0)
-                {
-                    //UserIdentity user = _loginService.login(digest.username,digest);
-                    UserIdentity user = login(digest.username, digest, req);
-                    if (user != null)
-                    {
-                        return new UserAuthentication(getAuthMethod(), user);
-                    }
-                }
-                else if (n == 0)
-                    stale = true;
             }
 
-            if (!DeferredAuthentication.isDeferred(response))
-            {
-                String domain = request.getContextPath();
-                if (domain == null)
-                    domain = "/";
-                response.setHeader(getChallengeHeader().asString(), "Digest realm=\"" + _loginService.getName() +
-                    "\", domain=\"" + domain +
-                    "\", nonce=\"" + newNonce(baseRequest) +
-                    "\", algorithm=" + getAlgorithm() +
-                    ", qop=\"auth\"" +
-                    ", stale=" + stale);
-                response.sendError(getUnauthorizedStatusCode());
+            if (DeferredAuthentication.isDeferred(response))
+                return Authentication.UNAUTHENTICATED;
 
-                return Authentication.SEND_CONTINUE;
-            }
+            // Requests that don't have the Authorization header
+            // or that have it but it's invalid (e.g. missing/bad
+            // nonce, bad opaque, etc.) are replied with 401.
 
-            return Authentication.UNAUTHENTICATED;
+            String domain = request.getContextPath();
+            if (domain == null)
+                domain = "/";
+
+            // RFC 7616[3.3]: only realm, domain, nonce, opaque, and qop must be quoted.
+            // Parameters stale and algorithm must not be quoted.
+            String value = "Digest realm=\"%s\"".formatted(_loginService.getName());
+            if (!isProxyMode())
+                value += ", domain=\"%s\"".formatted(domain);
+            String nonce = newNonce(baseRequest);
+            value += ", nonce=\"%s\"".formatted(nonce);
+            value += ", opaque=\"%s\"".formatted(newOpaque(nonce));
+            value += ", stale=%s".formatted(stale);
+            value += ", algorithm=%s".formatted(getAlgorithm());
+            value += ", qop=\"auth\"";
+            value += ", charset=UTF-8";
+            value += ", userhash=%s".formatted(isUserHashing());
+            response.setHeader(getChallengeHeader().asString(), value);
+
+            response.sendError(getUnauthorizedStatusCode());
+            return Authentication.SEND_CONTINUE;
         }
         catch (IOException e)
         {
             throw new ServerAuthException(e);
+        }
+    }
+
+    private Digest parseDigest(String method, String credentials)
+    {
+        try
+        {
+            String name = null;
+            String value = null;
+            Digest digest = new Digest(method, getAlgorithm());
+            Iterator<String> i = TOKENIZER.tokenize(credentials);
+            while (i.hasNext())
+            {
+                String tok = i.next();
+                char c = (tok.length() == 1) ? tok.charAt(0) : '\0';
+                switch (c)
+                {
+                    case '=' -> name = value;
+                    case ',' -> name = null;
+                    case ' ' ->
+                    {
+                    }
+                    default ->
+                    {
+                        value = tok;
+                        if (name != null)
+                        {
+                            switch (name.toLowerCase(Locale.ROOT))
+                            {
+                                case "response" -> digest.response = tok;
+                                case "username" -> digest.username = tok;
+                                case "userhash" -> digest.userhash = Boolean.parseBoolean(tok);
+                                case "username*" -> digest.usernameStar = tok;
+                                case "realm" -> digest.realm = tok;
+                                case "uri" -> digest.uri = tok;
+                                case "algorithm" -> digest.algorithm = tok;
+                                case "qop" -> digest.qop = tok;
+                                case "nonce" -> digest.nonce = tok;
+                                case "cnonce" -> digest.cnonce = tok;
+                                case "nc" -> digest.nc = tok;
+                                case "opaque" -> digest.opaque = tok;
+                            }
+                            name = null;
+                        }
+                    }
+                }
+            }
+
+            if (digest.username != null && digest.usernameStar != null)
+                return null;
+
+            if (digest.nc == null || digest.nc.length() != 8)
+                return null;
+
+            if (!getAlgorithm().equalsIgnoreCase(digest.algorithm))
+                return null;
+
+            if (!"auth".equalsIgnoreCase(digest.qop))
+                return null;
+
+            String resolvedUserName;
+            if (digest.userhash && isUserHashing())
+            {
+                if (digest.username == null)
+                    return null;
+                resolvedUserName = resolveHashedUserName(digest.username);
+            }
+            else if (digest.usernameStar != null)
+            {
+                resolvedUserName = resolveEncodedUserName(digest.usernameStar);
+            }
+            else
+            {
+                resolvedUserName = digest.username;
+            }
+            digest.resolvedUserName = resolvedUserName;
+
+            return digest;
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to parse digest", x);
+            return null;
+        }
+    }
+
+    /**
+     * <p>Resolves the hashed username received in the {@code Authorization} header.</p>
+     * <p>This method should look up the plain username from the username hash.</p>
+     * <p>By default, this method throws {@link UnsupportedOperationException}.</p>
+     *
+     * @param hashedUserName the hashed username
+     * @return the plain username
+     */
+    protected String resolveHashedUserName(String hashedUserName)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * <p>Resolves the encoded username received in the {@code Authorization} header.</p>
+     * <p>The username is encoded with RFC-5987 and this method should decode it.</p>
+     * <p>By default, this method only decodes RFC-5987 usernames encoded with UTF-8
+     * and no language; for example username: {@code UTF-8''caf%E2%82%AC} is decoded
+     * as {@code caf€}.</p>
+     *
+     * @param encodedUserName the encoded username
+     * @return the decoded username
+     */
+    protected String resolveEncodedUserName(String encodedUserName)
+    {
+        try
+        {
+            if (encodedUserName == null)
+                return null;
+            String encodedPrefix = "UTF-8''";
+            if (encodedUserName.startsWith(encodedPrefix))
+                return URI.create("scheme:" + encodedUserName.substring(encodedPrefix.length())).getSchemeSpecificPart();
+            return encodedUserName;
+        }
+        catch (Throwable x)
+        {
+            // Likely badly encoded username.
+            return null;
         }
     }
 
@@ -234,115 +381,199 @@ public class DigestAuthenticator extends LoginAuthenticator
 
     public String newNonce(Request request)
     {
-        Nonce nonce;
-
-        do
+        try
         {
-            byte[] nounce = new byte[24];
-            _random.nextBytes(nounce);
-
-            nonce = new Nonce(Base64.getEncoder().encodeToString(nounce), request.getTimeStamp(), getMaxNonceCount());
+            // The format of the nonce is such that it does
+            // not need server-side storage to be checked.
+            // nonce = base64(timestamp | random | hmac(timestamp | random))
+            Mac mac = newMac();
+            int dataLength = 2 * Long.BYTES;
+            byte[] bytes = new byte[dataLength + mac.getMacLength()];
+            ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+            byteBuffer.putLong(request.getTimeStamp()).putLong(_random.nextLong());
+            mac.update(bytes, 0, dataLength);
+            mac.doFinal(bytes, dataLength);
+            return Base64.getEncoder().encodeToString(bytes);
         }
-        while (_nonceMap.putIfAbsent(nonce._nonce, nonce) != null);
-        _nonceQueue.add(nonce);
-
-        return nonce._nonce;
+        catch (GeneralSecurityException x)
+        {
+            throw new RuntimeException(x);
+        }
     }
 
     /**
      * @param digest the digest data to check
-     * @param request the request object
-     * @return -1 for a bad nonce, 0 for a stale none, 1 for a good nonce
+     * @return -1 for a bad nonce, 0 for a stale nonce, 1 for a good nonce
      */
-    private int checkNonce(Digest digest, Request request)
+    private int checkNonce(Digest digest)
     {
-        // firstly let's expire old nonces
-        long expired = request.getTimeStamp() - getMaxNonceAge();
-        Nonce nonce = _nonceQueue.peek();
-        while (nonce != null && nonce._ts < expired)
-        {
-            _nonceQueue.remove(nonce);
-            _nonceMap.remove(nonce._nonce);
-            nonce = _nonceQueue.peek();
-        }
-
-        // Now check the requested nonce
         try
         {
-            nonce = _nonceMap.get(digest.nonce);
+            String nonce = digest.nonce;
             if (nonce == null)
+                return -1;
+
+            String nc = digest.nc;
+            if (nc == null)
+                return -1;
+            long nonceNumber = Long.parseLong(digest.nc, 16);
+            if (nonceNumber >= getMaxNonceCount())
                 return 0;
 
-            long count = Long.parseLong(digest.nc, 16);
-            if (count >= _maxNC)
+            byte[] nonceBytes = Base64.getDecoder().decode(nonce);
+            ByteBuffer byteBuffer = ByteBuffer.wrap(nonceBytes);
+
+            long timestamp = byteBuffer.getLong();
+            long random = byteBuffer.getLong();
+
+            Mac mac = newMac();
+            int dataLength = 2 * Long.BYTES;
+            byte[] expected = new byte[dataLength + mac.getMacLength()];
+            ByteBuffer.wrap(expected).putLong(timestamp).putLong(random);
+            mac.update(expected, 0, dataLength);
+            mac.doFinal(expected, dataLength);
+
+            if (!MessageDigest.isEqual(expected, nonceBytes))
+                return -1;
+
+            long elapsed = System.currentTimeMillis() - timestamp;
+            if (elapsed < 0)
+                return -1;
+
+            if (elapsed > getMaxNonceAge())
                 return 0;
 
-            if (nonce.seen((int)count))
+            // Store the nonce to keep track of digest.nc, the nonce count.
+
+            // First, expire old nonces.
+            Iterator<Nonce> iterator = _nonces.values().iterator();
+            while (iterator.hasNext())
+            {
+                Nonce n = iterator.next();
+                elapsed = System.currentTimeMillis() - n._timestamp;
+                if (elapsed > getMaxNonceAge())
+                    iterator.remove();
+            }
+            // Store the used nonce.
+            Nonce n = _nonces.computeIfAbsent(nonce, k -> new Nonce(timestamp, getMaxNonceCount()));
+            // Check the nonce number to counter replay attacks.
+            if (n.seen((int)nonceNumber))
                 return -1;
 
             return 1;
         }
-        catch (Exception e)
+        catch (Throwable x)
         {
-            if (LOG.isTraceEnabled())
-                LOG.trace("IGNORED", e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to verify nonce", x);
+            return -1;
         }
-        return -1;
+    }
+
+    private String newOpaque(String nonce)
+    {
+        // The format of the opaque parameter is tied to the nonce:
+        // opaque = base64(hmac(nonce))
+        byte[] bytes = Base64.getDecoder().decode(nonce);
+        Mac mac = newMac();
+        byte[] macBytes = mac.doFinal(bytes);
+        return Base64.getEncoder().encodeToString(macBytes);
+    }
+
+    private boolean verifyOpaque(Digest digest)
+    {
+        try
+        {
+            // RFC-7616[3.3]: the opaque parameter SHOULD
+            // be sent by the client, but it may not.
+            if (digest.opaque == null)
+                return true;
+
+            String nonce = digest.nonce;
+            if (nonce == null)
+                return false;
+
+            Mac mac = newMac();
+            byte[] expected = mac.doFinal(Base64.getDecoder().decode(nonce));
+
+            byte[] actual = Base64.getDecoder().decode(digest.opaque);
+            return MessageDigest.isEqual(expected, actual);
+        }
+        catch (Throwable x)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to verify opaque", x);
+            return false;
+        }
+    }
+
+    private Mac newMac()
+    {
+        try
+        {
+            Mac mac = Mac.getInstance(_secretKey.getAlgorithm());
+            mac.init(_secretKey);
+            return mac;
+        }
+        catch (Throwable x)
+        {
+            throw new RuntimeException(x);
+        }
     }
 
     private static class Nonce
     {
         private final AutoLock _lock = new AutoLock();
-        final String _nonce;
-        final long _ts;
-        final BitSet _seen;
+        private final long _timestamp;
+        private final BitSet _seen;
 
-        public Nonce(String nonce, long ts, int size)
+        private Nonce(long timestamp, int size)
         {
-            _nonce = nonce;
-            _ts = ts;
+            _timestamp = timestamp;
             _seen = new BitSet(size);
         }
 
-        public boolean seen(int count)
+        private boolean seen(int number)
         {
             try (AutoLock ignored = _lock.lock())
             {
-                if (count >= _seen.size())
+                if (number >= _seen.size())
                     return true;
-                boolean s = _seen.get(count);
-                _seen.set(count);
+                boolean s = _seen.get(number);
+                _seen.set(number);
                 return s;
             }
         }
     }
 
+    // This class must remain {@code static} to avoid the hidden
+    // reference to the outer class, that would make it non-serializable.
     private static class Digest extends Credential
     {
         @Serial
         private static final long serialVersionUID = -2484639019549527724L;
-        private String algorithm;
-        final String method;
-        String username = "";
-        String realm = "";
-        String nonce = "";
-        String nc = "";
-        String cnonce = "";
-        String qop = "";
-        String uri = "";
-        String response = "";
 
-        Digest(String m)
-        {
-            this(m, "MD5");
-        }
-        
-        Digest(String method, String algorithm)
+        private final String method;
+        private String algorithm;
+        private String username;
+        private String usernameStar;
+        private String resolvedUserName;
+        private String realm;
+        private String nonce;
+        private String nc;
+        private String cnonce;
+        private String qop;
+        private String uri;
+        private String response;
+        private boolean userhash;
+        private String opaque;
+
+        private Digest(String method, String algorithm)
         {
             this.method = method;
             this.algorithm = algorithm;
         }
-        
+
         private String getAlgorithm()
         {
             return algorithm;
@@ -357,67 +588,47 @@ public class DigestAuthenticator extends LoginAuthenticator
 
             try
             {
-                // MD5 required by the specification
                 MessageDigest md = MessageDigest.getInstance(getAlgorithm());
                 byte[] ha1;
-                if (credentials instanceof Credential.MD5)
+                if (credentials instanceof MD5 md5)
                 {
                     // Credentials are already a MD5 digest - assume it's in
                     // form user:realm:password (we have no way to know since
                     // it's a digest, alright?)
-                    ha1 = ((Credential.MD5)credentials).getDigest();
+                    ha1 = md5.getDigest();
                 }
                 else
                 {
-                    // calc A1 digest
-                    md.update(username.getBytes(StandardCharsets.ISO_8859_1));
-                    md.update((byte)':');
-                    md.update(realm.getBytes(StandardCharsets.ISO_8859_1));
-                    md.update((byte)':');
-                    md.update(password.getBytes(StandardCharsets.ISO_8859_1));
-                    ha1 = md.digest();
+                    // Calculate H(A1).
+                    String a1 = resolvedUserName + ":" + realm + ":" + password;
+                    ha1 = md.digest(a1.getBytes(UTF_8));
                 }
-                // calc A2 digest
-                md.reset();
-                md.update(method.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(uri.getBytes(StandardCharsets.ISO_8859_1));
-                byte[] ha2 = md.digest();
 
-                // calc digest
-                // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":"
-                // nc-value ":" unq(cnonce-value) ":" unq(qop-value) ":" H(A2) )
-                // <">
-                // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":" H(A2)
-                // ) > <">
+                // Calculate H(A2).
+                String a2 = method + ":" + uri;
+                byte[] ha2 = md.digest(a2.getBytes(UTF_8));
 
-                md.update(TypeUtil.toString(ha1, 16).getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(nonce.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(nc.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(cnonce.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(qop.getBytes(StandardCharsets.ISO_8859_1));
-                md.update((byte)':');
-                md.update(TypeUtil.toString(ha2, 16).getBytes(StandardCharsets.ISO_8859_1));
-                
-                // check digest
-                return stringEquals(TypeUtil.toString(md.digest(), 16).toLowerCase(), response == null ? null : response.toLowerCase());
+                // Calculate response, must match what the client sent.
+                String expected = TypeUtil.toString(ha1, 16) + ":" +
+                    nonce + ":" + nc + ":" + cnonce + ":" + qop + ":" +
+                    TypeUtil.toString(ha2, 16);
+                expected = TypeUtil.toString(md.digest(expected.getBytes(UTF_8)), 16);
+
+                // Check digest.
+                return stringEquals(expected, response == null ? null : response.toLowerCase(Locale.ROOT));
             }
-            catch (Exception e)
+            catch (Throwable x)
             {
-                LOG.warn("Unable to process digest", e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to process digest", x);
+                return false;
             }
-
-            return false;
         }
 
         @Override
         public String toString()
         {
-            return username + "," + response;
+            return "%s@%x[u=%s]".formatted(TypeUtil.toShortName(getClass()), hashCode(), resolvedUserName);
         }
     }
 }

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/ConstraintTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/ConstraintTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -59,7 +60,6 @@ import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.util.StringUtil;
-import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.security.Password;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
@@ -70,6 +70,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -945,48 +946,22 @@ public class ConstraintTest
         }
     }
 
-    private static String CNONCE = "1234567890";
-
-    private String digest(String nonce, String username, String password, String uri, String nc) throws Exception
+    private String digest(String nonce, String password, String nc) throws Exception
     {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] ha1;
-        // calc A1 digest
-        md.update(username.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("TestRealm".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(password.getBytes(ISO_8859_1));
-        ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update("GET".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(uri.getBytes(ISO_8859_1));
-        byte[] ha2 = md.digest();
+        DigestAuthenticator authenticator = (DigestAuthenticator)_security.getAuthenticator();
+        MessageDigest md = MessageDigest.getInstance(authenticator.getAlgorithm());
 
-        // calc digest
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":"
-        // nc-value ":" unq(cnonce-value) ":" unq(qop-value) ":" H(A2) )
-        // <">
-        // request-digest = <"> < KD ( H(A1), unq(nonce-value) ":" H(A2)
-        // ) > <">
+        // Calculate A1 digest.
+        String a1 = "user:TestRealm:" + password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
 
-        md.update(TypeUtil.toString(ha1, 16).getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(nc.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(CNONCE.getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update("auth".getBytes(ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(ISO_8859_1));
-        byte[] digest = md.digest();
+        // Calculate A2 digest.
+        String a2 = "GET:/ctx/auth/info";
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
 
-        // check digest
-        return TypeUtil.toString(digest, 16);
+        String rsp = StringUtil.toHexString(ha1).toLowerCase(Locale.ROOT) + ":" + nonce + ":" + nc +
+            ":1234567890:auth:" + StringUtil.toHexString(ha2).toLowerCase(Locale.ROOT);
+        return StringUtil.toHexString(md.digest(rsp.getBytes(UTF_8))).toLowerCase(Locale.ROOT);
     }
 
     @Test
@@ -1012,61 +987,61 @@ public class ConstraintTest
         assertTrue(matcher.find());
         String nonce = matcher.group(1);
 
-        //wrong password
-        String digest = digest(nonce, "user", "WRONG", "/ctx/auth/info", "1");
+        // Wrong password.
+        String digest = digest(nonce, "WRONG", "00000001");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=1, " +
+            "nc=00000001, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // right password
-        digest = digest(nonce, "user", "password", "/ctx/auth/info", "2");
+        // Right password.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // once only
-        digest = digest(nonce, "user", "password", "/ctx/auth/info", "2");
+        // Replay of request with nc=00000002.
+        digest = digest(nonce, "password", "00000002");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=2, " +
+            "nc=00000002, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 401 Unauthorized"));
 
-        // increasing
-        digest = digest(nonce, "user", "password", "/ctx/auth/info", "4");
+        // Next request.
+        digest = digest(nonce, "password", "00000004");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=4, " +
+            "nc=00000004, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // out of order
-        digest = digest(nonce, "user", "password", "/ctx/auth/info", "3");
+        // Out of order request.
+        digest = digest(nonce, "password", "00000003");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=3, " +
+            "nc=00000003, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");
         assertThat(response, startsWith("HTTP/1.1 200 OK"));
 
-        // stale
-        digest = digest(nonce, "user", "password", "/ctx/auth/info", "5");
+        // Beyond max nonce count.
+        digest = digest(nonce, "password", "00000006");
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n" +
             "Authorization: Digest username=\"user\", qop=auth, cnonce=\"1234567890\", uri=\"/ctx/auth/info\", realm=\"TestRealm\", " +
-            "nc=5, " +
+            "nc=00000006, " +
             "nonce=\"" + nonce + "\", " +
             "response=\"" + digest + "\"\r\n" +
             "\r\n");

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/DigestPostTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/DigestPostTest.java
@@ -13,73 +13,355 @@
 
 package org.eclipse.jetty.ee9.test;
 
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.net.Socket;
+import java.net.InetSocketAddress;
 import java.net.URI;
-import java.nio.charset.StandardCharsets;
+import java.nio.channels.SocketChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.AuthenticationStore;
-import org.eclipse.jetty.client.BytesRequestContent;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.DigestAuthentication;
 import org.eclipse.jetty.client.HttpClient;
-import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.client.PathRequestContent;
 import org.eclipse.jetty.client.StringRequestContent;
 import org.eclipse.jetty.ee9.nested.ServletConstraint;
 import org.eclipse.jetty.ee9.security.ConstraintMapping;
 import org.eclipse.jetty.ee9.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee9.security.authentication.DigestAuthenticator;
 import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.security.AbstractLoginService;
 import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.UserPrincipal;
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.NetworkConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.IO;
-import org.eclipse.jetty.util.NanoTime;
-import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.security.Credential;
 import org.eclipse.jetty.util.security.Password;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class DigestPostTest
 {
-    private static final String NC = "00000001";
+    private static final String MESSAGE = """
+        0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789
+        9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210
+        1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890
+        0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321
+        abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz
+        ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ
+        Now is the time for all good men to come to the aid of the party.
+        How now brown cow.
+        The quick brown fox jumped over the lazy dog.
+        """;
 
-    public static final String __message =
-        "0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 0123456789 \n" +
-            "9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 9876543210 \n" +
-            "1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 1234567890 \n" +
-            "0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 0987654321 \n" +
-            "abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz \n" +
-            "ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ ABCDEFGHIJKLMNOPQRSTUVWXYZ \n" +
-            "Now is the time for all good men to come to the aid of the party.\n" +
-            "How now brown cow.\n" +
-            "The quick brown fox jumped over the lazy dog.\n";
+    private final String _user = "testuser";
+    private final String _password = "password";
+    private final String _realm = "testrealm";
+    private final String nc = "00000001";
+    private final String cnonce = "CLIENT_NONCE";
+    private Server _server;
+    private ServerConnector _connector;
+    private PostServlet _servlet;
+    private DigestAuthenticator _authenticator;
 
-    public static volatile String _received = null;
-    private static Server _server;
+    @BeforeEach
+    public void startServer() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+
+        ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
+        context.setContextPath("/test");
+        _servlet = new PostServlet();
+        context.addServlet(new ServletHolder(_servlet), "/");
+
+        TestLoginService realm = new TestLoginService(_realm);
+        realm.putUser(_user, new Password(_password), new String[]{"testRole"});
+        _server.addBean(realm);
+
+        ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
+        _authenticator = new DigestAuthenticator();
+        security.setAuthenticator(_authenticator);
+        security.setLoginService(realm);
+
+        ServletConstraint constraint = new ServletConstraint("SecureTest", "testRole");
+        constraint.setAuthenticate(true);
+        ConstraintMapping mapping = new ConstraintMapping();
+        mapping.setConstraint(constraint);
+        mapping.setPathSpec("/*");
+
+        security.setConstraintMappings(Collections.singletonList(mapping));
+
+        _server.setHandler(context);
+
+        _server.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        _server.stop();
+    }
+
+    @Test
+    public void testServerDirectlyHTTP10() throws Exception
+    {
+        try (SocketChannel socket1 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.0
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket1.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket1);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            try (SocketChannel socket2 = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+            {
+                _servlet._received = null;
+                request = """
+                    POST /test/ HTTP/1.0
+                    Host: localhost
+                    Content-Length: %d
+                    Authorization: %s
+                    
+                    %s\
+                    """.formatted(MESSAGE.length(), digest, MESSAGE);
+                socket2.write(UTF_8.encode(request));
+
+                response = HttpTester.parseResponse(socket2);
+
+                assertEquals(HttpStatus.OK_200, response.getStatus());
+                assertEquals(MESSAGE, _servlet._received);
+            }
+        }
+    }
+
+    @Test
+    public void testServerDirectlyHTTP11() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(_user, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testUserStar() throws Exception
+    {
+        try (SocketChannel socket = SocketChannel.open(new InetSocketAddress("localhost", _connector.getLocalPort())))
+        {
+            _servlet._received = null;
+            String request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                
+                %s\
+                """.formatted(MESSAGE.length(), MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            HttpTester.Response response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.UNAUTHORIZED_401, response.getStatus());
+            assertNull(_servlet._received);
+
+            String authenticate = response.get(HttpHeader.WWW_AUTHENTICATE);
+            String nonce = nonceFrom(authenticate);
+            assertNotNull(nonce);
+
+            String encodedUser = "UTF-8''" + _user.replace("e", "%65");
+            String rsp = newResponse("POST", "/test/", nonce);
+            String digest = """
+                Digest username*="%s", realm="%s", nonce="%s", uri="/test/", algorithm=%s, response="%s", qop=auth, nc=%s, cnonce="%s"\
+                """.formatted(encodedUser, _realm, nonce, _authenticator.getAlgorithm(), rsp, nc, cnonce);
+
+            _servlet._received = null;
+            request = """
+                POST /test/ HTTP/1.1
+                Host: localhost
+                Content-Length: %d
+                Authorization: %s
+                
+                %s\
+                """.formatted(MESSAGE.length(), digest, MESSAGE);
+            socket.write(UTF_8.encode(request));
+
+            response = HttpTester.parseResponse(socket);
+
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(MESSAGE, _servlet._received);
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientStringContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new StringRequestContent(MESSAGE))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(MESSAGE, _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    @Test
+    public void testServerWithHttpClientPathContent() throws Exception
+    {
+        try (HttpClient client = new HttpClient())
+        {
+            String uri = "http://localhost:" + _connector.getLocalPort() + "/test/";
+            AuthenticationStore authStore = client.getAuthenticationStore();
+            authStore.addAuthentication(new DigestAuthentication(URI.create(uri), _realm, _user, _password));
+            client.start();
+
+            _servlet._received = null;
+            Path path = MavenPaths.findTestResourceFile("message.txt");
+            ContentResponse response = client.newRequest(uri)
+                .method(HttpMethod.POST)
+                .body(new PathRequestContent(path))
+                .timeout(5, TimeUnit.SECONDS)
+                .send();
+
+            assertEquals(Files.readString(path), _servlet._received);
+            assertEquals(200, response.getStatus());
+        }
+    }
+
+    private String newResponse(String method, String uri, String nonce) throws Exception
+    {
+        MessageDigest md = MessageDigest.getInstance(_authenticator.getAlgorithm());
+
+        // Calculate A1 digest.
+        String a1 = _user + ":" + _realm + ":" + _password;
+        byte[] ha1 = md.digest(a1.getBytes(UTF_8));
+
+        // Calculate A2 digest.
+        String a2 = method + ":" + uri;
+        byte[] ha2 = md.digest(a2.getBytes(UTF_8));
+
+        String rsp = StringUtil.toHexString(ha1).toLowerCase(Locale.ROOT) + ":" + nonce + ":" + nc +
+            ":" + cnonce + ":auth:" + StringUtil.toHexString(ha2).toLowerCase(Locale.ROOT);
+        return StringUtil.toHexString(md.digest(rsp.getBytes(UTF_8))).toLowerCase(Locale.ROOT);
+    }
+
+    private String nonceFrom(String authenticate)
+    {
+        Pattern pattern = Pattern.compile("nonce=\"([^\"]+)\"");
+        Matcher matcher = pattern.matcher(authenticate);
+        if (matcher.find())
+            return matcher.group(1);
+        return null;
+    }
+
+    public static class PostServlet extends HttpServlet
+    {
+        public String _received;
+
+        @Override
+        public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException
+        {
+            String received = IO.toString(request.getInputStream());
+            _received = received;
+
+            response.setStatus(200);
+            response.getWriter().println("Received " + received.length() + " bytes");
+        }
+    }
 
     public static class TestLoginService extends AbstractLoginService
     {
@@ -91,12 +373,12 @@ public class DigestPostTest
             setName(name);
         }
 
-        public void putUser(String username, Credential credential, String[] rolenames)
+        public void putUser(String username, Credential credential, String[] roleNames)
         {
             UserPrincipal userPrincipal = new UserPrincipal(username, credential);
             users.put(username, userPrincipal);
-            if (rolenames != null)
-                roles.put(username, Arrays.stream(rolenames).map(RolePrincipal::new).collect(Collectors.toList()));
+            if (roleNames != null)
+                roles.put(username, Arrays.stream(roleNames).map(RolePrincipal::new).toList());
         }
 
         @Override
@@ -110,262 +392,5 @@ public class DigestPostTest
         {
             return users.get(username);
         }
-    }
-
-    @BeforeAll
-    public static void setUpServer()
-    {
-        try
-        {
-            _server = new Server();
-            _server.setConnectors(new Connector[]{new ServerConnector(_server)});
-
-            ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SECURITY);
-            context.setContextPath("/test");
-            context.addServlet(PostServlet.class, "/");
-
-            TestLoginService realm = new TestLoginService("test");
-            realm.putUser("testuser", new Password("password"), new String[]{"test"});
-            _server.addBean(realm);
-
-            ConstraintSecurityHandler security = (ConstraintSecurityHandler)context.getSecurityHandler();
-            security.setAuthenticator(new DigestAuthenticator());
-            security.setLoginService(realm);
-
-            ServletConstraint constraint = new ServletConstraint("SecureTest", "test");
-            constraint.setAuthenticate(true);
-            ConstraintMapping mapping = new ConstraintMapping();
-            mapping.setConstraint(constraint);
-            mapping.setPathSpec("/*");
-
-            security.setConstraintMappings(Collections.singletonList(mapping));
-
-            _server.setHandler(context);
-
-            _server.start();
-        }
-        catch (final Exception e)
-        {
-            e.printStackTrace();
-        }
-    }
-
-    @AfterAll
-    public static void tearDownServer() throws Exception
-    {
-        _server.stop();
-    }
-
-    @Test
-    public void testServerDirectlyHTTP10() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        String result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(NanoTime.now()).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerDirectlyHTTP11() throws Exception
-    {
-        Socket socket = new Socket("127.0.0.1", ((NetworkConnector)_server.getConnectors()[0]).getLocalPort());
-        byte[] bytes = __message.getBytes(StandardCharsets.UTF_8);
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.1\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        Thread.sleep(100);
-
-        byte[] buf = new byte[4096];
-        int len = socket.getInputStream().read(buf);
-        String result = new String(buf, 0, len, StandardCharsets.UTF_8);
-
-        assertTrue(result.startsWith("HTTP/1.1 401 Unauthorized"));
-        assertNull(_received);
-
-        int n = result.indexOf("nonce=");
-        String nonce = result.substring(n + 7, result.indexOf('"', n + 7));
-        MessageDigest md = MessageDigest.getInstance("MD5");
-        byte[] b = md.digest(String.valueOf(NanoTime.now()).getBytes(StandardCharsets.ISO_8859_1));
-        String cnonce = encode(b);
-        String digest = "Digest username=\"testuser\" realm=\"test\" nonce=\"" + nonce + "\" uri=\"/test/\" algorithm=MD5 response=\"" +
-            newResponse("POST", "/test/", cnonce, "testuser", "test", "password", nonce, "auth") +
-            "\" qop=auth nc=" + NC + " cnonce=\"" + cnonce + "\"";
-
-        _received = null;
-        socket.getOutputStream().write(
-            ("POST /test/ HTTP/1.0\r\n" +
-                "Host: 127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "\r\n" +
-                "Content-Length: " + bytes.length + "\r\n" +
-                "Authorization: " + digest + "\r\n" +
-                "\r\n").getBytes(StandardCharsets.UTF_8));
-        socket.getOutputStream().write(bytes);
-        socket.getOutputStream().flush();
-
-        result = IO.toString(socket.getInputStream());
-
-        assertTrue(result.startsWith("HTTP/1.1 200 OK"));
-        assertEquals(__message, _received);
-    }
-
-    @Test
-    public void testServerWithHttpClientStringContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new BytesRequestContent(__message.getBytes(StandardCharsets.UTF_8)));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-            assertEquals(__message, _received);
-            assertEquals(200, response.getStatus());
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    @Test
-    public void testServerWithHttpClientStreamContent() throws Exception
-    {
-        String srvUrl = "http://127.0.0.1:" + ((NetworkConnector)_server.getConnectors()[0]).getLocalPort() + "/test/";
-        HttpClient client = new HttpClient();
-        try
-        {
-            AuthenticationStore authStore = client.getAuthenticationStore();
-            authStore.addAuthentication(new DigestAuthentication(new URI(srvUrl), "test", "testuser", "password"));
-            client.start();
-
-            String sent = IO.toString(new FileInputStream("src/test/resources/message.txt"));
-
-            Request request = client.newRequest(srvUrl);
-            request.method(HttpMethod.POST);
-            request.body(new StringRequestContent(sent));
-            _received = null;
-            request = request.timeout(5, TimeUnit.SECONDS);
-            ContentResponse response = request.send();
-
-            assertEquals(200, response.getStatus());
-            assertEquals(sent, _received);
-        }
-        finally
-        {
-            client.stop();
-        }
-    }
-
-    public static class PostServlet extends HttpServlet
-    {
-        @Override
-        public void doPost(HttpServletRequest request, HttpServletResponse response)
-            throws IOException
-        {
-            String received = IO.toString(request.getInputStream());
-            _received = received;
-
-            response.setStatus(200);
-            response.getWriter().println("Received " + received.length() + " bytes");
-        }
-    }
-
-    protected String newResponse(String method, String uri, String cnonce, String principal, String realm, String credentials, String nonce, String qop)
-        throws Exception
-    {
-        MessageDigest md = MessageDigest.getInstance("MD5");
-
-        // calc A1 digest
-        md.update(principal.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(realm.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(credentials.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha1 = md.digest();
-        // calc A2 digest
-        md.reset();
-        md.update(method.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(uri.getBytes(StandardCharsets.ISO_8859_1));
-        byte[] ha2 = md.digest();
-
-        md.update(TypeUtil.toString(ha1, 16).getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(nonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(NC.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(cnonce.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(qop.getBytes(StandardCharsets.ISO_8859_1));
-        md.update((byte)':');
-        md.update(TypeUtil.toString(ha2, 16).getBytes(StandardCharsets.ISO_8859_1));
-        byte[] digest = md.digest();
-
-        // check digest
-        return encode(digest);
-    }
-
-    private static String encode(byte[] data)
-    {
-        StringBuilder buffer = new StringBuilder();
-        for (byte datum : data)
-        {
-            buffer.append(Integer.toHexString((datum & 0xf0) >>> 4));
-            buffer.append(Integer.toHexString(datum & 0x0f));
-        }
-        return buffer.toString();
     }
 }


### PR DESCRIPTION
* Implemented RFC 7616 missing parameters in WWW-Authenticate and Authentication.
* Dropped support for qop=auth-int in the client, as it was broken anyway.
* Updated server implementation to use a lighter weight storage of nonces, now only used for counts (the nonce format now uses HMAC to be as stateless as possible).
* Support for non-ascii usernames in the client via `username*` parameter.