### PR TITLE
IteratingCallback concurrent abort() may not notify abort event.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -1355,7 +1355,7 @@ public class GoAwayTest extends AbstractTest
         }
 
         // All the requests should fail, since the server is always closing the connection.
-        assertTrue(latch.await(15, TimeUnit.SECONDS));
+        assertTrue(latch.await(15, TimeUnit.SECONDS), latch.toString());
 
         List<Destination> destinations = httpClient.getDestinations();
         assertThat(destinations.size(), equalTo(1));

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -375,6 +375,7 @@ public abstract class IteratingCallback implements Callback
                 try
                 {
                     action = process();
+                    assert action != null;
                 }
                 catch (Throwable x)
                 {
@@ -395,7 +396,19 @@ public abstract class IteratingCallback implements Callback
                     case PROCESSING:
                     {
                         if (action == null)
-                            break processing;
+                        {
+                            if (_failure != null)
+                            {
+                                if (_aborted)
+                                    onAbortedOnFailureOnCompleted = _failure;
+                                else
+                                    onFailureOnCompleted = _failure;
+                                _state = _failure instanceof ClosedException ? State.CLOSED : State.COMPLETE;
+                                break processing;
+                            }
+                            throw new IllegalStateException(String.format("%s[action=%s]", this, action));
+                        }
+
                         switch (action)
                         {
                             case IDLE:
@@ -457,25 +470,42 @@ public abstract class IteratingCallback implements Callback
 
                     case PROCESSING_CALLED:
                     {
-                        if (action != Action.SCHEDULED && action != null)
+                        if (action == Action.SCHEDULED)
+                        {
+                            if (_failure != null)
+                            {
+                                if (_aborted)
+                                    onAbortedOnFailureOnCompleted = _failure;
+                                else
+                                    onFailureOnCompleted = _failure;
+                                _state = _failure instanceof ClosedException ? State.CLOSED : State.COMPLETE;
+                                break processing;
+                            }
+                            callOnSuccess = true;
+                            _state = State.PROCESSING;
+                            _reprocess = false;
+                            break;
+                        }
+                        if (action == null)
+                        {
+                            if (_failure != null)
+                            {
+                                if (_aborted)
+                                    onAbortedOnFailureOnCompleted = _failure;
+                                else
+                                    onFailureOnCompleted = _failure;
+                                _state = _failure instanceof ClosedException ? State.CLOSED : State.COMPLETE;
+                                break processing;
+                            }
+                            throw new IllegalStateException(String.format("%s[action=%s]", this, action));
+                        }
+                        else
                         {
                             _state = State.CLOSED;
-                            _failure = onAbortedOnFailureOnCompleted = ExceptionUtil.combine(_failure, new IllegalStateException("Action not scheduled"));
+                            _aborted = true;
+                            _failure = onAbortedOnFailureOnCompleted = ExceptionUtil.combine(_failure, new IllegalStateException("Action != SCHEDULED"));
                             break processing;
                         }
-                        if (_failure != null)
-                        {
-                            if (_aborted)
-                                onAbortedOnFailureOnCompleted = _failure;
-                            else
-                                onFailureOnCompleted = _failure;
-                            _state = _failure instanceof ClosedException ? State.CLOSED : State.COMPLETE;
-                            break processing;
-                        }
-                        callOnSuccess = true;
-                        _state = State.PROCESSING;
-                        _reprocess = false;
-                        break;
                     }
 
                     default:

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/IteratingCallback.java
@@ -336,18 +336,15 @@ public abstract class IteratingCallback implements Callback
         {
             switch (_state)
             {
-                case IDLE:
+                case IDLE ->
+                {
                     _state = State.PROCESSING;
                     process = true;
-                    break;
-
-                case PROCESSING:
-                case PROCESSING_CALLED:
-                    _reprocess = true;
-                    break;
-
-                default:
-                    break;
+                }
+                case PROCESSING, PROCESSING_CALLED -> _reprocess = true;
+                case PENDING, COMPLETE, CLOSED ->
+                {
+                }
             }
         }
         if (process)
@@ -393,7 +390,7 @@ public abstract class IteratingCallback implements Callback
 
                 switch (_state)
                 {
-                    case PROCESSING:
+                    case PROCESSING ->
                     {
                         if (action == null)
                         {
@@ -411,7 +408,7 @@ public abstract class IteratingCallback implements Callback
 
                         switch (action)
                         {
-                            case IDLE:
+                            case IDLE ->
                             {
                                 if (_aborted)
                                 {
@@ -432,7 +429,7 @@ public abstract class IteratingCallback implements Callback
                                 _state = State.IDLE;
                                 break processing;
                             }
-                            case SCHEDULED:
+                            case SCHEDULED ->
                             {
                                 // we won the race against the callback, so the callback has to process and we can break processing
                                 _state = State.PENDING;
@@ -444,7 +441,7 @@ public abstract class IteratingCallback implements Callback
                                 }
                                 break processing;
                             }
-                            case SUCCEEDED:
+                            case SUCCEEDED ->
                             {
                                 // we lost the race against the callback,
                                 _reprocess = false;
@@ -460,15 +457,9 @@ public abstract class IteratingCallback implements Callback
                                 }
                                 break processing;
                             }
-                            default:
-                            {
-                                break;
-                            }
                         }
-                        throw new IllegalStateException(String.format("%s[action=%s]", this, action));
                     }
-
-                    case PROCESSING_CALLED:
+                    case PROCESSING_CALLED ->
                     {
                         if (action == Action.SCHEDULED)
                         {
@@ -484,9 +475,8 @@ public abstract class IteratingCallback implements Callback
                             callOnSuccess = true;
                             _state = State.PROCESSING;
                             _reprocess = false;
-                            break;
                         }
-                        if (action == null)
+                        else if (action == null)
                         {
                             if (_failure != null)
                             {
@@ -502,14 +492,11 @@ public abstract class IteratingCallback implements Callback
                         else
                         {
                             _state = State.CLOSED;
-                            _aborted = true;
-                            _failure = onAbortedOnFailureOnCompleted = ExceptionUtil.combine(_failure, new IllegalStateException("Action != SCHEDULED"));
+                            _failure = onFailureOnCompleted = ExceptionUtil.combine(_failure, new IllegalStateException("Action != SCHEDULED"));
                             break processing;
                         }
                     }
-
-                    default:
-                        throw new IllegalStateException(String.format("%s[action=%s]", this, action));
+                    case IDLE, PENDING, COMPLETE, CLOSED -> throw new IllegalStateException(String.format("%s[action=%s]", this, action));
                 }
             }
             finally
@@ -559,13 +546,12 @@ public abstract class IteratingCallback implements Callback
                 LOG.debug("succeeded {}", this);
             switch (_state)
             {
-                case PROCESSING:
+                case PROCESSING ->
                 {
                     // Another thread is processing, so we just tell it the state
                     _state = State.PROCESSING_CALLED;
-                    break;
                 }
-                case PENDING:
+                case PENDING ->
                 {
                     if (_aborted)
                     {
@@ -587,27 +573,19 @@ public abstract class IteratingCallback implements Callback
                         _state = State.PROCESSING;
                         onSuccessProcessing = true;
                     }
-                    break;
                 }
-                case COMPLETE, CLOSED:
+                case COMPLETE, CLOSED ->
                 {
                     // Too late
                     return;
                 }
-                default:
-                {
-                    throw new IllegalStateException(toString());
-                }
+                case IDLE, PROCESSING_CALLED -> throw new IllegalStateException(toString());
             }
         }
         if (onSuccessProcessing)
-        {
             doOnSuccessProcessing();
-        }
         else if (onCompleted != null)
-        {
             doOnCompleted(onCompleted);
-        }
     }
 
     /**
@@ -640,15 +618,13 @@ public abstract class IteratingCallback implements Callback
                 LOG.debug("failed {}", this, cause);
             switch (_state)
             {
-                case PROCESSING:
-                case PROCESSING_CALLED:
+                case PROCESSING, PROCESSING_CALLED ->
                 {
                     // Another thread is processing, so we just tell it the state
                     _state = State.PROCESSING_CALLED;
                     _failure = ExceptionUtil.combine(_failure, cause);
-                    break;
                 }
-                case PENDING:
+                case PENDING ->
                 {
                     if (_aborted)
                     {
@@ -673,18 +649,14 @@ public abstract class IteratingCallback implements Callback
                         _failure = cause;
                         onFailureOnCompleted = _failure;
                     }
-                    break;
                 }
-                case COMPLETE, CLOSED:
+                case COMPLETE, CLOSED ->
                 {
                     // Too late
                     ExceptionUtil.addSuppressedIfNotAssociated(_failure, cause);
                     return;
                 }
-                default:
-                {
-                    throw new IllegalStateException(toString());
-                }
+                case IDLE -> throw new IllegalStateException(toString());
             }
         }
         if (onFailureOnCompleted != null)
@@ -733,7 +705,6 @@ public abstract class IteratingCallback implements Callback
                         _failure = new ClosedException();
                     }
                 }
-
                 case PENDING ->
                 {
                     // We are waiting for the callback, so we can only call onAbort and then keep waiting
@@ -741,12 +712,7 @@ public abstract class IteratingCallback implements Callback
                     _failure = new AbortingException(onAbortedOnFailureIfNotPendingDoCompleted);
                     _aborted = true;
                 }
-
-                case COMPLETE ->
-                {
-                    _state = State.CLOSED;
-                }
-
+                case COMPLETE -> _state = State.CLOSED;
                 case CLOSED ->
                 {
                     // too late
@@ -791,42 +757,34 @@ public abstract class IteratingCallback implements Callback
 
             switch (_state)
             {
-                case IDLE:
+                case IDLE ->
                 {
                     // Nothing happening so we can abort and complete
                     _state = State.COMPLETE;
                     _failure = cause;
                     _aborted = true;
                     onAbortedOnFailureOnCompleted = true;
-                    break;
                 }
-
-                case PROCESSING:
+                case PROCESSING ->
                 {
                     // Another thread is processing, so we just tell it the state and let it handle everything
                     _failure = cause;
                     _aborted = true;
-                    break;
                 }
-
-                case PROCESSING_CALLED:
+                case PROCESSING_CALLED ->
                 {
                     // Another thread is processing, but we have already succeeded or failed.
                     _failure = ExceptionUtil.combine(_failure, cause);
                     _aborted = true;
-                    break;
                 }
-
-                case PENDING:
+                case PENDING ->
                 {
                     // We are waiting for the callback, so we can only call onAbort and then keep waiting
                     onAbort = true;
                     _failure = new AbortingException(cause);
                     _aborted = true;
-                    break;
                 }
-
-                case COMPLETE, CLOSED:
+                case COMPLETE, CLOSED ->
                 {
                     // too late
                     ExceptionUtil.addSuppressedIfNotAssociated(_failure, cause);
@@ -932,20 +890,18 @@ public abstract class IteratingCallback implements Callback
     {
         try (AutoLock ignored = _lock.lock())
         {
-            switch (_state)
+            return switch (_state)
             {
-                case IDLE:
-                    return true;
-
-                case COMPLETE:
+                case IDLE -> true;
+                case COMPLETE ->
+                {
                     _state = State.IDLE;
                     _failure = null;
                     _reprocess = false;
-                    return true;
-
-                default:
-                    return false;
-            }
+                    yield true;
+                }
+                case PROCESSING, PROCESSING_CALLED, PENDING, CLOSED -> false;
+            };
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -46,6 +46,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class IteratingCallbackTest
@@ -973,6 +974,7 @@ public class IteratingCallbackTest
         icb.iterate();
         assertEquals(1, count.get());
         assertTrue(icb.isAborted());
+        assertNotNull(failure.get());
     }
 
     @Test
@@ -1007,6 +1009,7 @@ public class IteratingCallbackTest
         icb.succeeded();
         assertEquals(1, count.get());
         assertTrue(icb.isAborted());
+        assertNotNull(failure.get());
     }
 
     @Test

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/IteratingCallbackTest.java
@@ -636,7 +636,7 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testICBSuccess() throws Exception
+    public void testIterateThenSucceedThenFail() throws Exception
     {
         TestIteratingCB callback = new TestIteratingCB();
         callback.iterate();
@@ -656,7 +656,7 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testICBFailure() throws Exception
+    public void testIterateThenFailThenSucceed() throws Exception
     {
         Throwable failure = new Throwable();
         TestIteratingCB callback = new TestIteratingCB();
@@ -679,7 +679,7 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testICBAbortSuccess() throws Exception
+    public void testAbortThenSucceedThenFail() throws Exception
     {
         TestIteratingCB callback = new TestIteratingCB();
         callback.iterate();
@@ -905,10 +905,10 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testOnSuccessCalledDespiteISE() throws Exception
+    public void testOnFailureCalledWhenReturningWrongAction() throws Exception
     {
         CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<Throwable> aborted = new AtomicReference<>();
+        AtomicReference<Throwable> failure = new AtomicReference<>();
         IteratingCallback icb = new IteratingCallback()
         {
             @Override
@@ -919,16 +919,9 @@ public class IteratingCallbackTest
             }
 
             @Override
-            protected void onAborted(Throwable cause)
+            protected void onFailure(Throwable cause)
             {
-                aborted.set(cause);
-                super.onAborted(cause);
-            }
-
-            @Override
-            protected void onCompleteSuccess()
-            {
-                latch.countDown();
+                failure.set(cause);
             }
 
             @Override
@@ -940,11 +933,11 @@ public class IteratingCallbackTest
 
         icb.iterate();
         assertTrue(latch.await(5, TimeUnit.SECONDS));
-        assertThat(aborted.get(), instanceOf(IllegalStateException.class));
+        assertThat(failure.get(), instanceOf(IllegalStateException.class));
     }
 
     @Test
-    public void testAbortFromOnSuccessInProcess() throws Exception
+    public void testSucceededInProcessThenAbortFromOnSuccess() throws Exception
     {
         AtomicInteger count = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -978,7 +971,7 @@ public class IteratingCallbackTest
     }
 
     @Test
-    public void testAbortFromOnSuccessAfterProcess() throws Exception
+    public void testSucceededAfterProcessThenAbortFromOnSuccess() throws Exception
     {
         AtomicInteger count = new AtomicInteger();
         AtomicReference<Throwable> failure = new AtomicReference<>();
@@ -1119,7 +1112,7 @@ public class IteratingCallbackTest
 
     @ParameterizedTest
     @ValueSource(booleans = {false, true})
-    public void testAbortThenFailFromProcess(boolean succeed)
+    public void testAbortThenCompleteThenThrowFromProcess(boolean succeed)
     {
         AccountingIteratingCallback icb = new AccountingIteratingCallback()
         {


### PR DESCRIPTION
In `IteratingCallback`, it was possible that a concurrent call to `abort()` found the `IteratingCallback` in `PROCESSING` state (as another thread was iterating it). The contract is that event notifications (calling the `onXYZ()` methods) must be serialized, so the aborting thread was supposed to only change the state, and the iterating thread was supposed to emit the abort event.

However, `processing(false)` was re-entered; the parameter was `false` because of the concurrent abort(). This lead to the `action` to remain `null`, and the handling of the `action` in the `PROCESSING` state was just to exit the iteration, without notifying the abort event.

The fix is to handle the case where `action==null` in the `PROCESSING` case, and notify the abort event.