### PR TITLE
12.0.x: Fix deadlock in `HttpOutput.close()`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -462,7 +462,8 @@ public class HttpOutput extends ServletOutputStream
     public void close() throws IOException
     {
         ByteBuffer content = null;
-        Blocker.Callback blocker = null;
+        boolean acquireBlocker = false;
+        boolean combineClosedCallback = false;
         try (AutoLock l = _channelState.lock())
         {
             if (_softClose)
@@ -491,8 +492,8 @@ public class HttpOutput extends ServletOutputStream
                         case BLOCKING:
                         case BLOCKED:
                             // block until CLOSED state reached.
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         default:
@@ -508,7 +509,7 @@ public class HttpOutput extends ServletOutputStream
                             // Output is idle blocking state, but we still do an async close
                             _apiState = ApiState.BLOCKED;
                             _state = State.CLOSING;
-                            blocker = _writeBlocker.callback();
+                            acquireBlocker = true;
                             content = _aggregate != null && _aggregate.hasRemaining() ? _aggregate.getByteBuffer() : BufferUtil.EMPTY_BUFFER;
                             break;
 
@@ -518,8 +519,8 @@ public class HttpOutput extends ServletOutputStream
                             // then trigger a close from onWriteComplete
                             _state = State.CLOSE;
                             // and block until it is complete
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         case ASYNC:
@@ -539,6 +540,17 @@ public class HttpOutput extends ServletOutputStream
                             break;
                     }
                     break;
+            }
+        }
+
+        // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
+        Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
+
+        if (combineClosedCallback)
+        {
+            try (AutoLock l = _channelState.lock())
+            {
+                _closedCallback = Callback.combine(_closedCallback, blocker);
             }
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -550,7 +550,18 @@ public class HttpOutput extends ServletOutputStream
         {
             try (AutoLock l = _channelState.lock())
             {
-                _closedCallback = Callback.combine(_closedCallback, blocker);
+                // Check if onWriteComplete fired while the lock was not held; when it does,
+                // it nulls _closedCallback so no blocking is needed anymore.
+                if (_closedCallback != null)
+                {
+                    _closedCallback = Callback.combine(_closedCallback, blocker);
+                }
+                else
+                {
+                    blocker.succeeded();
+                    blocker.close();
+                    blocker = null;
+                }
             }
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputBlockingTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputBlockingTest.java
@@ -1,0 +1,129 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HttpOutputBlockingTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        executorService = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        executorService.shutdownNow();
+        server.stop();
+    }
+
+    @Test
+    public void testConcurrentCloseDeadlock() throws Exception
+    {
+        final int concurrentCloses = 100;
+        final int concurrentRequests = 100;
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        ServletContextHandler handler = new ServletContextHandler("/");
+        handler.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                OutputStream out = resp.getOutputStream();
+                out.write("OK".getBytes(StandardCharsets.UTF_8));
+
+                for (int i = 0; i < concurrentCloses; i++)
+                {
+                    Future<Object> f = executorService.submit(() ->
+                    {
+                        out.close();
+                        return null;
+                    });
+                    futures.add(f);
+                }
+
+                for (Future<?> future : futures)
+                {
+                    try
+                    {
+                        future.get();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }), "/path/*");
+        server.setHandler(handler);
+        server.start();
+
+        StringBuilder request = new StringBuilder();
+        request.append("GET /path/ HTTP/1.1\r\n")
+            .append("Host: localhost\r\n")
+            .append("\r\n");
+
+        int port = connector.getLocalPort();
+        try (Socket socket = new Socket("localhost", port))
+        {
+            socket.setSoTimeout(10000);
+            for (int i = 0; i < concurrentRequests; i++)
+            {
+                OutputStream out = socket.getOutputStream();
+                out.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+
+                HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+                assertThat(response, notNullValue());
+                assertThat(response.getStatus(), is(200));
+                assertThat(response.getContent(), containsString("OK"));
+            }
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> futures.stream().allMatch(Future::isDone));
+    }
+}

