### PR TITLE
Fixes #15267 - Introduce module for MinimumDataRateHandler.

### DIFF
--- a/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
+++ b/documentation/jetty/modules/code/examples/src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java
@@ -101,6 +101,7 @@ import org.eclipse.jetty.server.handler.DefaultHandler;
 import org.eclipse.jetty.server.handler.DoSHandler;
 import org.eclipse.jetty.server.handler.EventsHandler;
 import org.eclipse.jetty.server.handler.GracefulHandler;
+import org.eclipse.jetty.server.handler.MinimumDataRateHandler;
 import org.eclipse.jetty.server.handler.MovedContextHandler;
 import org.eclipse.jetty.server.handler.PathMappingsHandler;
 import org.eclipse.jetty.server.handler.QoSHandler;
@@ -1646,7 +1647,7 @@ public class HTTPServerDocs
 
         // Create and link the MinimumDataRateHandler to the Server.
         // Create the MinimumDataRateHandler with a minimum read rate of 1KB per second and no minimum write rate.
-        StatisticsHandler.MinimumDataRateHandler dataRateHandler = new StatisticsHandler.MinimumDataRateHandler(1024L, 0L);
+        MinimumDataRateHandler dataRateHandler = new MinimumDataRateHandler(1024L, 0L);
         server.setHandler(dataRateHandler);
 
         // Create a ContextHandlerCollection to hold contexts.

--- a/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
+++ b/documentation/jetty/modules/operations-guide/pages/modules/standard.adoc
@@ -581,6 +581,18 @@ However, the RMI server is configured to bind to `localhost`, i.e. `127.0.0.1`.
 
 If the system property `java.rmi.server.hostname` is not specified, the RMI client will try to connect to `127.0.1.1` (because that's what in the RMI stub) and fail because nothing is listening on that address.
 
+[[min-data-rate]]
+== Module `min-data-rate`
+
+The `min-data-rate` installs the `MinimumDataRateHandler` at the root of the `Handler` tree.
+`MinimumDataRateHandler` enables support to enforce minimum data rates for reading request content and writing response content, as explained in xref:programming-guide:server/http.adoc#handler-use-min-data-rate[this section].
+
+The module properties are:
+
+----
+include::{jetty-home}/modules/min-data-rate.mod[tags=documentation]
+----
+
 [[openid]]
 == Module `openid`
 

--- a/documentation/jetty/modules/programming-guide/pages/server/http.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http.adoc
@@ -1179,13 +1179,35 @@ Server
         └── ContextHandler N
 ----
 
-It is possible to act on those statistics by subclassing `StatisticsHandler`.
-For instance, `StatisticsHandler.MinimumDataRateHandler` can be used to enforce a minimum read rate and a minimum write rate based of the figures collected by the `StatisticsHandler`:
+[[handler-use-min-data-rate]]
+=== MinimumDataRateHandler
+
+`MinimumDataRateHandler` is a subclass of `StatisticsHandler` that enforces a minimum request content read rate and a minimum response content write rate based of the figures that it collects:
 
 [,java,indent=0]
 ----
 include::code:example$src/main/java/org/eclipse/jetty/docs/programming/server/http/HTTPServerDocs.java[tags=dataRateHandler]
 ----
+
+The `Handler` tree structure looks like the following:
+
+[,screen]
+----
+Server
+└── MinimumDataRateHandler
+    └── ContextHandlerCollection
+        ├── ContextHandler 1
+        :── ...
+        └── ContextHandler N
+----
+
+When minimum data rate is not enforced, bad clients may cause threads to be blocked on the server, and excessive memory consumption (as requests and responses stay in memory for longer than expected).
+
+Configuring the minimum read rate protects the server against bad clients that send request content very slowly, without tripping the idle timeout.
+When the server detects that the minimum threshold is not reached, it will abort the request, freeing server resources.
+
+Configuring the minimum write rate protects the server against bad clients that read response content very slowly, without tripping the idle timeout, and cause TCP congestion (for HTTP/1.1) or flow control stalls (for HTTP/2 and HTTP/3).
+When the server detects that the minimum threshold is not reached, it will abort the response, freeing server resources.
 
 [[handler-use-events]]
 ==== EventsHandler

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-min-data-rate.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-min-data-rate.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<!DOCTYPE Configure PUBLIC "-//Jetty//Configure//EN" "https://jetty.org/configure_10_0.dtd">
+
+<Configure id="Server" class="org.eclipse.jetty.server.Server">
+  <Call name="insertHandler">
+    <Arg>
+      <New class="org.eclipse.jetty.server.handler.MinimumDataRateHandler">
+        <Arg type="long">
+          <Property name="jetty.minDataRate.minReadRate" default="0" />
+        </Arg>
+        <Arg type="long">
+          <Property name="jetty.minDataRate.minWriteRate" default="0" />
+        </Arg>
+      </New>
+    </Arg>
+  </Call>
+</Configure>

--- a/jetty-core/jetty-server/src/main/config/modules/min-data-rate.mod
+++ b/jetty-core/jetty-server/src/main/config/modules/min-data-rate.mod
@@ -1,0 +1,22 @@
+[description]
+Enables minimum data rate enforcement for request content and response content.
+
+[tags]
+server
+
+[depends]
+server
+
+[xml]
+etc/jetty-min-data-rate.xml
+
+[ini-template]
+#tag::documentation[]
+## The minimum data rate to enforce when reading request content, in bytes/s.
+## Use 0 to disable the minimum data rate enforcement.
+#jetty.minDataRate.minReadRate=0
+
+## The minimum data rate to enforce when writing response content, in bytes/s.
+## Use 0 to disable the minimum data rate enforcement.
+#jetty.minDataRate.minWriteRate=0
+#end::documentation[]

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -637,39 +637,47 @@ public class HttpConfiguration implements Dumpable
     }
 
     /**
-     * @return The minimum request data rate in bytes per second; or &lt;=0 for no limit
+     * @return The minimum request content data rate in bytes per second; use {@code <=0} for no minimum
+     * @deprecated use {@link org.eclipse.jetty.server.handler.MinimumDataRateHandler} instead
      */
     @ManagedAttribute("The minimum request content data rate in bytes per second")
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public long getMinRequestDataRate()
     {
         return _minRequestDataRate;
     }
 
     /**
-     * @param bytesPerSecond The minimum request data rate in bytes per second; or &lt;=0 for no limit
+     * @param bytesPerSecond The minimum request content data rate in bytes per second; use {@code <=0} for no minimum
+     * @deprecated use {@link org.eclipse.jetty.server.handler.MinimumDataRateHandler} instead
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public void setMinRequestDataRate(long bytesPerSecond)
     {
         _minRequestDataRate = bytesPerSecond;
     }
 
     /**
-     * @return The minimum response data rate in bytes per second; or &lt;=0 for no limit
+     * @return The minimum response content data rate in bytes per second; use {@code <=0} for no minimum
+     * @deprecated use {@link org.eclipse.jetty.server.handler.MinimumDataRateHandler} instead
      */
     @ManagedAttribute("The minimum response content data rate in bytes per second")
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public long getMinResponseDataRate()
     {
         return _minResponseDataRate;
     }
 
     /**
-     * <p>Sets an minimum response content data rate.</p>
+     * <p>Sets the minimum response content data rate.</p>
      * <p>The value is enforced only approximately - not precisely - due to the fact that
      * for efficiency reasons buffer writes may be comprised of both response headers and
      * response content.</p>
      *
-     * @param bytesPerSecond The minimum response data rate in bytes per second; or &lt;=0 for no limit
+     * @param bytesPerSecond The minimum response content data rate in bytes per second; use {@code <=0} for no minimum
+     * @deprecated use {@link org.eclipse.jetty.server.handler.MinimumDataRateHandler} instead
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public void setMinResponseDataRate(long bytesPerSecond)
     {
         _minResponseDataRate = bytesPerSecond;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
@@ -372,7 +372,7 @@ public abstract class EventsHandler extends Handler.Wrapper
         {
             notifyOnResponseBegin(getRequest(), this);
             notifyOnResponseWrite(getRequest(), last, byteBuffer);
-            ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
+            ByteBuffer copy = byteBuffer == null ? null : byteBuffer.asReadOnlyBuffer();
             super.write(last, byteBuffer, Callback.from(callback.getInvocationType(), () ->
             {
                 notifyOnResponseWriteComplete(getRequest(), last, copy, null);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EventsHandler.java
@@ -163,11 +163,11 @@ public abstract class EventsHandler extends Handler.Wrapper
         }
     }
 
-    private void notifyOnResponseWriteComplete(Request request, Throwable failure)
+    private void notifyOnResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
     {
         try
         {
-            onResponseWriteComplete(request, failure);
+            onResponseWriteComplete(request, last, content, failure);
         }
         catch (Throwable x)
         {
@@ -268,11 +268,11 @@ public abstract class EventsHandler extends Handler.Wrapper
 
     /**
      * Invoked before each response content chunk has been written (i.e. from
-     * within the any call to {@link Response#write(boolean, ByteBuffer, Callback)}).
+     * within the call to {@link Response#write(boolean, ByteBuffer, Callback)}).
      *
      * @param request the request object. The {@code read()}, {@code demand(Runnable)} and {@code fail(Throwable)} methods must not be called by the listener.
      * @param last indicating last write
-     * @param content The {@link ByteBuffer} of the response content chunk (readonly).
+     * @param content The {@link ByteBuffer} of the response content chunk.
      * @see Response#write(boolean, ByteBuffer, Callback)
      */
     protected void onResponseWrite(Request request, boolean last, ByteBuffer content)
