### PR TITLE
 Issue #15228 - Deprecate use of `newResource()` during webapp started phase.

### DIFF
--- a/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
+++ b/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
@@ -35,6 +35,7 @@ import java.util.StringTokenizer;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.jar.Manifest;
 
+import org.eclipse.jetty.io.IOResources;
 import org.eclipse.jetty.util.ClassMatcher;
 import org.eclipse.jetty.util.ClassVisibilityChecker;
 import org.eclipse.jetty.util.FileID;
@@ -96,7 +97,9 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
          * @param urlOrPath The URL or path to convert
          * @return The Resource for the URL/path
          * @throws IOException The Resource could not be created.
+         * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
          */
+        @Deprecated(since = "12.1.11", forRemoval = true)
         Resource newResource(String urlOrPath) throws IOException;
 
         /**
@@ -637,14 +640,17 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
                 if (externalForm.startsWith("jar:file:") && externalForm.contains("!/"))
                 {
                     URI jarURI = URIUtil.unwrapContainer(new URI(externalForm));
-                    Resource manifestResource = getContext().newResource(URIUtil.uriJarPrefix(jarURI, "!/META-INF/MANIFEST.MF").toASCIIString());
-                    if (manifestResource.exists())
+                    try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
                     {
-                        try (InputStream is = manifestResource.newInputStream())
+                        Resource manifestResource = resourceFactory.newResource(URIUtil.uriJarPrefix(jarURI, "!/META-INF/MANIFEST.MF").toASCIIString());
+                        if (Resources.isReadableFile(manifestResource))
                         {
-                            Manifest manifest = new Manifest(is);
-                            definePackage(packageName, manifest, jarURI.toURL());
-                            return;
+                            try (InputStream is = IOResources.asInputStream(manifestResource))
+                            {
+                                Manifest manifest = new Manifest(is);
+                                definePackage(packageName, manifest, jarURI.toURL());
+                                return;
+                            }
                         }
                     }
                 }

--- a/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
+++ b/jetty-core/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppClassLoader.java
@@ -97,7 +97,9 @@ public class WebAppClassLoader extends URLClassLoader implements ClassVisibility
          * @param urlOrPath The URL or path to convert
          * @return The Resource for the URL/path
          * @throws IOException The Resource could not be created.
-         * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
+         * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
+         *             at webapp initialization time only.  The use of this method during
+         *             context started phase can result in excessive memory consumption.
          */
         @Deprecated(since = "12.1.11", forRemoval = true)
         Resource newResource(String urlOrPath) throws IOException;

--- a/jetty-core/jetty-util/src/main/java/module-info.java
+++ b/jetty-core/jetty-util/src/main/java/module-info.java
@@ -39,5 +39,10 @@ module org.eclipse.jetty.util
     exports org.eclipse.jetty.util.thread;
     exports org.eclipse.jetty.util.thread.strategy;
 
+    // Allow representation of
+    // opens org.eclipse.jetty.util.resource
+       // to java.management,
+         //  org.eclipse.jetty.jmx;
+
     uses org.eclipse.jetty.util.security.CredentialProvider;
 }

--- a/jetty-core/jetty-util/src/main/java/module-info.java
+++ b/jetty-core/jetty-util/src/main/java/module-info.java
@@ -39,10 +39,5 @@ module org.eclipse.jetty.util
     exports org.eclipse.jetty.util.thread;
     exports org.eclipse.jetty.util.thread.strategy;
 
-    // Allow representation of
-    // opens org.eclipse.jetty.util.resource
-       // to java.management,
-         //  org.eclipse.jetty.jmx;
-
     uses org.eclipse.jetty.util.security.CredentialProvider;
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResource.java
@@ -19,11 +19,14 @@ import java.nio.file.FileSystem;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
 
 /**
  * Java NIO Path Resource with file system pooling. {@link FileSystem} implementations that must be closed
  * must use this class, for instance the one handling the `jar` scheme.
  */
+@ManagedObject("A Mounted Path Resource")
 public class MountedPathResource extends PathResource
 {
     private final FileSystem fileSystem;
@@ -62,11 +65,13 @@ public class MountedPathResource extends PathResource
         return URIUtil.unwrapContainer(container.getURI()).equals(containerUri);
     }
 
+    @ManagedAttribute("The FileSystem")
     public FileSystem getFileSystem()
     {
         return fileSystem;
     }
 