--- a/jetty-ee8/jetty-ee8-nested/pom.xml
+++ b/jetty-ee8/jetty-ee8-nested/pom.xml
@@ -49,6 +49,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-nested/pom.xml
+++ b/jetty-ee9/jetty-ee9-nested/pom.xml
@@ -48,6 +48,11 @@
       <artifactId>slf4j-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -614,7 +614,18 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         {
             try (AutoLock l = _channelState.lock())
             {
-                _closedCallback = Callback.combine(_closedCallback, blocker);
+                // Check if onWriteComplete fired while the lock was not held; when it does,
+                // it nulls _closedCallback so no blocking is needed anymore.
+                if (_closedCallback != null)
+                {
+                    _closedCallback = Callback.combine(_closedCallback, blocker);
+                }
+                else
+                {
+                    blocker.succeeded();
+                    blocker.close();
+                    blocker = null;
+                }
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -622,6 +622,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 }
                 else
                 {
+                    // Here, combineClosedCallback is only ever true if acquireBlocker is also true,
+                    // so blocker can never be null.
                     blocker.succeeded();
                     blocker.close();
                     blocker = null;

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -529,7 +529,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     public void close() throws IOException
     {
         ByteBuffer content = null;
-        Blocker blocker = null;
+        boolean acquireBlocker = false;
+        boolean combineClosedCallback = false;
         try (AutoLock l = _channelState.lock())
         {
             if (_onError != null)
@@ -555,8 +556,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                         case BLOCKING:
                         case BLOCKED:
                             // block until CLOSED state reached.
-                            blocker = _writeBlocker.acquire();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         default:
@@ -572,7 +573,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             // Output is idle blocking state, but we still do an async close
                             _apiState = ApiState.BLOCKED;
                             _state = State.CLOSING;
-                            blocker = _writeBlocker.acquire();
+                            acquireBlocker = true;
                             content = _aggregate != null && _aggregate.hasRemaining() ? _aggregate.getByteBuffer() : BufferUtil.EMPTY_BUFFER;
                             break;
 
@@ -582,8 +583,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             // then trigger a close from onWriteComplete
                             _state = State.CLOSE;
                             // and block until it is complete
-                            blocker = _writeBlocker.acquire();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         case ASYNC:
@@ -603,6 +604,17 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             break;
                     }
                     break;
+            }
+        }
+
+        // Do not call _writeBlocker.acquire() from within a lock as it itself also takes a lock.
+        Blocker blocker = acquireBlocker ? _writeBlocker.acquire() : null;
+
+        if (combineClosedCallback)
+        {
+            try (AutoLock l = _channelState.lock())
+            {
+                _closedCallback = Callback.combine(_closedCallback, blocker);
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputBlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputBlockingTest.java
@@ -1,0 +1,132 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.nested;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HttpOutputBlockingTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private ContextHandler context;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        context = new ContextHandler(server, "/ctx");
+        executorService = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        executorService.shutdownNow();
+        server.stop();
+    }
+
+    @Test
+    public void testConcurrentCloseDeadlock() throws Exception
+    {
+        final int concurrentCloses = 100;
+        final int concurrentRequests = 100;
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        AbstractHandler handler = new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                HttpOutput out = (HttpOutput)response.getOutputStream();
+                out.write("OK".getBytes(StandardCharsets.UTF_8));
+
+
+                for (int i = 0; i < concurrentCloses; i++)
+                {
+                    Future<Object> f = executorService.submit(() ->
+                    {
+                        out.close();
+                        return null;
+                    });
+                    futures.add(f);
+                }
+
+                for (Future<?> future : futures)
+                {
+                    try
+                    {
+                        future.get();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+
+        context.setHandler(handler);
+        server.start();
+
+        StringBuilder request = new StringBuilder();
+        request.append("GET /ctx/path/info HTTP/1.1\r\n")
+            .append("Host: localhost\r\n")
+            .append("\r\n");
+
+        int port = connector.getLocalPort();
+        try (Socket socket = new Socket("localhost", port))
+        {
+            socket.setSoTimeout(10000);
+            for (int i = 0; i < concurrentRequests; i++)
+            {
+                OutputStream out = socket.getOutputStream();
+                out.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+
+                HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+                assertThat(response, notNullValue());
+                assertThat(response.getStatus(), is(200));
+                assertThat(response.getContent(), containsString("OK"));
+            }
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> futures.stream().allMatch(Future::isDone));
+    }
+}


### PR DESCRIPTION
Affects EE 8, 9 and 10.

Fixes #15226