@@ -288,9 +288,22 @@ public abstract class EventsHandler extends Handler.Wrapper
      * This will always fire <em>before</em> {@link #onResponseTrailersComplete(Request, HttpFields)} is fired.
      *
      * @param request the request object. The {@code read()}, {@code demand(Runnable)} and {@code fail(Throwable)} methods must not be called by the listener.
+     * @param last indicating last write
+     * @param content The {@link ByteBuffer} of the response content chunk (read-only).
      * @param failure if there was a failure to write the given content
      * @see Response#write(boolean, ByteBuffer, Callback)
      */
+    protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
+    {
+        onResponseWriteComplete(request, failure);
+    }
+
+    /**
+     * @param request the request object
+     * @param failure the write failure, or {@code null} if the write operation succeeded
+     * @deprecated use {@link #onResponseWriteComplete(Request, boolean, ByteBuffer, Throwable)} instead
+     */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     protected void onResponseWriteComplete(Request request, Throwable failure)
     {
         if (LOG.isDebugEnabled())
@@ -298,7 +311,7 @@ public abstract class EventsHandler extends Handler.Wrapper
     }
 
     /**
-     * Invoked after the response trailers have been written <em>and</em> the final {@link #onResponseWriteComplete(Request, Throwable)} event was fired.
+     * Invoked after the response trailers have been written <em>and</em> the final {@link #onResponseWriteComplete(Request, boolean, ByteBuffer, Throwable)} event was fired.
      *
      * @param request the request object. The {@code read()}, {@code demand(Runnable)} and {@code fail(Throwable)} methods must not be called by the listener.
      * @param trailers the written trailers.
@@ -359,13 +372,14 @@ public abstract class EventsHandler extends Handler.Wrapper
         {
             notifyOnResponseBegin(getRequest(), this);
             notifyOnResponseWrite(getRequest(), last, byteBuffer);
+            ByteBuffer copy = byteBuffer.asReadOnlyBuffer();
             super.write(last, byteBuffer, Callback.from(callback.getInvocationType(), () ->
             {
-                notifyOnResponseWriteComplete(getRequest(), null);
+                notifyOnResponseWriteComplete(getRequest(), last, copy, null);
                 callback.succeeded();
             }, x ->
             {
-                notifyOnResponseWriteComplete(getRequest(), x);
+                notifyOnResponseWriteComplete(getRequest(), last, copy, x);
                 callback.failed(x);
             }));
         }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MinimumDataRateHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/MinimumDataRateHandler.java
@@ -1,0 +1,185 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.NanoTime;
+import org.eclipse.jetty.util.thread.Scheduler;
+
+/**
+ * Checks that the wrapped handler can read/write at a minimal rate of N bytes per second.
+ * When reading or writing does not conform to the specified rates, this handler prevents
+ * further reads or writes by making them immediately fail.
+ */
+public class MinimumDataRateHandler extends StatisticsHandler
+{
+    private final long _minimumReadRate;
+    private final long _minimumWriteRate;
+
+    /**
+     * Creates a {@code MinimumDataRateHandler} with the specified read and write rates.
+     * @param minimumReadRate the minimum number of bytes to be read per second, or 0 for not checking the read rate.
+     * @param minimumWriteRate the minimum number of bytes to be written per second, or 0 for not checking the write rate.
+     */
+    public MinimumDataRateHandler(long minimumReadRate, long minimumWriteRate)
+    {
+        this(null, minimumReadRate, minimumWriteRate);
+    }
+
+    /**
+     * Creates a {@code MinimumDataRateHandler} with the specified read and write rates.
+     *
+     * @param handler the handler to wrap.
+     * @param minimumReadRate the minimum number of bytes to be read per second, or 0 for not checking the read rate.
+     * @param minimumWriteRate the minimum number of bytes to be written per second, or 0 for not checking the write rate.
+     */
+    public MinimumDataRateHandler(Handler handler, long minimumReadRate, long minimumWriteRate)
+    {
+        super(handler);
+        _minimumReadRate = minimumReadRate;
+        _minimumWriteRate = minimumWriteRate;
+    }
+
+    @Override
+    public boolean handle(Request request, Response response, Callback callback) throws Exception
+    {
+        MinimumDataRateRequest wrappedRequest = new MinimumDataRateRequest(request);
+        MinimumDataRateResponse wrappedResponse = new MinimumDataRateResponse(wrappedRequest, response);
+        return super.handle(wrappedRequest, wrappedResponse, callback);
+    }
+
+    private long dataRatePerSecond(long beginNanoTime, long bytes)
+    {
+        if (bytes == 0)
+            return 0;
+        long elapsed = NanoTime.since(beginNanoTime);
+        return bytes * 1_000_000_000 / (elapsed > 0 ? elapsed : 1);
+    }
+
+    protected class MinimumDataRateRequest extends Request.Wrapper
+    {
+        private long _firstDemandNanoTime;
+        private Content.Chunk _errorContent;
+
+        private MinimumDataRateRequest(Request request)
+        {
+            super(request);
+        }
+
+        @Override
+        public void demand(Runnable demandCallback)
+        {
+            if (_minimumReadRate > 0)
+            {
+                if (_firstDemandNanoTime == 0)
+                {
+                    _firstDemandNanoTime = NanoTime.now();
+                    if (_firstDemandNanoTime == 0)
+                        _firstDemandNanoTime = 1;
+                }
+
+                long read = getBytesRead();
+                if (read > 0)
+                {
+                    long rate = dataRatePerSecond(_firstDemandNanoTime, read);
+                    if (rate < _minimumReadRate)
+                    {
+                        _errorContent = Content.Chunk.from(new TimeoutException("read rate is too low"));
+                        demandCallback.run();
+                        return;
+                    }
+                }
+            }
+            super.demand(demandCallback);
+        }
+
+        @Override
+        public Content.Chunk read()
+        {
+            return _errorContent != null ? _errorContent : super.read();
+        }
+    }
+
+    protected class MinimumDataRateResponse extends Response.Wrapper
+    {
+        private long _firstWriteNanoTime;
+        
+        public MinimumDataRateResponse(MinimumDataRateRequest request, Response wrapped)
+        {
+            super(request, wrapped);
+        }
+
+        @Override
+        public MinimumDataRateRequest getRequest()
+        {
+            return (MinimumDataRateRequest)super.getRequest();
+        }
+
+        @Override
+        public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+        {
+            if (_minimumWriteRate > 0)
+            {
+                if (_firstWriteNanoTime == 0)
+                {
+                    _firstWriteNanoTime = NanoTime.now();
+                    if (_firstWriteNanoTime == 0)
+                        _firstWriteNanoTime = 1;
+                }
+
+                long written = getBytesWritten();
+                if (written > 0)
+                {
+                    long rate = dataRatePerSecond(_firstWriteNanoTime, written);
+                    if (rate < _minimumWriteRate)
+                    {
+                        fail(callback);
+                        return;
+                    }
+                }
+                else
+                {
+                    // It's the first write; if it is also the last, use a timer to verify the rate.
+                    if (last)
+                    {
+                        long length = byteBuffer.remaining();
+                        if (length > 0)
+                        {
+                            Callback original = callback;
+                            long maxWriteDuration = length * 1_000_000_000L / _minimumWriteRate;
+                            Scheduler.Task task = getRequest().getComponents().getScheduler().schedule(() -> fail(original), maxWriteDuration, TimeUnit.NANOSECONDS);
+                            callback = Callback.from(task::cancel, callback);
+                        }
+                    }
+                }
+            }
+            super.write(last, byteBuffer, callback);
+        }
+
+        private void fail(Callback callback)
+        {
+            TimeoutException cause = new TimeoutException("write rate is too low");
+            getRequest()._errorContent = Content.Chunk.from(cause);
+            callback.failed(cause);
+        }
+    }
+}

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/StatisticsHandler.java
@@ -16,16 +16,13 @@ package org.eclipse.jetty.server.handler;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.time.Duration;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
 
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.Request;
-import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.util.BufferUtil;
-import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedOperation;
@@ -90,11 +87,14 @@ public class StatisticsHandler extends EventsHandler
     }
 
     @Override