+    @ManagedAttribute("The Container Path")
     public Path getContainerPath()
     {
         return containerUri == null ? null : Path.of(containerUri);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/MountedPathResourceFactory.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.annotation.ManagedObject;
 
 /**
  * A ResourceFactory for mounted FileSystems.
@@ -31,6 +32,7 @@ import org.eclipse.jetty.util.URIUtil;
  * as a {@link FileSystem} suitable for {@link PathResource}.
  * </p>
  */
+@ManagedObject("Factory for Mounted Resources")
 public class MountedPathResourceFactory implements ResourceFactory
 {
     private static final Map<String, String> ENV_MULTIRELEASE_RUNTIME;

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/PathResource.java
@@ -30,12 +30,15 @@ import java.util.stream.Stream;
 
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Java NIO Path Resource.
  */
+@ManagedObject("A Path Resource")
 public class PathResource extends Resource
 {
     private static final Logger LOG = LoggerFactory.getLogger(PathResource.class);
@@ -200,6 +203,7 @@ public class PathResource extends Resource
         }
     }
 
+    @ManagedAttribute("The Path")
     @Override
     public Path getPath()
     {
@@ -279,6 +283,7 @@ public class PathResource extends Resource
         return fn.toString();
     }
 
+    @ManagedAttribute("The URI")
     @Override
     public URI getURI()
     {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/Resource.java
@@ -34,6 +34,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,6 +46,7 @@ import org.slf4j.LoggerFactory;
  * Supports real filesystems, and also <a href="https://docs.oracle.com/en/java/javase/17/docs/api/jdk.zipfs/module-summary.html">ZipFS</a>.
  * </p>
  */
+@ManagedObject("A Jetty Resource")
 public abstract class Resource implements Iterable<Resource>
 {
     private static final Logger LOG = LoggerFactory.getLogger(Resource.class);

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -771,4 +771,11 @@ public interface ResourceFactory
     interface LifeCycle extends org.eclipse.jetty.util.component.LifeCycle, ResourceFactory, Dumpable
     {
     }
+
+    interface Tracking
+    {
+        int getTrackingCount();
+
+        List<Resource> getTrackedResources();
+    }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -772,10 +772,4 @@ public interface ResourceFactory
     {
     }
 
-    interface Tracking
-    {
-        int getTrackingCount();
-
-        List<Resource> getTrackedResources();
-    }
 }

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -22,11 +22,26 @@ import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import javax.management.Attribute;
+import javax.management.AttributeList;
+import javax.management.AttributeNotFoundException;
+import javax.management.DynamicMBean;
+import javax.management.InvalidAttributeValueException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanConstructorInfo;
+import javax.management.MBeanException;
+import javax.management.MBeanInfo;
+import javax.management.MBeanNotificationInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.ReflectionException;
 
 import org.eclipse.jetty.util.Index;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
+import org.eclipse.jetty.util.annotation.ManagedAttribute;
+import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.DumpableCollection;
@@ -56,7 +71,7 @@ class ResourceFactoryInternals
 
         /* Best-effort attempt to support an alternate FileSystem type that is in use for classpath
          * resources.
-         * 
+         *
          * The build.properties is present in the jetty-util jar, and explicitly included for reflection
          * with native-image (unlike classes, which are not accessible by default), so we use that
          * resource as a reference.
@@ -101,7 +116,7 @@ class ResourceFactoryInternals
      * @see ResourceFactory#unregisterResourceFactory(String)
      * @see #isSupported(String)
      */
-    static boolean isSupported(URI uri) // TODO: boolean isSupported
+    static boolean isSupported(URI uri)
     {
         if (uri == null || uri.getScheme() == null)
             return false;
@@ -125,7 +140,14 @@ class ResourceFactoryInternals
         return RESOURCE_FACTORIES.getBest(str) != null;
     }
 
-    static class Closeable implements ResourceFactory.Closeable, ResourceFactory.Tracking
+    interface Tracking
+    {
+        int getTrackingCount();
+
+        List<Resource> getTrackedResources();
+    }
+
+    static class Closeable implements ResourceFactory.Closeable, Tracking
     {
         private boolean closed = false;
         private final CompositeResourceFactory _compositeResourceFactory = new CompositeResourceFactory();
@@ -145,21 +167,24 @@ class ResourceFactoryInternals
             _compositeResourceFactory.closeFileSystems();
         }
 
+        @ManagedAttribute("Count of Tracked Resources")
         public int getTrackingCount()
         {
             return _compositeResourceFactory.mounted.size();
         }
 
         @Override
+        @ManagedAttribute("Tracked Resources")
         public List<Resource> getTrackedResources()
         {
             return Collections.unmodifiableList(_compositeResourceFactory.mounted);
         }
     }
 
-    static class LifeCycle extends AbstractLifeCycle implements ResourceFactory.LifeCycle, ResourceFactory.Tracking
+    static class LifeCycle extends AbstractLifeCycle implements ResourceFactory.LifeCycle, Tracking, DynamicMBean
     {
         private final CompositeResourceFactory _compositeResourceFactory = new CompositeResourceFactory();
+        private MBeanInfo mBeanInfo;
 
         @Override
         public Resource newResource(URI uri)
@@ -194,8 +219,101 @@ class ResourceFactoryInternals
         {
             return Collections.unmodifiableList(_compositeResourceFactory.mounted);
         }
+
+        @Override
+        public Object getAttribute(String name) throws AttributeNotFoundException, MBeanException, ReflectionException
+        {
+            Objects.requireNonNull(name, "Attribute Name");
+
+            return switch (name)
+            {
+                case "trackedCount" -> getTrackingCount();
+                case "trackedResources" -> getTrackedResources();
+                default ->
+                    throw new AttributeNotFoundException("Cannot find " + name + " attribute in " + this.getClass().getName());
+            };
+        }
+
+        @Override
+        public void setAttribute(Attribute attribute) throws AttributeNotFoundException, InvalidAttributeValueException, MBeanException, ReflectionException
+        {
+            Objects.requireNonNull(attribute, "attribute");
+            String name = attribute.getName();
+            // No attributes are writable
+            throw new AttributeNotFoundException("Cannot set attribute " + name + " because it is read-only");
+        }
+
+        @Override
+        public AttributeList getAttributes(String[] attributeNames)
+        {
+            Objects.requireNonNull(attributeNames, "attributeNames[]");
+
+            AttributeList ret = new AttributeList();
+
+            for (String name : attributeNames)
+            {
+                try
+                {
+                    Object value = getAttribute(name);
+                    ret.add(new Attribute(name, value));
+                }
+                catch (Exception e)
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Unable to get JMX Attribute [{}]", name, e);
+                }
+            }
+            return ret;
+        }
+
+        @Override
+        public AttributeList setAttributes(AttributeList attributes)
+        {
+            return new AttributeList();
+        }
+
+        @Override
+        public Object invoke(String actionName, Object[] params, String[] signature) throws MBeanException, ReflectionException
+        {
+            throw new ReflectionException(
+                new NoSuchMethodException(actionName),
+                "Cannot find the operation " + actionName + " in " + this.getClass().getName());
+        }
+
+        @Override
+        public MBeanInfo getMBeanInfo()
+        {
+            if (mBeanInfo != null)
+                return mBeanInfo;
+
+            MBeanAttributeInfo[] attrs = new MBeanAttributeInfo[2];
+            attrs[0] = new MBeanAttributeInfo(
+                "trackedCount",
+                "java.lang.Integer",
+                "Count of Tracked Resources",
+                true,
+                false,
+                false);
+            attrs[1] = new MBeanAttributeInfo(
+                "trackedResources",
+                "org.eclipse.jetty.util.resource.Resource",
+                "Tracked Resources",
+                true,
+                false,
+                false);
+
+            mBeanInfo = new MBeanInfo(this.getClass().getName(),
+                "Factory for Resources",
+                attrs,
+                new MBeanConstructorInfo[0],
+                new MBeanOperationInfo[0],
+                new MBeanNotificationInfo[0]);
+
+            return mBeanInfo;
+        }
     }
 
+    @ManagedObject("Composite Factory for Resources")
     static class CompositeResourceFactory implements ResourceFactory
     {
         private final List<MountedPathResource> mounted = new CopyOnWriteArrayList<>();

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactoryInternals.java
@@ -20,6 +20,7 @@ import java.net.URL;
 import java.nio.file.FileSystem;
 import java.nio.file.Path;
 import java.nio.file.ProviderNotFoundException;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -124,12 +125,7 @@ class ResourceFactoryInternals
         return RESOURCE_FACTORIES.getBest(str) != null;
     }
 
-    interface Tracking
-    {
-        int getTrackingCount();
-    }
-
-    static class Closeable implements ResourceFactory.Closeable, Tracking
+    static class Closeable implements ResourceFactory.Closeable, ResourceFactory.Tracking
     {
         private boolean closed = false;
         private final CompositeResourceFactory _compositeResourceFactory = new CompositeResourceFactory();
@@ -153,9 +149,15 @@ class ResourceFactoryInternals
         {
             return _compositeResourceFactory.mounted.size();
         }
+
+        @Override
+        public List<Resource> getTrackedResources()
+        {
+            return Collections.unmodifiableList(_compositeResourceFactory.mounted);
+        }
     }
 
