### PR TITLE
Issue #14006 - suppress warning logs for pending read in onCompleted (12.1)

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -47,6 +47,7 @@ import org.eclipse.jetty.http.UriCompliance;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.server.Components;
 import org.eclipse.jetty.server.ConnectionMetaData;
 import org.eclipse.jetty.server.Context;
@@ -1646,7 +1647,7 @@ public class HttpChannelState implements HttpChannel, Components
                 // Turn pending demand into failure.
                 if (httpChannelState._onContentAvailable != null)
                 {
-                    failure = ExceptionUtil.combine(failure, new IllegalStateException("demand pending"));
+                    failure = ExceptionUtil.combine(failure, new QuietException.Exception("demand pending"));
                 }
                 else
                 {
@@ -1657,6 +1658,8 @@ public class HttpChannelState implements HttpChannel, Components
                     // persistent otherwise RequestLog.log() would be able to read
                     // x-www-form-urlencoded parameters in one case and not the other.
                     Throwable unconsumed = stream.consumeAvailable();
+                    if (unconsumed != null)
+                        unconsumed = new QuietException.RuntimeException(unconsumed);
                     httpChannelState._consumeAvailableFailure = unconsumed;
                     if (httpChannelState.getConnectionMetaData().isPersistent() && !httpChannelState._expects100Continue)
                         failure = ExceptionUtil.combine(failure, unconsumed);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java
@@ -51,6 +51,7 @@ import org.eclipse.jetty.io.Connection;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
+import org.eclipse.jetty.io.QuietException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
 import org.eclipse.jetty.server.AbstractMetaDataConnection;
 import org.eclipse.jetty.server.ConnectionFactory;
@@ -1637,7 +1638,7 @@ public class HttpConnection extends AbstractMetaDataConnection implements Runnab
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("abort due to pending read {} {} ", this, getEndPoint());
-                abort(new IOException("Pending read in onCompleted"));
+                abort(new QuietException.Exception("Pending read in onCompleted"));
                 _httpChannel.recycle();
                 _parser.reset();
                 _generator.reset();


### PR DESCRIPTION
## Closes #14006

Merge changes from PR https://github.com/jetty/jetty.project/pull/15114 to `12.1.x`, with an additional check to wrap the exception from `stream.consumeAvailable()` as a `QuietException`.