-    protected void onResponseWrite(Request request, boolean last, ByteBuffer content)
+    protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
     {
-        int length = BufferUtil.length(content);
-        if (length > 0)
-            _bytesWritten.add(length);
+        if (failure == null)
+        {
+            int length = BufferUtil.length(content);
+            if (length > 0)
+                _bytesWritten.add(length);
+        }
     }
 
     @Override
@@ -308,123 +308,19 @@ public class StatisticsHandler extends EventsHandler
     }
 
     /**
-     * Checks that the wrapped handler can read/write at a minimal rate of N bytes per second.
-     * When reading or writing does not conform to the specified rates, this handler prevents
-     * further reads or writes by making them immediately fail.
+     * @deprecated use {@link org.eclipse.jetty.server.handler.MinimumDataRateHandler} instead.
      */
-    public static class MinimumDataRateHandler extends StatisticsHandler
+    @Deprecated(since = "12.1.11", forRemoval = true)
+    public static class MinimumDataRateHandler extends org.eclipse.jetty.server.handler.MinimumDataRateHandler
     {
-        private final long _minimumReadRate;
-        private final long _minimumWriteRate;
-
-        /**
-         * Creates a {@code MinimumDataRateHandler} with the specified read and write rates.
-         * @param minimumReadRate the minimum number of bytes to be read per second, or 0 for not checking the read rate.
-         * @param minimumWriteRate the minimum number of bytes to be written per second, or 0 for not checking the write rate.
-         */
         public MinimumDataRateHandler(long minimumReadRate, long minimumWriteRate)
         {
             this(null, minimumReadRate, minimumWriteRate);
         }
 
-        /**
-         * Creates a {@code MinimumDataRateHandler} with the specified read and write rates.
-         *
-         * @param handler the handler to wrap.
-         * @param minimumReadRate the minimum number of bytes to be read per second, or 0 for not checking the read rate.
-         * @param minimumWriteRate the minimum number of bytes to be written per second, or 0 for not checking the write rate.
-         */
         public MinimumDataRateHandler(Handler handler, long minimumReadRate, long minimumWriteRate)
         {
-            super(handler);
-            _minimumReadRate = minimumReadRate;
-            _minimumWriteRate = minimumWriteRate;
-        }
-
-        @Override
-        public boolean handle(Request request, Response response, Callback callback) throws Exception
-        {
-            MinimumDataRateRequest wrappedRequest = new MinimumDataRateRequest(request);
-            MinimumDataRateResponse wrappedResponse = new MinimumDataRateResponse(wrappedRequest, response);
-            return super.handle(wrappedRequest, wrappedResponse, callback);
-        }
-
-        protected class MinimumDataRateRequest extends Request.Wrapper
-        {
-            private Content.Chunk _errorContent;
-
-            private MinimumDataRateRequest(Request request)
-            {
-                super(request);
-            }
-
-            private long dataRatePerSecond(long dataCount)
-            {
-                if (dataCount == 0L)
-                    return 0L;
-                long delayInNs = NanoTime.since(getHeadersNanoTime());
-                // If you read 1 byte or more in 0ns or less, you have infinite bandwidth.
-                if (delayInNs <= 0L)
-                    return Long.MAX_VALUE;
-                return dataCount * 1_000_000_000 / delayInNs;
-            }
-
-            @Override
-            public void demand(Runnable demandCallback)
-            {
-                if (_minimumReadRate > 0)
-                {
-                    long rr = dataRatePerSecond(getBytesRead());
-                    if (rr < _minimumReadRate)
-                    {
-                        _errorContent = Content.Chunk.from(new TimeoutException("read rate is too low: " + rr));
-                        demandCallback.run();
-                        return;
-                    }
-                }
-                super.demand(demandCallback);
-            }
-
-            @Override
-            public Content.Chunk read()
-            {
-                return _errorContent != null ? _errorContent : super.read();
-            }
-        }
-
-        protected class MinimumDataRateResponse extends Response.Wrapper
-        {
-            public MinimumDataRateResponse(MinimumDataRateRequest request, Response wrapped)
-            {
-                super(request, wrapped);
-            }
-
-            @Override
-            public MinimumDataRateRequest getRequest()
-            {
-                return (MinimumDataRateRequest)super.getRequest();
-            }
-
-            @Override
-            public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
-            {
-                if (_minimumWriteRate > 0)
-                {
-                    long bytesWritten = getBytesWritten();
-                    if (bytesWritten > 0L)
-                    {
-                        long wr = getRequest().dataRatePerSecond(bytesWritten);
-                        if (wr < _minimumWriteRate)
-                        {
-                            TimeoutException cause = new TimeoutException("write rate is too low: " + wr);
-                            getRequest()._errorContent = Content.Chunk.from(cause);
-                            callback.failed(cause);
-                            return;
-                        }
-                    }
-                }
-                super.write(last, byteBuffer, callback);
-            }
+            super(handler, minimumReadRate, minimumWriteRate);
         }
     }
 }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EventsHandlerTest.java