-    static class LifeCycle extends AbstractLifeCycle implements ResourceFactory.LifeCycle
+    static class LifeCycle extends AbstractLifeCycle implements ResourceFactory.LifeCycle, ResourceFactory.Tracking
     {
         private final CompositeResourceFactory _compositeResourceFactory = new CompositeResourceFactory();
 
@@ -180,6 +182,17 @@ class ResourceFactoryInternals
                 .map(PathResource::getURI)
                 .toList();
             Dumpable.dumpObjects(out, indent, this, new DumpableCollection("newResourceReferences", referencedUris));
+        }
+
+        public int getTrackingCount()
+        {
+            return _compositeResourceFactory.mounted.size();
+        }
+
+        @Override
+        public List<Resource> getTrackedResources()
+        {
+            return Collections.unmodifiableList(_compositeResourceFactory.mounted);
         }
     }
 

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -232,7 +232,7 @@ public class PathResourceTest
             Resource resBadFile = resourceFactory.newResource(jarUri.toASCIIString() + "bad/file.txt");
             assertNull(resBadFile);
 
-            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
+            if (resourceFactory instanceof ResourceFactory.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(0));
             }
@@ -266,7 +266,7 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
+            if (resourceFactory instanceof ResourceFactory.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(2));
             }
@@ -305,12 +305,12 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory2.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
+            if (resourceFactory1 instanceof ResourceFactory.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(2));
             }
 
-            if (resourceFactory2 instanceof ResourceFactoryInternals.Tracking tracking)
+            if (resourceFactory2 instanceof ResourceFactory.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(1));
             }
@@ -318,7 +318,7 @@ public class PathResourceTest
             // Close Resource Factory 1
             resourceFactory1.close();
 
-            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
+            if (resourceFactory1 instanceof ResourceFactory.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(0));
             }

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/PathResourceTest.java
@@ -232,7 +232,7 @@ public class PathResourceTest
             Resource resBadFile = resourceFactory.newResource(jarUri.toASCIIString() + "bad/file.txt");
             assertNull(resBadFile);
 
-            if (resourceFactory instanceof ResourceFactory.Tracking tracking)
+            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(0));
             }
@@ -266,7 +266,7 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            if (resourceFactory instanceof ResourceFactory.Tracking tracking)
+            if (resourceFactory instanceof ResourceFactoryInternals.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(2));
             }
@@ -305,12 +305,12 @@ public class PathResourceTest
             Resource twoTxt = resourceFactory2.newResource(jarUri.toASCIIString() + "datainf/two.txt");
             assertTrue(Resources.isReadableFile(twoTxt));
 
-            if (resourceFactory1 instanceof ResourceFactory.Tracking tracking)
+            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(2));
             }
 
-            if (resourceFactory2 instanceof ResourceFactory.Tracking tracking)
+            if (resourceFactory2 instanceof ResourceFactoryInternals.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(1));
             }
@@ -318,7 +318,7 @@ public class PathResourceTest
             // Close Resource Factory 1
             resourceFactory1.close();
 
-            if (resourceFactory1 instanceof ResourceFactory.Tracking tracking)
+            if (resourceFactory1 instanceof ResourceFactoryInternals.Tracking tracking)
             {
                 assertThat(tracking.getTrackingCount(), is(0));
             }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -62,6 +62,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -233,9 +234,10 @@ public class ResourceServlet extends HttpServlet
         {
             try
             {
-                baseResource = URIUtil.isRelative(rb) ? baseResource.resolve(rb) :  contextHandler.newResource(rb);
+                ResourceFactory resourceFactory = ResourceFactory.of(contextHandler);
+                baseResource = URIUtil.isRelative(rb) ? baseResource.resolve(rb) : resourceFactory.newResource(rb);
                 if (baseResource.isAlias())
-                    baseResource = contextHandler.newResource(baseResource.getRealURI());
+                    baseResource = resourceFactory.newResource(baseResource.getRealURI());
             }
             catch (Exception e)
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -798,7 +798,9 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -811,7 +813,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -824,7 +828,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)
@@ -2889,15 +2895,29 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            Resource resource = getJettyResource(path);
-            if (resource != null)
-                return resource.getURI().toURL();
+            try
+            {
+                Resource resource = getJettyResource(path);
+                if (resource != null)
+                    return resource.getURI().toURL();
+            }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
+            }
+            catch (IOException e)
+            {
+                MalformedURLException malformedURLException = new MalformedURLException(path);
+                ExceptionUtil.addSuppressedIfNotAssociated(malformedURLException, e);
+                throw malformedURLException;
+            }
 
             // No hits
             return null;
         }
 
