### PR TITLE
[httpclient] forward httpversion for http:// uri on request.copy to avoid to loose protocol constraints on redirects for example

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -134,7 +134,16 @@ public class HttpRequest implements Request
             newURI = HttpURI.from(getScheme(), getHost(), getPort(), null).toURI();
 
         HttpRequest newRequest = copyInstance(newURI);
-        newRequest.useVersion(getVersion());
+        if (isVersionExplicit() && "http".equals(uri.getScheme()))
+        {
+            // this part is a bit hard since we don't know if we can forward to the new address
+            // for now only copy for http, assume https will guess it with alpn
+            newRequest.version(getVersion());
+        }
+        else
+        {
+            newRequest.useVersion(getVersion());
+        }
         newRequest.method(getMethod())
             .body(getBody())
             .idleTimeout(getIdleTimeout(), TimeUnit.MILLISECONDS)

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/transport/HttpRequestTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/transport/HttpRequestTest.java
@@ -1,0 +1,40 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.client.transport;
+
+import java.net.URI;
+
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.http.HttpVersion;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpRequestTest
+{
+    @Test
+    void forwardVersionOnCopy() throws Exception
+    {
+        try (final var client = new HttpClient())
+        {
+            final var req = new HttpRequest(client, null, URI.create("http://localhost:1234"));
+            assertEquals(HttpVersion.HTTP_1_1, req.getVersion());
+
+            assertEquals(HttpVersion.HTTP_1_1, req.copy(URI.create("http://localhost:4567")).getVersion());
+
+            req.useVersion(HttpVersion.HTTP_2);
+            assertEquals(HttpVersion.HTTP_2, req.copy(URI.create("http://localhost:4567")).getVersion());
+        }
+    }
+}


### PR DESCRIPTION
main issue is upgrading from 12.1.0 to any more recent version the httpredirector code changed the way the request copy passed to the destination was done and now we don't forward the version explicitly set on the request so if using http2 in preference over http1 in a dynamic client transport and set http/1.1  as version on the request, it is lost on the redirect and it is likely it fails.

indeed it mainly occurs on http backends but it happens and broke some validation environments.

idea there is to forward the version if set and the protocol is not using SSL so it is likely the version will not be guessed (no alpn).