@@ -195,7 +195,7 @@ public class EventsHandlerTest
             }
 
             @Override
-            protected void onResponseWriteComplete(Request request, Throwable failure)
+            protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
             {
                 events.add("onResponseWriteComplete");
             }

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MinimumDataRateHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/MinimumDataRateHandlerTest.java
@@ -1,0 +1,386 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.server.handler;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.Callback;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class MinimumDataRateHandlerTest
+{
+    private Server server;
+    private LocalConnector connector;
+
+    private void start(Handler handler) throws Exception
+    {
+        server = new Server();
+        connector = new LocalConnector(server);
+        server.addConnector(connector);
+
+        server.setHandler(handler);
+        server.start();
+    }
+
+    @AfterEach
+    public void dispose() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void testMinimumDataReadRate() throws Exception
+    {
+        long minimumReadRate = 1200;
+        start(new MinimumDataRateHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                while (true)
+                {
+                    Content.Chunk chunk = request.read();
+                    if (chunk == null)
+                    {
+                        request.demand(() -> handle(request, response, callback));
+                        return true;
+                    }
+
+                    if (Content.Chunk.isFailure(chunk))
+                    {
+                        callback.failed(chunk.getFailure());
+                        return true;
+                    }
+
+                    chunk.release();
+                    if (chunk.isLast())
+                    {
+                        response.setStatus(HttpStatus.OK_200);
+                        callback.succeeded();
+                        return true;
+                    }
+                }
+            }
+        }, minimumReadRate, 0));
+
+        String request = """
+            POST / HTTP/1.1\r
+            Host: localhost\r
+            Content-Length: 1000\r
+            \r
+            """;
+
+        try (LocalConnector.LocalEndPoint endPoint = connector.executeRequest(request))
+        {
+            // Send 10 byte every 10 ms, should avg to ~1000
+            // bytes/s, which is below the minimum read rate.
+            for (int i = 0; i < 100; ++i)
+            {
+                Thread.sleep(10);
+                endPoint.addInput(ByteBuffer.allocate(10));
+            }
+
+            ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS);
+            assertNotNull(byteBuffer);
+            HttpTester.Response response = HttpTester.parseResponse(byteBuffer);
+            assertThat(response.getStatus(), is(HttpStatus.INTERNAL_SERVER_ERROR_500));
+            assertThat(response.getContent(), containsString("read rate is too low"));
+        }
+    }
+
+    @Test
+    public void testMinimumDataReadRateFirstDemandDelayed() throws Exception
+    {
+        long delay = 1000;
+        long minimumReadRate = 1200;
+        CountDownLatch demandLatch = new CountDownLatch(1);
+        start(new MinimumDataRateHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Delay the first demand, it should not trip the data rate.
+                // Only enforce the data rate after the application demands for data.
+                Thread.sleep(delay);
+                read(request, response, callback);
+                return true;
+            }
+
+            private void read(Request request, Response response, Callback callback)
+            {
+                while (true)
+                {
+                    Content.Chunk chunk = request.read();
+                    if (chunk == null)
+                    {
+                        request.demand(() -> read(request, response, callback));
+                        demandLatch.countDown();
+                        return;
+                    }
+
+                    if (Content.Chunk.isFailure(chunk))
+                    {
+                        callback.failed(chunk.getFailure());
+                        return;
+                    }
+
+                    chunk.release();
+                    if (chunk.isLast())
+                    {
+                        response.setStatus(HttpStatus.OK_200);
+                        callback.succeeded();
+                        return;
+                    }
+                }
+            }
+        }, minimumReadRate, 0));
+
+        String request = """
+            POST / HTTP/1.1\r
+            Host: localhost\r
+            Content-Length: 1000\r
+            \r
+            """;
+
+        try (LocalConnector.LocalEndPoint endPoint = connector.executeRequest(request))
+        {
+            // Wait to send the content until the server demands.
+            assertTrue(demandLatch.await(2 * delay, TimeUnit.MILLISECONDS));
+
+            // Send the whole content.
+            endPoint.addInput(ByteBuffer.allocate(1000));
+
+            ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS);
+            assertNotNull(byteBuffer);
+            HttpTester.Response response = HttpTester.parseResponse(byteBuffer);
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        }
+    }
+
+    @Test
+    public void testMinimumDataWriteRate() throws Exception
+    {
+        long minimumWriteRate = 1200;
+        AtomicReference<Throwable> writeFailureRef = new AtomicReference<>();
+        CountDownLatch writeCompleteLatch = new CountDownLatch(1);
+        start(new MinimumDataRateHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                write(response, 0, new Callback.Nested(callback)
+                {
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        super.failed(x);
+                        writeFailureRef.set(x);
+                    }
+
+                    @Override
+                    public void completed()
+                    {
+                        writeCompleteLatch.countDown();
+                    }
+                });
+                return true;
+            }
+
+            private void write(Response response, int counter, Callback callback)
+            {
+                try
+                {
+                    // Write 10 bytes every 10 ms, should avg ~1000 bytes/s.
+                    Thread.sleep(10);
+
+                    if (counter < 100)
+                    {
+                        response.write(false, ByteBuffer.allocate(10), new Callback()
+                        {
+                            @Override
+                            public void succeeded()
+                            {
+                                write(response, counter + 1, callback);
+                            }
+
+                            @Override
+                            public void failed(Throwable x)
+                            {
+                                callback.failed(x);
+                            }
+                        });
+                    }
+                    else
+                    {
+                        response.write(true, ByteBuffer.allocate(0), callback);
+                    }
+                }
+                catch (InterruptedException x)
+                {
+                    callback.failed(x);
+                }
+            }
+        }, 0, minimumWriteRate));
+
+        String request = """
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            \r
+            """;
+
+        try (LocalConnector.LocalEndPoint endPoint = connector.executeRequest(request))
+        {
+            assertTrue(writeCompleteLatch.await(5, TimeUnit.SECONDS));
+            ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS);
+            assertNotNull(byteBuffer);
+            // The response is a 200 OK with chunked content, that has been interrupted.
+            String response = StandardCharsets.UTF_8.decode(byteBuffer.slice()).toString();
+            assertThat(response, containsString("HTTP/1.1 200 OK"));
+            // Cannot parse a full response, since it has been interrupted.
+            assertNull(HttpTester.parseResponse(byteBuffer));
+            assertThat(writeFailureRef.get().getMessage(), containsString("write rate is too low"));
+        }
+    }
+
+    @Test
+    public void testMinimumDataWriteRateFirstWriteDelayed() throws Exception
+    {
+        long delay = 1000;
+        long minimumWriteRate = 1200;
+        start(new MinimumDataRateHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Delay the first write, it should not trip the data rate.
+                // Only enforce the data rate after the application writes.
+                Thread.sleep(delay);
+
+                // A first small write to initialize the data rate check.
+                CompletableFuture<?> future = new CompletableFuture<>();
+                response.write(false, ByteBuffer.allocate(10), Callback.from(future));
+                future.get(5, TimeUnit.SECONDS);
+
+                // Write the rest.
+                response.write(false, ByteBuffer.allocate(990), callback);
+                return true;
+            }
+        }, 0, minimumWriteRate));
+
+        String request = """
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            \r
+            """;
+
+        try (LocalConnector.LocalEndPoint endPoint = connector.executeRequest(request))
+        {
+            ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS);
+            assertNotNull(byteBuffer);
+            HttpTester.Response response = HttpTester.parseResponse(byteBuffer);
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        }
+    }
+
+    @Test
+    public void testMinimumDataWriteRateWithSingleLastWrite() throws Exception
+    {
+        long minimumWriteRate = 1200;
+        AtomicReference<Throwable> writeFailureRef = new AtomicReference<>();
+        CountDownLatch writeCompleteLatch = new CountDownLatch(1);
+        start(new Handler.Wrapper(new MinimumDataRateHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                // Perform a single last write that takes too long to complete.
+                response.write(true, ByteBuffer.allocate(1000), new Callback.Nested(callback)
+                {
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        super.failed(x);
+                        writeFailureRef.set(x);
+                    }
+
+                    @Override
+                    public void completed()
+                    {
+                        writeCompleteLatch.countDown();
+                    }
+                });
+                return true;
+            }
+        }, 0, minimumWriteRate))
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                return super.handle(request, new Response.Wrapper(request, response)
+                {
+                    @Override
+                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
+                    {
+                        // Only partially write the response to simulate TCP congestion.
+                        // The data rate timeout should fire and fail the Handler callback.
+                        int length = byteBuffer.remaining() / 2;
+                        ByteBuffer partial = byteBuffer.slice(byteBuffer.position(), length);
+                        byteBuffer.position(byteBuffer.position() + length);
+                        super.write(false, partial, Callback.NOOP);
+                    }
+                }, callback);
+            }
+        });
+
+        String request = """
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            \r
+            """;
+
+        try (LocalConnector.LocalEndPoint endPoint = connector.executeRequest(request))
+        {
+            assertTrue(writeCompleteLatch.await(5, TimeUnit.SECONDS));
+            ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS);
+            assertNotNull(byteBuffer);
+            // The response is a 200 OK with chunked content, that has been interrupted.
+            String response = StandardCharsets.UTF_8.decode(byteBuffer.slice()).toString();
+            assertThat(response, containsString("HTTP/1.1 200 OK"));
+            // Cannot parse a full response, since it has been interrupted.
+            assertNull(HttpTester.parseResponse(byteBuffer));
+            assertThat(writeFailureRef.get().getMessage(), containsString("write rate is too low"));
+        }
+    }
+}

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/StatisticsHandlerTest.java
@@ -20,12 +20,8 @@ import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jetty.io.ConnectionStatistics;
-import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.server.Handler;
 import org.eclipse.jetty.server.LocalConnector;