-        private Resource getJettyResource(String path)
+        private Resource getJettyResource(String path) throws IOException
         {
             try
             {
@@ -2921,13 +2941,16 @@ public class ServletContextHandler extends ContextHandler
                     // return first
                     if (Resources.exists(r))
                         return r;
+                }
             }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
             }
             catch (Throwable throwable)
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
-                return null;
+                throw new IOException("Unable to get Jetty Resource: " + path, throwable);
             }
 
             // No hits

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -798,7 +798,9 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
+     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
     {
         return ResourceFactory.of(this).newResource(url);
@@ -809,7 +811,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
+     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
     {
         return ResourceFactory.of(this).newResource(uri);
@@ -820,7 +824,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
+     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)
     {
         return ResourceFactory.of(this).newResource(urlOrPath);
@@ -2883,6 +2889,16 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
+            Resource resource = getJettyResource(path);
+            if (resource != null)
+                return resource.getURI().toURL();
+
+            // No hits
+            return null;
+        }
+
+        private Resource getJettyResource(String path)
+        {
             try
             {
                 // This is an API call from the application which may pass non-normalized paths.
@@ -2904,17 +2920,14 @@ public class ServletContextHandler extends ContextHandler
                 {
                     // return first
                     if (Resources.exists(r))
-                        return r.getURI().toURL();
-                }
+                        return r;
             }
-            catch (MalformedURLException e)
-            {
-                throw e;
             }
-            catch (Throwable e)
+            catch (Throwable throwable)
             {
-                // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
-                throw (MalformedURLException)new MalformedURLException(path).initCause(e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
+                return null;
             }
 
             // No hits
@@ -2926,22 +2939,18 @@ public class ServletContextHandler extends ContextHandler
         {
             try
             {
-                URL url = getResource(path);
-                if (url == null)
-                    return null;
-                Resource r = ResourceFactory.of(ServletContextHandler.this).newResource(url);
-                // Cannot serve directories as an InputStream
-                if (r.isDirectory())
-                    return null;
-                return IOResources.asInputStream(r);
+                Resource resource = getJettyResource(path);
+                if (Resources.isReadableFile(resource))
+                    return IOResources.asInputStream(resource);
             }
             catch (Throwable e)
             {
-                // catch RuntimeException and things like java.nio.fileInvalidPathException here.
                 if (LOG.isTraceEnabled())
                     LOG.trace("IGNORED", e);
                 return null;
             }
+            // not found
+            return null;
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletContextHandlerTest.java
@@ -15,9 +15,16 @@ package org.eclipse.jetty.ee10.servlet;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -36,6 +43,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -75,6 +84,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -88,27 +98,35 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.Decorator;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Jetty;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -124,6 +142,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
 
+@ExtendWith(WorkDirExtension.class)
 public class ServletContextHandlerTest
 {
     private Server _server;
@@ -2670,5 +2689,92 @@ public class ServletContextHandlerTest
         assertThrows(MalformedURLException.class, () -> context.getResource("badpath"));
         assertThat(context.getServletContext().getResource("/../down/"), nullValue());
         assertThat(context.getServletContext().getResource("/down/.././../"), nullValue());
+    }
+
+    @Test
+    public void testGetResourceAsStream(WorkDir workDir) throws Exception
+    {
+        Path baseDir = workDir.getEmptyPathDir();
+        FS.ensureDirExists(baseDir.resolve("WEB-INF"));
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/classes"));
+        Files.writeString(baseDir.resolve("index.html"), "This is the root index file", UTF_8);
+
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/lib"));
+        Path jarFile = baseDir.resolve("WEB-INF/lib/foo.jar");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        URI jarFileUri = URIUtil.toJarFileUri(jarFile.toUri());
+        try (FileSystem zipfs = FileSystems.newFileSystem(jarFileUri, env))
+        {
+            Path jarroot = zipfs.getPath("/");
+            FS.ensureDirExists(jarroot.resolve("deep"));
+            Files.writeString(jarroot.resolve("deep/example.dat"), "Contents of JAR Example Data", UTF_8);
+        }
+
+        ServletContextHandler context = new ServletContextHandler("/context");
+        ResourceFactory resourceFactory = ResourceFactory.of(context);
+        Resource jarResource = resourceFactory.newResource(jarFileUri);
+        List<Resource> resources = List.of(
+            resourceFactory.newResource(baseDir),
+            jarResource
+        );
+        Resource baseResource = ResourceFactory.combine(resources);
+        context.setBaseResource(baseResource);
+        context.addServlet(new HelloServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                InputStream in = req.getServletContext().getResourceAsStream("/deep/example.dat");
+                assertNotNull(in, "Resource must be found in ServletContext");
+
+                byte[] data = IO.readBytes(in);
+                String value = new String(data, UTF_8);
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().print(value);
+            }
+        }, "/servlet/*");
+        _server.setHandler(context);
+
+        _server.setName("Test"); // Set server name to make JMX lookup predictable
+        // Enable JMX
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+        MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);
+        _server.addBean(mbeanContainer);
+        _server.start();
+
+        String rawRequest = """
+            GET /context/servlet/ HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        String rawResponse = _connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
+
+        // Use JMX to confirm status of ResourceFactory
+        String jmxName = "org.eclipse.jetty.util.resource:type=resourcefactoryinternals$lifecycle,context=Test/_context,id=0";
+        Set<ObjectName> mbeanNames = mbeanServer.queryNames(ObjectName.getInstance(jmxName), null);
+        assertEquals(1, mbeanNames.size());
+        ObjectName objectName = mbeanNames.iterator().next();
+
+        Object trackedCount = mbeanServer.getAttribute(objectName, "trackedCount");
+        assertNotNull(trackedCount);
+        assertThat(trackedCount, instanceOf(Integer.class));
+        assertThat((Integer)trackedCount, is(1));
+
+        Object trackedResources = mbeanServer.getAttribute(objectName, "trackedResources");
+        assertNotNull(trackedResources);
+        assertThat(trackedResources, instanceOf(List.class));
+        if (trackedResources instanceof List<?> trackedList)
+        {
+            assertThat(trackedList.size(), is(1));
+            Resource tracked = (Resource)trackedList.get(0);
+            FileSystem originalJarFileSystem = jarResource.getPath().getFileSystem();
+            assertThat("Tracked Resource: " + tracked, tracked.getPath().getFileSystem(), sameInstance(originalJarFileSystem));
+        }
     }
 }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebAppContext.java
@@ -1620,11 +1620,11 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
         if (resource == null)
         {
-            if (getWar() == null || getWar().length() == 0)
+            if (getWar() == null || getWar().isEmpty())
                 throw new IllegalStateException("No resourceBase or war set for context");
 
             // Use name of given resource in the temporary dirname
-            resource = newResource(getWar());
+            resource = ResourceFactory.of(this).newResource(getWar());
         }
         return resource;
     }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebInfConfiguration.java
@@ -159,7 +159,7 @@ public class WebInfConfiguration extends AbstractConfiguration
         {
             String war = context.getWar();
             if (StringUtil.isNotBlank(war))
-                webApp = context.newResource(war);
+                webApp = ResourceFactory.of(context).newResource(war);
             else
                 webApp = context.getBaseResource();
 
@@ -172,7 +172,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 URI realURI = webApp.getRealURI();
                 if (LOG.isDebugEnabled())
                     LOG.debug("{} anti-aliased to {}", webApp, realURI);
-                Resource realWebApp = context.newResource(realURI);
+                Resource realWebApp = ResourceFactory.of(context).newResource(realURI);
                 if (Resources.exists(realWebApp))
                     webApp = realWebApp;
             }

--- a/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/java/org/eclipse/jetty/ee10/webapp/WebXmlConfiguration.java
@@ -14,13 +14,13 @@
 package org.eclipse.jetty.ee10.webapp;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
 import org.eclipse.jetty.ee10.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +61,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
                     }
                 }
                 if (Resources.missing(dftResource))
-                    dftResource = context.newResource(defaultsDescriptor);
+                    dftResource = ResourceFactory.of(context).newResource(defaultsDescriptor);
             }
             if (Resources.isReadableFile(dftResource))
                 context.getMetaData().setDefaultsDescriptor(new DefaultsDescriptor(dftResource));
@@ -83,7 +83,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
             {
                 Resource orideResource = context.getResourceFactory().newClassLoaderResource(overrideDescriptor);
                 if (Resources.missing(orideResource))
-                    orideResource = context.newResource(overrideDescriptor);
+                    orideResource = ResourceFactory.of(context).newResource(overrideDescriptor);
                 if (Resources.isReadableFile(orideResource))
                     context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));
             }
@@ -99,12 +99,12 @@ public class WebXmlConfiguration extends AbstractConfiguration
         context.getMetaData().addDescriptorProcessor(new StandardDescriptorProcessor());
     }
 
-    protected Resource findWebXml(WebAppContext context) throws IOException, MalformedURLException
+    protected Resource findWebXml(WebAppContext context) throws IOException
     {
         String descriptor = context.getDescriptor();
         if (descriptor != null)
         {
-            Resource web = context.newResource(descriptor);
+            Resource web = ResourceFactory.of(context).newResource(descriptor);
             if (web != null && !web.isDirectory())
                 return web;
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -62,6 +62,7 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -238,9 +239,10 @@ public class ResourceServlet extends HttpServlet
         {
             try
             {
-                baseResource = URIUtil.isRelative(rb) ? baseResource.resolve(rb) :  contextHandler.newResource(rb);
+                ResourceFactory resourceFactory = ResourceFactory.of(contextHandler);
+                baseResource = URIUtil.isRelative(rb) ? baseResource.resolve(rb) : resourceFactory.newResource(rb);
                 if (baseResource.isAlias())
-                    baseResource = contextHandler.newResource(baseResource.getRealURI());
+                    baseResource = resourceFactory.newResource(baseResource.getRealURI());
             }
             catch (Exception e)
             {

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -796,7 +796,9 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -805,11 +807,13 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
-     * Convert URL to Resource wrapper for {@link ResourceFactory#newResource(URL)} enables extensions to provide alternate resource implementations.
+     * Convert URL to Resource wrapper for {@link ResourceFactory#newResource(URI)} enables extensions to provide alternate resource implementations.
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -822,7 +826,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)
@@ -2881,15 +2887,29 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            Resource resource = getJettyResource(path);
-            if (resource != null)
-                return resource.getURI().toURL();
+            try
+            {
+                Resource resource = getJettyResource(path);
+                if (resource != null)
+                    return resource.getURI().toURL();
+            }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
+            }
+            catch (IOException e)
+            {
+                MalformedURLException malformedURLException = new MalformedURLException(path);
+                ExceptionUtil.addSuppressedIfNotAssociated(malformedURLException, e);
+                throw malformedURLException;
+            }
 
             // No hits
             return null;
         }
 
-        private Resource getJettyResource(String path)
+        private Resource getJettyResource(String path) throws IOException
         {
             try
             {
@@ -2915,11 +2935,14 @@ public class ServletContextHandler extends ContextHandler
                         return r;
                 }
             }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
+            }
             catch (Throwable throwable)
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
-                return null;
+                throw new IOException("Unable to get Jetty Resource: " + path, throwable);
             }
 
             // No hits
@@ -2937,8 +2960,10 @@ public class ServletContextHandler extends ContextHandler
             }
             catch (Throwable e)
             {
+                // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
                 if (LOG.isTraceEnabled())
                     LOG.trace("IGNORED", e);
+                // Per servlet spec, there's no exception thrown from this API
                 return null;
             }
             // not found

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -796,7 +796,9 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
+     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
     {
         return ResourceFactory.of(this).newResource(url);
@@ -807,7 +809,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
+     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
     {
         return ResourceFactory.of(this).newResource(uri);
@@ -818,7 +822,9 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
+     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)
     {
         return ResourceFactory.of(this).newResource(urlOrPath);
@@ -2875,6 +2881,16 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
+            Resource resource = getJettyResource(path);
+            if (resource != null)
+                return resource.getURI().toURL();
+
+            // No hits
+            return null;
+        }
+
+        private Resource getJettyResource(String path)
+        {
             try
             {
                 // This is an API call from the application which may pass non-normalized paths.
@@ -2896,17 +2912,14 @@ public class ServletContextHandler extends ContextHandler
                 {
                     // return first
                     if (Resources.exists(r))
-                        return r.getURI().toURL();
+                        return r;
                 }
             }
-            catch (MalformedURLException e)
+            catch (Throwable throwable)
             {
-                throw e;
-            }
-            catch (Throwable e)
-            {
-                // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
-                throw (MalformedURLException)new MalformedURLException(path).initCause(e);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
+                return null;
             }
 
             // No hits
@@ -2918,14 +2931,9 @@ public class ServletContextHandler extends ContextHandler
         {
             try
             {
-                URL url = getResource(path);
-                if (url == null)
-                    return null;
-                Resource r = ResourceFactory.of(ServletContextHandler.this).newResource(url);
-                // Cannot serve directories as an InputStream
-                if (r.isDirectory())
-                    return null;
-                return IOResources.asInputStream(r);
+                Resource resource = getJettyResource(path);
+                if (Resources.isReadableFile(resource))
+                    return IOResources.asInputStream(resource);
             }
             catch (Throwable e)
             {
@@ -2933,6 +2941,8 @@ public class ServletContextHandler extends ContextHandler
                     LOG.trace("IGNORED", e);
                 return null;
             }
+            // not found
+            return null;
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletContextHandlerTest.java
@@ -15,9 +15,15 @@ package org.eclipse.jetty.ee11.servlet;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -88,27 +94,35 @@ import org.eclipse.jetty.server.handler.ContextHandlerCollection;
 import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.Decorator;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Jetty;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
@@ -124,6 +138,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.junit.jupiter.api.condition.OS.LINUX;
 import static org.junit.jupiter.api.condition.OS.MAC;
 
+@ExtendWith(WorkDirExtension.class)
 public class ServletContextHandlerTest
 {
     private Server _server;
@@ -2670,5 +2685,80 @@ public class ServletContextHandlerTest
         assertThrows(MalformedURLException.class, () -> context.getResource("badpath"));
         assertThat(context.getServletContext().getResource("/../down/"), nullValue());
         assertThat(context.getServletContext().getResource("/down/.././../"), nullValue());
+    }
+
+    @Test
+    public void testGetResourceAsStream(WorkDir workDir) throws Exception
+    {
+        Path baseDir = workDir.getEmptyPathDir();
+        FS.ensureDirExists(baseDir.resolve("WEB-INF"));
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/classes"));
+        Files.writeString(baseDir.resolve("index.html"), "This is the root index file", UTF_8);
+
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/lib"));
+        Path jarFile = baseDir.resolve("WEB-INF/lib/foo.jar");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        URI jarFileUri = URIUtil.toJarFileUri(jarFile.toUri());
+        try (FileSystem zipfs = FileSystems.newFileSystem(jarFileUri, env))
+        {
+            Path jarroot = zipfs.getPath("/");
+            FS.ensureDirExists(jarroot.resolve("deep"));
+            Files.writeString(jarroot.resolve("deep/example.dat"), "Contents of JAR Example Data", UTF_8);
+        }
+
+        ServletContextHandler context = new ServletContextHandler("/context");
+        ResourceFactory resourceFactory = ResourceFactory.of(context);
+        Resource jarResource = resourceFactory.newResource(jarFileUri);
+        List<Resource> resources = List.of(
+            resourceFactory.newResource(baseDir),
+            jarResource
+        );
+        Resource baseResource = ResourceFactory.combine(resources);
+        context.setBaseResource(baseResource);
+        context.addServlet(new HelloServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                InputStream in = req.getServletContext().getResourceAsStream("/deep/example.dat");
+                assertNotNull(in, "Resource must be found in ServletContext");
+
+                byte[] data = IO.readBytes(in);
+                String value = new String(data, UTF_8);
+                resp.setCharacterEncoding(UTF_8);
+                resp.setContentType("text/plain");
+                resp.getWriter().print(value);
+            }
+        }, "/servlet/*");
+        _server.setHandler(context);
+
+        _server.start();
+
+        String rawRequest = """
+            GET /context/servlet/ HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        String rawResponse = _connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
+
+        ResourceFactory actualResourceFactory = ResourceFactory.of(context);
+        if (actualResourceFactory instanceof ResourceFactory.Tracking tracking)
+        {
+            List<Resource> trackedResources = tracking.getTrackedResources();
+            // Grab the original Jar FileSystem we are using.
+            FileSystem originalJarFileSystem = jarResource.getPath().getFileSystem();
+
+            // Should only be tracking the original FileSystem from the `jarFileUri`,
+            // the call to ServletContext.getResourceAsStream() should not create a new FileSystem.
+            for (Resource resource: trackedResources)
+            {
+                assertThat("Tracked Resource: " + resource, resource.getPath().getFileSystem(), sameInstance(originalJarFileSystem));
+            }
+        }
     }
 }

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletContextHandlerTest.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
@@ -42,6 +43,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -81,6 +84,7 @@ import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.pathmap.MatchedResource;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.SecurityHandler;
@@ -702,7 +706,6 @@ public class ServletContextHandlerTest
     public void createServer()
     {
         _server = new Server();
-
         _connector = new LocalConnector(_server);
         _server.addConnector(_connector);
         __testServlets.set(0);
@@ -2734,6 +2737,11 @@ public class ServletContextHandlerTest
         }, "/servlet/*");
         _server.setHandler(context);
 
