### PR TITLE
Issue #15232 - Fix ServletContextRequest.getAttribute(String) impl in EE11

### DIFF
--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
@@ -339,8 +339,8 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
     @Override
     public Object getAttribute(String name)
     {
-        if (AbstractSessionManager.RequestedSession.class.getName().equals(name))
-            return _requestedSession;
+        if (AbstractSessionManager.RequestedSession.isApplicableAttribute(name))
+            return _requestedSession.getAttribute(name);
         return _attributes.getAttribute(name);
     }
 


### PR DESCRIPTION
Correct a `ServletContextRequest.getAttribute(String)` from an apparent bad merge.

Closes: #15232