@@ -45,10 +41,8 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
-import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -82,162 +76,6 @@ public class StatisticsHandlerTest
     {
         _server.stop();
         _server.join();
-    }
-
-    @Test
-    public void testMinimumDataReadRateHandler() throws Exception
-    {
-        StatisticsHandler.MinimumDataRateHandler mdrh = new StatisticsHandler.MinimumDataRateHandler(1100, 0);
-        mdrh.setHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                while (true)
-                {
-                    Content.Chunk chunk = request.read();
-                    if (chunk == null)
-                    {
-                        request.demand(() -> handle(request, response, callback));
-                        return true;
-                    }
-
-                    if (Content.Chunk.isFailure(chunk))
-                    {
-                        callback.failed(chunk.getFailure());
-                        return true;
-                    }
-
-                    chunk.release();
-                    if (chunk.isLast())
-                    {
-                        callback.succeeded();
-                        return true;
-                    }
-                }
-            }
-        });
-
-        _latchHandler.setHandler(mdrh);
-        AtomicReference<String> messageRef = new AtomicReference<>();
-        _server.setErrorHandler((request, response, callback) ->
-        {
-            messageRef.set((String)request.getAttribute(ErrorHandler.ERROR_MESSAGE));
-            callback.succeeded();
-            return true;
-        });
-        _server.start();
-
-        String request = """
-            POST / HTTP/1.1\r
-            Host: localhost\r
-            Content-Length: 1000\r
-            \r
-            """;
-
-        try (StacklessLogging ignore = new StacklessLogging(Response.class))
-        {
-            LocalConnector.LocalEndPoint endPoint = _connector.executeRequest(request);
-
-            // send 10 byte every 10 ms -> should avg to ~1000 bytes/s
-            for (int i = 0; i < 100; i++)
-            {
-                Thread.sleep(10);
-                endPoint.addInput(ByteBuffer.allocate(10));
-            }
-
-            _latchHandler.await();
-            AtomicInteger statusHolder = new AtomicInteger();
-            endPoint.waitForResponse(false, 5, TimeUnit.SECONDS, statusHolder::set);
-            assertThat(statusHolder.get(), is(500));
-            assertThat(messageRef.get(), startsWith("java.util.concurrent.TimeoutException: read rate is too low"));
-        }
-    }
-
-    @Test
-    public void testMinimumDataWriteRateHandler() throws Exception
-    {
-        AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
-        CountDownLatch latch = new CountDownLatch(1);
-        int expectedContentLength = 1000;
-        StatisticsHandler.MinimumDataRateHandler mdrh = new StatisticsHandler.MinimumDataRateHandler(new Handler.Abstract.NonBlocking()
-        {
-            @Override
-            public boolean handle(Request request, Response response, Callback callback)
-            {
-                write(response, 0, new Callback()
-                {
-                    @Override
-                    public void succeeded()
-                    {
-                        callback.succeeded();
-                        latch.countDown();
-                    }
-
-                    @Override
-                    public void failed(Throwable x)
-                    {
-                        callback.failed(x);
-                        exceptionRef.set(x);
-                        latch.countDown();
-                    }
-                });
-                return true;
-            }
-
-            private void write(Response response, int counter, Callback finalCallback)
-            {
-                try
-                {
-                    Thread.sleep(1);
-                }
-                catch (InterruptedException e)
-                {
-                    // ignore
-                }
-
-                if (counter < expectedContentLength)
-                {
-                    Callback cb = new Callback()
-                    {
-                        @Override
-                        public void succeeded()
-                        {
-                            write(response, counter + 1, finalCallback);
-                        }
-
-                        @Override
-                        public void failed(Throwable x)
-                        {
-                            finalCallback.failed(x);
-                        }
-                    };
-                    response.write(false, ByteBuffer.allocate(1), cb);
-                }
-                else
-                {
-                    response.write(true, ByteBuffer.allocate(1), finalCallback);
-                }
-            }
-        }, 0, 1000);
-
-        _latchHandler.setHandler(mdrh);
-        _server.start();
-
-        String request = """
-                GET / HTTP/1.1\r
-                Host: localhost\r
-                \r
-                """;
-
-        LocalConnector.LocalEndPoint endPoint = _connector.executeRequest(request);
-
-        assertTrue(latch.await(5, TimeUnit.SECONDS));
-        AtomicInteger statusHolder = new AtomicInteger();
-        ByteBuffer byteBuffer = endPoint.waitForResponse(false, 5, TimeUnit.SECONDS, statusHolder::set);
-        assertThat(statusHolder.get(), is(500));
-        assertThat(exceptionRef.get(), instanceOf(TimeoutException.class));
-        assertThat(exceptionRef.get().getMessage(), startsWith("write rate is too low"));
     }
 
     @Test

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/EventsHandlerTest.java
@@ -185,7 +185,7 @@ public class EventsHandlerTest extends AbstractTest
             }
 
             @Override