+        _server.setName("Test"); // Set server name to make JMX lookup predictable
+        // Enable JMX
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+        MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);
+        _server.addBean(mbeanContainer);
         _server.start();
 
         String rawRequest = """
@@ -2746,19 +2754,26 @@ public class ServletContextHandlerTest
         HttpTester.Response response = HttpTester.parseResponse(rawResponse);
         assertThat(response.getStatus(), is(200));
 
-        ResourceFactory actualResourceFactory = ResourceFactory.of(context);
-        if (actualResourceFactory instanceof ResourceFactory.Tracking tracking)
-        {
-            List<Resource> trackedResources = tracking.getTrackedResources();
-            // Grab the original Jar FileSystem we are using.
-            FileSystem originalJarFileSystem = jarResource.getPath().getFileSystem();
+        // Use JMX to confirm status of ResourceFactory
+        String jmxName = "org.eclipse.jetty.util.resource:type=resourcefactoryinternals$lifecycle,context=Test/_context,id=0";
+        Set<ObjectName> mbeanNames = mbeanServer.queryNames(ObjectName.getInstance(jmxName), null);
+        assertEquals(1, mbeanNames.size());
+        ObjectName objectName = mbeanNames.iterator().next();
 
-            // Should only be tracking the original FileSystem from the `jarFileUri`,
-            // the call to ServletContext.getResourceAsStream() should not create a new FileSystem.
-            for (Resource resource: trackedResources)
-            {
-                assertThat("Tracked Resource: " + resource, resource.getPath().getFileSystem(), sameInstance(originalJarFileSystem));
-            }
+        Object trackedCount = mbeanServer.getAttribute(objectName, "trackedCount");
+        assertNotNull(trackedCount);
+        assertThat(trackedCount, instanceOf(Integer.class));
+        assertThat((Integer)trackedCount, is(1));
+
+        Object trackedResources = mbeanServer.getAttribute(objectName, "trackedResources");
+        assertNotNull(trackedResources);
+        assertThat(trackedResources, instanceOf(List.class));
+        if (trackedResources instanceof List<?> trackedList)
+        {
+            assertThat(trackedList.size(), is(1));
+            Resource tracked = (Resource)trackedList.get(0);
+            FileSystem originalJarFileSystem = jarResource.getPath().getFileSystem();
+            assertThat("Tracked Resource: " + tracked, tracked.getPath().getFileSystem(), sameInstance(originalJarFileSystem));
         }
     }
 }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebAppContext.java
@@ -1518,7 +1518,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
                 throw new IllegalStateException("No resourceBase or war set for context");
 
             // Use name of given resource in the temporary dirname
-            resource = newResource(getWar());
+            resource = ResourceFactory.of(this).newResource(getWar());
         }
         return resource;
     }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebInfConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebInfConfiguration.java
@@ -159,7 +159,7 @@ public class WebInfConfiguration extends AbstractConfiguration
         {
             String war = context.getWar();
             if (StringUtil.isNotBlank(war))
-                webApp = context.newResource(war);
+                webApp = ResourceFactory.of(context).newResource(war);
             else
                 webApp = context.getBaseResource();
 
@@ -172,7 +172,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 URI realURI = webApp.getRealURI();
                 if (LOG.isDebugEnabled())
                     LOG.debug("{} anti-aliased to {}", webApp, realURI);
-                Resource realWebApp = context.newResource(realURI);
+                Resource realWebApp = ResourceFactory.of(context).newResource(realURI);
                 if (Resources.exists(realWebApp))
                     webApp = realWebApp;
             }

--- a/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebXmlConfiguration.java
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/java/org/eclipse/jetty/ee11/webapp/WebXmlConfiguration.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import org.eclipse.jetty.ee11.servlet.ErrorPageErrorHandler;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
                     }
                 }
                 if (Resources.missing(dftResource))
-                    dftResource = context.newResource(defaultsDescriptor);
+                    dftResource = ResourceFactory.of(context).newResource(defaultsDescriptor);
             }
             if (Resources.isReadableFile(dftResource))
                 context.getMetaData().setDefaultsDescriptor(new DefaultsDescriptor(dftResource));
@@ -83,7 +84,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
             {
                 Resource orideResource = context.getResourceFactory().newClassLoaderResource(overrideDescriptor);
                 if (Resources.missing(orideResource))
-                    orideResource = context.newResource(overrideDescriptor);
+                    orideResource = ResourceFactory.of(context).newResource(overrideDescriptor);
                 if (Resources.isReadableFile(orideResource))
                     context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));
             }
@@ -104,7 +105,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String descriptor = context.getDescriptor();
         if (descriptor != null)
         {
-            Resource web = context.newResource(descriptor);
+            Resource web = ResourceFactory.of(context).newResource(descriptor);
             if (web != null && !web.isDirectory())
                 return web;
         }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1602,7 +1602,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -1616,7 +1618,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri) throws IOException
@@ -1630,7 +1634,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uriOrPath The URL or path to convert
      * @return The Resource for the URL/path
      * @throws IOException The Resource could not be created.
-     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
+     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
+     *             at webapp initialization time only.  The use of this method during
+     *             context started phase can result in excessive memory consumption.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String uriOrPath) throws IOException
@@ -2073,15 +2079,29 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
-            Resource resource = getJettyResource(path);
-            if (resource != null)
-                return resource.getURI().toURL();
+            try
+            {
+                Resource resource = getJettyResource(path);
+                if (resource != null)
+                    return resource.getURI().toURL();
+            }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
+            }
+            catch (IOException e)
+            {
+                MalformedURLException malformedURLException = new MalformedURLException(path);
+                ExceptionUtil.addSuppressedIfNotAssociated(malformedURLException, e);
+                throw malformedURLException;
+            }
 
             // No hits
             return null;
         }
 
-        private Resource getJettyResource(String path)
+        private Resource getJettyResource(String path) throws IOException
         {
             try
             {
@@ -2107,11 +2127,14 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
                         return r;
                 }
             }
+            catch (MalformedURLException e)
+            {
+                // rethrow
+                throw e;
+            }
             catch (Throwable throwable)
             {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
-                return null;
+                throw new IOException("Unable to get Jetty Resource: " + path, throwable);
             }
 
             // No hits
@@ -2132,6 +2155,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
                 // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
                 if (LOG.isTraceEnabled())
                     LOG.trace("IGNORED", e);
+                // Per servlet spec, there's no exception thrown from this API
                 return null;
             }
             // not found

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1323,7 +1323,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     {
         try
         {
-            setBaseResource(newResource(resourceBase));
+            Resource baseResource = ResourceFactory.of(this).newResource(resourceBase);
+            setBaseResource(baseResource);
         }
         catch (IllegalArgumentException e)
         {
@@ -1601,7 +1602,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
+     * @deprecated use ResourceFactory.of(component).newResource(URL) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
     {
         return ResourceFactory.of(this).newResource(url);
@@ -1613,7 +1616,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
      * @throws IOException if unable to create a Resource from the URL
+     * @deprecated use ResourceFactory.of(component).newResource(URI) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri) throws IOException
     {
         return ResourceFactory.of(this).newResource(uri);
@@ -1625,7 +1630,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uriOrPath The URL or path to convert
      * @return The Resource for the URL/path
      * @throws IOException The Resource could not be created.
+     * @deprecated use ResourceFactory.of(component).newResource(String) properly at webapp initialization time only.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String uriOrPath) throws IOException
     {
         return ResourceFactory.of(this).newResource(uriOrPath);
@@ -2066,31 +2073,48 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         @Override
         public URL getResource(String path) throws MalformedURLException
         {
+            Resource resource = getJettyResource(path);
+            if (resource != null)
+                return resource.getURI().toURL();
+
+            // No hits
+            return null;
+        }
+
+        private Resource getJettyResource(String path)
+        {
             try
             {
                 // This is an API call from the application which may pass non-normalized paths.
                 // Thus, we normalize here, to avoid the enforcement of normalized paths in
-                // ContextHandler.this.getResource(path).
+                // ServletContextHandler.this.getResource(path).
                 path = URIUtil.normalizePath(path);
                 if (path == null)
                     return null;
 
-                if (!path.startsWith("/"))
-                    throw new MalformedURLException(path);
-
+                // Assumption is that the resource base has been properly setup.
+                // Spec requirement is that the WAR file is interrogated first.
+                // If a WAR file is mounted, or is extracted to a temp directory,
+                // then the first entry of the resource base must be the WAR file.
                 Resource resource = ContextHandler.this.getResource(path);
-                if (resource != null && resource.exists())
-                    return resource.getURI().toURL();
+                if (!Resources.exists(resource))
+                    return null;
+
+                for (Resource r : resource)
+                {
+                    // return first
+                    if (Resources.exists(r))
+                        return r;
+                }
             }
-            catch (MalformedURLException e)
+            catch (Throwable throwable)
             {
-                throw e;
+                if (LOG.isDebugEnabled())
+                    LOG.debug("Unable to get Jetty Resource for path: {}", path, throwable);
+                return null;
             }
-            catch (Throwable e)
-            {
-                // catch IOException, RuntimeException, and things like java.nio.fileInvalidPathException here.
-                throw (MalformedURLException)new MalformedURLException(path).initCause(e);
-            }
+
+            // No hits
             return null;
         }
 
@@ -2099,14 +2123,9 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
         {
             try
             {
-                URL url = getResource(path);
-                if (url == null)
-                    return null;
-                Resource r = ResourceFactory.of(ContextHandler.this).newResource(url);
-                // Cannot serve directories as an InputStream
-                if (r.isDirectory())
-                    return null;
-                return IOResources.asInputStream(r);
+                Resource resource = getJettyResource(path);
+                if (Resources.isReadableFile(resource))
+                    return IOResources.asInputStream(resource);
             }
             catch (Throwable e)
             {
@@ -2115,6 +2134,8 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
                     LOG.trace("IGNORED", e);
                 return null;
             }
+            // not found
+            return null;
         }
 
         @Override

--- a/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/main/java/org/eclipse/jetty/ee9/servlet/DefaultServlet.java
@@ -222,7 +222,7 @@ public class DefaultServlet extends HttpServlet implements WelcomeFactory
                 throw new UnavailableException("baseResource & relativeBaseResource");
             try
             {
-                _baseResource = _contextHandler.newResource(br);
+                _baseResource = ResourceFactory.of(_contextHandler).newResource(br);
             }
             catch (Exception e)
             {

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
@@ -38,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ServletContextHandlerTest.java
@@ -14,21 +14,33 @@
 package org.eclipse.jetty.ee9.servlet;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
+import java.lang.management.ManagementFactory;
+import java.net.URI;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.EventListener;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.Filter;
@@ -73,18 +85,27 @@ import org.eclipse.jetty.ee9.security.RoleInfo;
 import org.eclipse.jetty.ee9.security.SecurityHandler;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.jmx.MBeanContainer;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.DecoratedObjectFactory;
 import org.eclipse.jetty.util.Decorator;
+import org.eclipse.jetty.util.IO;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
+import org.eclipse.jetty.util.resource.Resource;
+import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -109,6 +130,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
+@ExtendWith(WorkDirExtension.class)
 public class ServletContextHandlerTest
 {
     private Server _server;
@@ -2437,5 +2459,94 @@ public class ServletContextHandlerTest
             reached.testcase=true
             mode.testcase=%s
             """.formatted(dispatcherMode)));
+    }
+
+    @Test
+    public void testGetResourceAsStream(WorkDir workDir) throws Exception
+    {
+        Path baseDir = workDir.getEmptyPathDir();
+        FS.ensureDirExists(baseDir.resolve("WEB-INF"));
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/classes"));
+        Files.writeString(baseDir.resolve("index.html"), "This is the root index file", UTF_8);
+
+        FS.ensureDirExists(baseDir.resolve("WEB-INF/lib"));
+        Path jarFile = baseDir.resolve("WEB-INF/lib/foo.jar");
+
+        Map<String, String> env = new HashMap<>();
+        env.put("create", "true");
+        URI jarFileUri = URIUtil.toJarFileUri(jarFile.toUri());
+        try (FileSystem zipfs = FileSystems.newFileSystem(jarFileUri, env))
+        {
+            Path jarroot = zipfs.getPath("/");
+            FS.ensureDirExists(jarroot.resolve("deep"));
+            Files.writeString(jarroot.resolve("deep/example.dat"), "Contents of JAR Example Data", UTF_8);
+        }
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/context");
+        ResourceFactory resourceFactory = ResourceFactory.of(context);
+        Resource jarResource = resourceFactory.newResource(jarFileUri);
+        List<Resource> resources = List.of(
+            resourceFactory.newResource(baseDir),
+            jarResource
+        );
+        Resource baseResource = ResourceFactory.combine(resources);
+        context.setBaseResource(baseResource);
+        ServletHolder testHolder = new ServletHolder(new HelloServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                InputStream in = req.getServletContext().getResourceAsStream("/deep/example.dat");
+                assertNotNull(in, "Resource must be found in ServletContext");
+
+                byte[] data = IO.readBytes(in);
+                String value = new String(data, UTF_8);
+                resp.setCharacterEncoding("utf-8");
+                resp.setContentType("text/plain");
+                resp.getWriter().print(value);
+            }
+        });
+        context.addServlet(testHolder, "/servlet/*");
+        _server.setHandler(context);
+
+        _server.setName("Test"); // Set server name to make JMX lookup predictable
+        // Enable JMX
+        MBeanServer mbeanServer = ManagementFactory.getPlatformMBeanServer();
+        MBeanContainer mbeanContainer = new MBeanContainer(mbeanServer);
+        _server.addBean(mbeanContainer);
+        _server.start();
+
+        String rawRequest = """
+            GET /context/servlet/ HTTP/1.1
+            Host: local
+            Connection: close
+            
+            """;
+        String rawResponse = _connector.getResponse(rawRequest);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(200));
+
+        // Use JMX to confirm status of ResourceFactory
+        String jmxName = "org.eclipse.jetty.util.resource:type=resourcefactoryinternals$lifecycle,context=Test/_context/_context,id=0";
+        Set<ObjectName> mbeanNames = mbeanServer.queryNames(ObjectName.getInstance(jmxName), null);
+        assertEquals(1, mbeanNames.size());
+        ObjectName objectName = mbeanNames.iterator().next();
+
+        Object trackedCount = mbeanServer.getAttribute(objectName, "trackedCount");
+        assertNotNull(trackedCount);
+        assertThat(trackedCount, instanceOf(Integer.class));
+        assertThat((Integer)trackedCount, is(1));
+
+        Object trackedResources = mbeanServer.getAttribute(objectName, "trackedResources");
+        assertNotNull(trackedResources);
+        assertThat(trackedResources, instanceOf(List.class));
+        if (trackedResources instanceof List<?> trackedList)
+        {
+            assertThat(trackedList.size(), is(1));
+            Resource tracked = (Resource)trackedList.get(0);
+            FileSystem originalJarFileSystem = jarResource.getPath().getFileSystem();
+            assertThat("Tracked Resource: " + tracked, tracked.getPath().getFileSystem(), sameInstance(originalJarFileSystem));
+        }
     }
 }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebInfConfiguration.java