-            protected void onResponseWriteComplete(Request request, Throwable failure)
+            protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
             {
                 if (failure != null)
                     failures.add(failure);
@@ -368,7 +368,7 @@ public class EventsHandlerTest extends AbstractTest
         }
 
         @Override
-        protected void onResponseWriteComplete(Request request, Throwable failure)
+        protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
         {
             addEvent("onResponseWriteComplete");
         }
@@ -424,7 +424,7 @@ public class EventsHandlerTest extends AbstractTest
         }
 
         @Override
-        protected void onResponseWriteComplete(Request request, Throwable failure)
+        protected void onResponseWriteComplete(Request request, boolean last, ByteBuffer content, Throwable failure)
         {
             useForbiddenMethods(request, exceptions);
         }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.IteratingCallback;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
@@ -126,7 +125,6 @@ public class HttpOutput extends ServletOutputStream
     private State _state = State.OPEN;
     private boolean _softClose = false;
     private long _written;
-    private long _firstByteNanoTime = -1;
     private ByteBufferPool.Sized _pool;
     private RetainableByteBuffer _aggregate;
     private int _bufferSize;
@@ -237,27 +235,11 @@ public class HttpOutput extends ServletOutputStream
 
     private void channelWrite(ByteBuffer content, boolean last, Callback callback)
     {
-        if (_firstByteNanoTime == -1)
-        {
-            long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-            if (minDataRate > 0)
-                _firstByteNanoTime = NanoTime.now();
-            else
-                _firstByteNanoTime = Long.MAX_VALUE;
-        }
         _servletChannel.getResponse().write(last, content, callback);
     }
 
     private void channelWrite(RetainableByteBuffer content, boolean last, Callback callback)
     {
-        if (_firstByteNanoTime == -1)
-        {
-            long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-            if (minDataRate > 0)
-                _firstByteNanoTime = NanoTime.now();
-            else
-                _firstByteNanoTime = Long.MAX_VALUE;
-        }
         content.writeTo(_servletChannel.getResponse(), last, callback);
     }
 