@@ -160,8 +160,8 @@ public class WebInfConfiguration extends AbstractConfiguration
         if (webApp == null)
         {
             String war = context.getWar();
-            if (war != null && war.length() > 0)
-                webApp = context.newResource(war);
+            if (war != null && !war.isEmpty())
+                webApp = ResourceFactory.of(context).newResource(war);
             else
                 webApp = context.getBaseResource();
 
@@ -174,7 +174,7 @@ public class WebInfConfiguration extends AbstractConfiguration
                 URI realURI = webApp.getRealURI();
                 if (LOG.isDebugEnabled())
                     LOG.debug("{} anti-aliased to {}", webApp, realURI);
-                Resource realWebApp = context.newResource(realURI);
+                Resource realWebApp = ResourceFactory.of(context).newResource(realURI);
                 if (realWebApp != null && realWebApp.exists())
                     webApp = realWebApp;
             }

--- a/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/java/org/eclipse/jetty/ee9/webapp/WebXmlConfiguration.java
@@ -64,7 +64,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
                     }
                 }
                 if (Resources.missing(dftResource))
-                    dftResource = context.newResource(defaultsDescriptor);
+                    dftResource = ResourceFactory.of(context).newResource(defaultsDescriptor);
             }
             if (Resources.isReadableFile(dftResource))
                 context.getMetaData().setDefaultsDescriptor(new DefaultsDescriptor(dftResource));