@@ -1329,7 +1311,6 @@ public class HttpOutput extends ServletOutputStream
             _written = 0;
             _writeListener = null;
             _onError = null;
-            _firstByteNanoTime = -1;
             _closedCallback = null;
             _applicationContentLength = -1;
         }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -37,7 +37,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.IteratingCallback;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.TypeUtil;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.slf4j.Logger;
@@ -126,7 +125,6 @@ public class HttpOutput extends ServletOutputStream
     private State _state = State.OPEN;
     private boolean _softClose = false;
     private long _written;
-    private long _firstByteNanoTime = -1;
     private ByteBufferPool.Sized _pool;
     private RetainableByteBuffer _aggregate;
     private int _bufferSize;
@@ -237,27 +235,11 @@ public class HttpOutput extends ServletOutputStream
 
     private void channelWrite(ByteBuffer content, boolean last, Callback callback)
     {
-        if (_firstByteNanoTime == -1)
-        {
-            long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-            if (minDataRate > 0)
-                _firstByteNanoTime = NanoTime.now();
-            else
-                _firstByteNanoTime = Long.MAX_VALUE;
-        }
         _servletChannel.getResponse().write(last, content, callback);
     }
 
     private void channelWrite(RetainableByteBuffer content, boolean last, Callback callback)
     {
-        if (_firstByteNanoTime == -1)
-        {
-            long minDataRate = _servletChannel.getConnectionMetaData().getHttpConfiguration().getMinResponseDataRate();
-            if (minDataRate > 0)
-                _firstByteNanoTime = NanoTime.now();
-            else
-                _firstByteNanoTime = Long.MAX_VALUE;
-        }
         content.writeTo(_servletChannel.getResponse(), last, callback);
     }
 
@@ -1342,7 +1324,6 @@ public class HttpOutput extends ServletOutputStream
             _written = 0;
             _writeListener = null;
             _onError = null;
-            _firstByteNanoTime = -1;
             _closedCallback = null;
             _applicationContentLength = -1;
         }

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -42,7 +42,6 @@ import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.IteratingCallback;
-import org.eclipse.jetty.util.NanoTime;
 import org.eclipse.jetty.util.SharedBlockingCallback;
 import org.eclipse.jetty.util.SharedBlockingCallback.Blocker;
 import org.eclipse.jetty.util.TypeUtil;
@@ -197,7 +196,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     private boolean _softClose = false;
     private Interceptor _interceptor;
     private long _written;
-    private long _firstByteNanoTime = -1;
     private ByteBufferPool.Sized _pool;
     private RetainableByteBuffer _aggregate;
     private int _bufferSize;
@@ -280,15 +278,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
     private void channelWrite(ByteBuffer content, boolean last, Callback callback)
     {
-        if (_firstByteNanoTime == -1)
-        {
-            long minDataRate = getHttpChannel().getHttpConfiguration().getMinResponseDataRate();
-            if (minDataRate > 0)
-                _firstByteNanoTime = NanoTime.now();
-            else
-                _firstByteNanoTime = Long.MAX_VALUE;
-        }
-
         _interceptor.write(content, last, callback);
     }
 
@@ -1471,7 +1460,6 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             _written = 0;
             _writeListener = null;
             _onError = null;
-            _firstByteNanoTime = -1;
             _closedCallback = null;
         }
     }

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/ModulesTest.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 import static org.eclipse.jetty.tests.distribution.AbstractJettyHomeTest.START_TIMEOUT;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ModulesTest
 {
@@ -121,6 +122,28 @@ public class ModulesTest
             assertThat(run.awaitConsoleLogsFor("Started oejs.Server", START_TIMEOUT, TimeUnit.SECONDS), is(true));
             run.stop();
             assertThat(run.awaitFor(START_TIMEOUT, TimeUnit.SECONDS), is(true));
+        }
+    }
+
+    @Test
+    public void testMinDataRate() throws Exception
+    {
+        String jettyVersion = System.getProperty("jettyVersion");
+        JettyHomeTester distribution = JettyHomeTester.Builder.newInstance()
+            .jettyVersion(jettyVersion)
+            .build();
+
+        // Add module.
+        try (JettyHomeTester.Run run1 = distribution.start("--add-modules=min-data-rate"))
+        {
+            assertTrue(run1.awaitForStart());
+            assertThat(run1.getExitValue(), is(0));
+
+            // Verify that Jetty starts.
+            try (JettyHomeTester.Run run2 = distribution.start())
+            {
+                assertTrue(run2.awaitForJettyStart());
+            }
         }
     }
 }


### PR DESCRIPTION
* Improved EventsHandler by changing `onResponseWriteComplete()` to take also the `last` and the content `ByteBuffer` as parameters. This allows a more precise accounting for written bytes.
* Updated `StatisticsHandler` to account for written bytes only if they are successfully written.
* Deprecated `HttpConfiguration.minRequestDataRate` and `HttpConfiguration.minResponseDataRate`. Only the former was still used, and only in Servlet code, but the mechanism should be replaced by `MinimumDataRateHandler`.
* Remove dead code in eeN's `HttpOutput` that was referring to `HttpConfiguration.minResponseDataRate` without actually enforcing the rate.
* Introduced `min-data-rate.mod`.
* Moved `MinimumDataRateHandler` to upper level, and added more tests.
* Updated documentation.