@@ -86,7 +86,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
             {
                 Resource orideResource = context.getResourceFactory().newClassLoaderResource(overrideDescriptor);
                 if (orideResource == null)
-                    orideResource = context.newResource(overrideDescriptor);
+                    orideResource = ResourceFactory.of(context).newResource(overrideDescriptor);
                 context.getMetaData().addOverrideDescriptor(new OverrideDescriptor(orideResource));
             }
         }
@@ -106,7 +106,7 @@ public class WebXmlConfiguration extends AbstractConfiguration
         String descriptor = context.getDescriptor();
         if (descriptor != null)
         {
-            Resource web = context.newResource(descriptor);
+            Resource web = ResourceFactory.of(context).newResource(descriptor);
             if (web != null && !web.isDirectory())
                 return web;
         }


### PR DESCRIPTION
With the removal of `FileSystemPool` (PR #14826), the `Resource` and `ResourceFactory` APIs are more strict in usage.
The old techniques (pre Jetty 12) where a call to `newResource()` and `resolve()` were identical in behavior are no longer true.
Any call to `newResource()` has the potential to create a new `FileSystem` object instance (true for non-`file` schema URIs, like `jar:file:///path/to/foo.jar`, or `resources://`, or `bundle://`, etc)

That means we need to stop using `newResource()` during the started phase in a webapp, and only rely on the `resolve()` methods to find new Jetty `Resource` objects.

This PR deprecates all of the various `newResource()` APIs that can be used during the started phase of a webapp, and changes all of the calls to these newly deprecated APIs to use the appropriate API based on the when the `Resource` is needed, and for how long it is being tracked.