### PR TITLE
Issue #15156 - fixes for wrapped requests with deferred authentication

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -189,6 +189,36 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         return new org.eclipse.jetty.http.ImmutableHttpFields(fields);
     }
 
+    static HttpCompliance copyHttpCompliance(HttpFields httpFields)
+    {
+        while (true)
+        {
+            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
+                return immutable._httpCompliance;
+            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
+                return mutable._httpCompliance;
+            if (httpFields instanceof Mutable.Wrapper wrapper)
+                httpFields = wrapper.getWrapped();
+            else
+                return null;
+        }
+    }
+
+    static Supplier<ComplianceViolation.Listener> copyComplianceListener(HttpFields httpFields)
+    {
+        while (true)
+        {
+            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
+                return immutable._listenerSupplier;
+            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
+                return mutable._listenerSupplier;
+            if (httpFields instanceof Mutable.Wrapper wrapper)
+                httpFields = wrapper.getWrapped();
+            else
+                return null;
+        }
+    }
+
     /**
      * <p>Supplies this instance, typically used to supply HTTP trailers.</p>
      *

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -189,36 +189,6 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         return new org.eclipse.jetty.http.ImmutableHttpFields(fields);
     }
 
-    static HttpCompliance copyHttpCompliance(HttpFields httpFields)
-    {
-        while (true)
-        {
-            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
-                return immutable._httpCompliance;
-            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
-                return mutable._httpCompliance;
-            if (httpFields instanceof Mutable.Wrapper wrapper)
-                httpFields = wrapper.getWrapped();
-            else
-                return null;
-        }
-    }
-
-    static Supplier<ComplianceViolation.Listener> copyComplianceListener(HttpFields httpFields)
-    {
-        while (true)
-        {
-            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
-                return immutable._listenerSupplier;
-            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
-                return mutable._listenerSupplier;
-            if (httpFields instanceof Mutable.Wrapper wrapper)
-                httpFields = wrapper.getWrapped();
-            else
-                return null;
-        }
-    }
-
     /**
      * <p>Supplies this instance, typically used to supply HTTP trailers.</p>
      *

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpFields.java
@@ -978,9 +978,9 @@ public interface HttpFields extends Iterable<HttpField>, Supplier<HttpFields>
         return StreamSupport.stream(spliterator(), false);
     }
 
-    default QuotedCSV newQuotedCSV(boolean b)
+    default QuotedCSV newQuotedCSV(boolean keepQuotes)
     {
-        return new QuotedCSV(b);
+        return new QuotedCSV(keepQuotes);
     }
 
     default QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
@@ -43,8 +43,8 @@ class MutableHttpFields implements HttpFields.Mutable
     private static final int INITIAL_SIZE = 16;
     private static final int SIZE_INCREMENT = 4;
 
-    final HttpCompliance _httpCompliance;
-    final Supplier<ComplianceViolation.Listener> _listenerSupplier;
+    private final HttpCompliance _httpCompliance;
+    private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
     private HttpField[] _fields;
     private boolean _immutable;
     private int _size;
@@ -76,8 +76,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields)
     {
-        _httpCompliance = HttpFields.copyHttpCompliance(fields);
-        _listenerSupplier = HttpFields.copyComplianceListener(fields);
+        _httpCompliance = copyHttpCompliance(fields);
+        _listenerSupplier = copyComplianceListener(fields);
         if (fields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
         {
             _fields = immutable._fields;
@@ -103,8 +103,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields, HttpField replaceField)
     {
-        _httpCompliance = HttpFields.copyHttpCompliance(fields);
-        _listenerSupplier = HttpFields.copyComplianceListener(fields);
+        _httpCompliance = copyHttpCompliance(fields);
+        _listenerSupplier = copyComplianceListener(fields);
         _fields = new HttpField[fields.size() + SIZE_INCREMENT];
         _size = 0;
         boolean put = false;
@@ -133,8 +133,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields, EnumSet<HttpHeader> removeFields)
     {
-        _httpCompliance = HttpFields.copyHttpCompliance(fields);
-        _listenerSupplier = HttpFields.copyComplianceListener(fields);
+        _httpCompliance = copyHttpCompliance(fields);
+        _listenerSupplier = copyComplianceListener(fields);
         _fields = new HttpField[fields.size() + SIZE_INCREMENT];
         _size = 0;
         for (HttpField f : fields)
@@ -149,6 +149,36 @@ class MutableHttpFields implements HttpFields.Mutable
         _httpCompliance = httpCompliance;
         _listenerSupplier = listenerSupplier;
         _fields = new HttpField[INITIAL_SIZE];
+    }
+
+    static HttpCompliance copyHttpCompliance(HttpFields httpFields)
+    {
+        while (true)
+        {
+            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
+                return immutable._httpCompliance;
+            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
+                return mutable._httpCompliance;
+            if (httpFields instanceof Mutable.Wrapper wrapper)
+                httpFields = wrapper.getWrapped();
+            else
+                return null;
+        }
+    }
+
+    static Supplier<ComplianceViolation.Listener> copyComplianceListener(HttpFields httpFields)
+    {
+        while (true)
+        {
+            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
+                return immutable._listenerSupplier;
+            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
+                return mutable._listenerSupplier;
+            if (httpFields instanceof Mutable.Wrapper wrapper)
+                httpFields = wrapper.getWrapped();
+            else
+                return null;
+        }
     }
 
     @Override

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/MutableHttpFields.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
-import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.BiPredicate;
@@ -44,8 +43,8 @@ class MutableHttpFields implements HttpFields.Mutable
     private static final int INITIAL_SIZE = 16;
     private static final int SIZE_INCREMENT = 4;
 
-    private final HttpCompliance _httpCompliance;
-    private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
+    final HttpCompliance _httpCompliance;
+    final Supplier<ComplianceViolation.Listener> _listenerSupplier;
     private HttpField[] _fields;
     private boolean _immutable;
     private int _size;
@@ -77,8 +76,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields)
     {
-        _httpCompliance = copyHttpCompliance(fields);
-        _listenerSupplier = copyComplianceListener(fields);
+        _httpCompliance = HttpFields.copyHttpCompliance(fields);
+        _listenerSupplier = HttpFields.copyComplianceListener(fields);
         if (fields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
         {
             _fields = immutable._fields;
@@ -104,8 +103,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields, HttpField replaceField)
     {
-        _httpCompliance = copyHttpCompliance(fields);
-        _listenerSupplier = copyComplianceListener(fields);
+        _httpCompliance = HttpFields.copyHttpCompliance(fields);
+        _listenerSupplier = HttpFields.copyComplianceListener(fields);
         _fields = new HttpField[fields.size() + SIZE_INCREMENT];
         _size = 0;
         boolean put = false;
@@ -134,8 +133,8 @@ class MutableHttpFields implements HttpFields.Mutable
      */
     protected MutableHttpFields(HttpFields fields, EnumSet<HttpHeader> removeFields)
     {
-        _httpCompliance = copyHttpCompliance(fields);
-        _listenerSupplier = copyComplianceListener(fields);
+        _httpCompliance = HttpFields.copyHttpCompliance(fields);
+        _listenerSupplier = HttpFields.copyComplianceListener(fields);
         _fields = new HttpField[fields.size() + SIZE_INCREMENT];
         _size = 0;
         for (HttpField f : fields)
@@ -150,36 +149,6 @@ class MutableHttpFields implements HttpFields.Mutable
         _httpCompliance = httpCompliance;
         _listenerSupplier = listenerSupplier;
         _fields = new HttpField[INITIAL_SIZE];
-    }
-
-    private static HttpCompliance copyHttpCompliance(HttpFields httpFields)
-    {
-        while (true)
-        {
-            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
-                return immutable._httpCompliance;
-            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
-                return mutable._httpCompliance;
-            if (httpFields instanceof Wrapper wrapper)
-                httpFields = wrapper.getWrapped();
-            else
-                return null;
-        }
-    }
-
-    private static Supplier<ComplianceViolation.Listener> copyComplianceListener(HttpFields httpFields)
-    {
-        while (true)
-        {
-            if (httpFields instanceof org.eclipse.jetty.http.ImmutableHttpFields immutable)
-                return immutable._listenerSupplier;
-            if (httpFields instanceof org.eclipse.jetty.http.MutableHttpFields mutable)
-                return mutable._listenerSupplier;
-            if (httpFields instanceof Wrapper wrapper)
-                httpFields = wrapper.getWrapped();
-            else
-                return null;
-        }
     }
 
     @Override

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /**
  * Implements a quoted comma-separated list of values
@@ -123,6 +124,18 @@ public class QuotedCSV extends QuotedCSVParser implements Iterable<String>
         super(keepQuotes);
         _compliance = compliance;
         _listener = listener;
+        for (String v : values)
+        {
+            addValue(v);
+        }
+    }
+
+    public QuotedCSV(HttpFields httpFields, boolean keepQuotes, String... values)
+    {
+        super(keepQuotes);
+        _compliance = MutableHttpFields.copyHttpCompliance(httpFields);
+        Supplier<ComplianceViolation.Listener> supplier = MutableHttpFields.copyComplianceListener(httpFields);
+        _listener = (supplier != null) ? supplier.get() : null;
         for (String v : values)
         {
             addValue(v);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedCSV.java
@@ -132,14 +132,13 @@ public class QuotedCSV extends QuotedCSVParser implements Iterable<String>
 
     public QuotedCSV(HttpFields httpFields, boolean keepQuotes, String... values)
     {
-        super(keepQuotes);
-        _compliance = MutableHttpFields.copyHttpCompliance(httpFields);
+        this(MutableHttpFields.copyHttpCompliance(httpFields), extractComplianceViolationListener(httpFields), keepQuotes, values);
+    }
+
+    private static ComplianceViolation.Listener extractComplianceViolationListener(HttpFields httpFields)
+    {
         Supplier<ComplianceViolation.Listener> supplier = MutableHttpFields.copyComplianceListener(httpFields);
-        _listener = (supplier != null) ? supplier.get() : null;
-        for (String v : values)
-        {
-            addValue(v);
-        }
+        return (supplier != null) ? supplier.get() : null;
     }
 
     @Override

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
@@ -105,6 +106,20 @@ public class QuotedQualityCSV extends QuotedCSV implements Iterable<String>
     {
         _compliance = compliance;
         _listener = listener;
+        _secondaryOrdering = secondaryOrdering == null ? s -> 0 : secondaryOrdering;
+    }
+
+    /**
+     * Orders values with equal quality with the given function.
+     *
+     * @param httpFields the {@link HttpFields} instance to extract the {@link ComplianceViolation.Mode} and {@link ComplianceViolation.Listener}.
+     * @param secondaryOrdering Function to apply an ordering other than specified by quality, highest values are sorted first.
+     */
+    public QuotedQualityCSV(HttpFields httpFields, ToIntFunction<String> secondaryOrdering)
+    {
+        _compliance = MutableHttpFields.copyHttpCompliance(httpFields);
+        Supplier<ComplianceViolation.Listener> supplier = MutableHttpFields.copyComplianceListener(httpFields);
+        _listener = (supplier != null) ? supplier.get() : null;
         _secondaryOrdering = secondaryOrdering == null ? s -> 0 : secondaryOrdering;
     }
 

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/QuotedQualityCSV.java
@@ -117,10 +117,13 @@ public class QuotedQualityCSV extends QuotedCSV implements Iterable<String>
      */
     public QuotedQualityCSV(HttpFields httpFields, ToIntFunction<String> secondaryOrdering)
     {
-        _compliance = MutableHttpFields.copyHttpCompliance(httpFields);
+        this(MutableHttpFields.copyHttpCompliance(httpFields), extractComplianceViolationListener(httpFields), secondaryOrdering);
+    }
+
+    private static ComplianceViolation.Listener extractComplianceViolationListener(HttpFields httpFields)
+    {
         Supplier<ComplianceViolation.Listener> supplier = MutableHttpFields.copyComplianceListener(httpFields);
-        _listener = (supplier != null) ? supplier.get() : null;
-        _secondaryOrdering = secondaryOrdering == null ? s -> 0 : secondaryOrdering;
+        return (supplier != null) ? supplier.get() : null;
     }
 
     private QuotedQualityCSV(ComplianceViolation.Mode compliance, ComplianceViolation.Listener listener, List<String> preferredOrder)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -277,7 +277,8 @@ public class ServletApiRequest implements HttpServletRequest
         AuthenticationState authenticationState = getAuthenticationState();
         if (authenticationState instanceof AuthenticationState.Deferred deferred)
         {
-            Request wrappedCoreRequest = ServletCoreRequest.wrap(_servletContextRequest.getHttpServletRequest());
+            HttpServletRequest httpServletRequest = getWrappedRequest();
+            Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
             AuthenticationState undeferred = deferred.authenticate(wrappedCoreRequest);
             if (undeferred != null)
                 authenticationState = undeferred;
@@ -293,23 +294,11 @@ public class ServletApiRequest implements HttpServletRequest
             AuthenticationState undeferred;
             try (Blocker.Callback callback = Blocker.callback())
             {
-                // Find the most wrapped HttpServletRequest to use for the authentication.
-                HttpServletRequest httpServletRequest;
-                if (_async == null)
-                {
-                    httpServletRequest = _servletContextRequest.getHttpServletRequest();
-                }
-                else
-                {
-                    if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
-                        httpServletRequest = asyncHttpServletRequest;
-                    else
-                        httpServletRequest = _servletContextRequest.getHttpServletRequest();
-                }
-
+                // Find the outermost wrapped HttpServletRequest to use for the authentication.
+                HttpServletRequest httpServletRequest = getWrappedRequest();
                 boolean included = httpServletRequest.getDispatcherType() == DispatcherType.INCLUDE;
                 Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
-                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, included);
+                Response wrappedCoreResponse = ServletCoreResponse.wrap(wrappedCoreRequest, response, included);
                 undeferred = deferred.authenticate(wrappedCoreRequest, wrappedCoreResponse, callback);
                 if (undeferred instanceof AuthenticationState.ResponseSent)
                     callback.block();
@@ -321,6 +310,23 @@ public class ServletApiRequest implements HttpServletRequest
                 authenticationState = undeferred;
         }
         return authenticationState;
+    }
+
+    private HttpServletRequest getWrappedRequest()
+    {
+        HttpServletRequest httpServletRequest;
+        if (_async == null)
+        {
+            httpServletRequest = _servletContextRequest.getHttpServletRequest();
+        }
+        else
+        {
+            if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
+                httpServletRequest = asyncHttpServletRequest;
+            else
+                httpServletRequest = _servletContextRequest.getHttpServletRequest();
+        }
+        return httpServletRequest;
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -277,7 +277,8 @@ public class ServletApiRequest implements HttpServletRequest
         AuthenticationState authenticationState = getAuthenticationState();
         if (authenticationState instanceof AuthenticationState.Deferred deferred)
         {
-            AuthenticationState undeferred = deferred.authenticate(getRequest());
+            Request wrappedCoreRequest = ServletCoreRequest.wrap(_servletContextRequest.getHttpServletRequest());
+            AuthenticationState undeferred = deferred.authenticate(wrappedCoreRequest);
             if (undeferred != null)
                 authenticationState = undeferred;
         }
@@ -292,8 +293,24 @@ public class ServletApiRequest implements HttpServletRequest
             AuthenticationState undeferred;
             try (Blocker.Callback callback = Blocker.callback())
             {
-                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, false);
-                undeferred = deferred.authenticate(getRequest(), wrappedCoreResponse, callback);
+                // Find the most wrapped HttpServletRequest to use for the authentication.
+                HttpServletRequest httpServletRequest;
+                if (_async == null)
+                {
+                    httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                }
+                else
+                {
+                    if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
+                        httpServletRequest = asyncHttpServletRequest;
+                    else
+                        httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                }
+
+                boolean included = httpServletRequest.getDispatcherType() == DispatcherType.INCLUDE;
+                Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
+                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, included);
+                undeferred = deferred.authenticate(wrappedCoreRequest, wrappedCoreResponse, callback);
                 if (undeferred instanceof AuthenticationState.ResponseSent)
                     callback.block();
                 else

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextRequest.java
@@ -25,6 +25,8 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletRequestAttributeListener;
 import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpFields;
@@ -114,6 +116,8 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
     private HttpFields _trailers;
     private ManagedSession _managedSession;
     AbstractSessionManager.RequestedSession _requestedSession;
+    private ServletRequest _servletRequest;
+    private ServletResponse _servletResponse;
 
     protected ServletContextRequest(
         ServletContextHandler.ServletContextApi servletContextApi,
@@ -389,9 +393,49 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
         return _servletApiRequest;
     }
 
-    public HttpServletResponse getHttpServletResponse()
+    public ServletApiResponse getServletApiResponse()
     {
         return _response.getServletApiResponse();
+    }
+
+    public HttpServletRequest getHttpServletRequest()
+    {
+        ServletRequest servletRequest = getServletRequest();
+        if (servletRequest == null)
+            return getServletApiRequest();
+        if (!(servletRequest instanceof HttpServletRequest httpServletRequest))
+            throw new IllegalStateException("Not an HTTP request");
+        return httpServletRequest;
+    }
+
+    public HttpServletResponse getHttpServletResponse()
+    {
+        ServletResponse servletResponse = getServletResponse();
+        if (servletResponse == null)
+            return getServletApiResponse();
+        if  (!(servletResponse instanceof HttpServletResponse httpServletResponse))
+            throw new IllegalStateException("Not an HTTP response");
+        return httpServletResponse;
+    }
+
+    public ServletRequest getServletRequest()
+    {
+        return _servletRequest;
+    }
+
+    public ServletResponse getServletResponse()
+    {
+        return _servletResponse;
+    }
+
+    public void setServletRequest(ServletRequest servletRequest)
+    {
+        _servletRequest = servletRequest;
+    }
+
+    public void setServletResponse(ServletResponse servletResponse)
+    {
+        _servletResponse = servletResponse;
     }
 
     public String getServletName()

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
@@ -14,13 +14,18 @@
 package org.eclipse.jetty.ee10.servlet;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.ToIntFunction;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
@@ -28,7 +33,10 @@ import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.QuotedCSV;
+import org.eclipse.jetty.http.QuotedQualityCSV;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
@@ -71,25 +79,8 @@ public class ServletCoreRequest implements Request
         _wrapped = !(request instanceof ServletApiRequest);
         _servletContextRequest = ServletContextRequest.getServletContextRequest(_servletRequest);
         _attributes = attributes == null ? _servletContextRequest : attributes;
+        _httpFields = new HttpServletRequestHttpFields(request, _servletContextRequest.getHeaders());
 
-        // Copy the original headers to carry over the
-        // HttpCompliance and the violation listener.
-        HttpFields.Mutable fields = HttpFields.build(_servletContextRequest.getHeaders());
-        fields.clear();
-
-        Enumeration<String> headerNames = request.getHeaderNames();
-        while (headerNames.hasMoreElements())
-        {
-            String headerName = headerNames.nextElement();
-            Enumeration<String> headerValues = request.getHeaders(headerName);
-            while (headerValues.hasMoreElements())
-            {
-                String headerValue = headerValues.nextElement();
-                fields.add(new HttpField(headerName, headerValue));
-            }
-        }
-
-        _httpFields = fields.asImmutable();
         String includedServletPath = (String)request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
         boolean included = includedServletPath != null;
 
@@ -364,7 +355,9 @@ public class ServletCoreRequest implements Request
                 set = new HashSet<>();
                 Enumeration<String> e = _servletRequest.getAttributeNames();
                 while (e.hasMoreElements())
+                {
                     set.add(e.nextElement());
+                }
                 _attributeNames = set;
             }
             return set;
@@ -379,6 +372,94 @@ public class ServletCoreRequest implements Request
             {
                 _servletRequest.removeAttribute(e.nextElement());
             }
+        }
+    }
+
+    private static final class HttpServletRequestHttpFields implements HttpFields
+    {
+        private final HttpServletRequest _httpServletRequest;
+        private final List<HttpField> _fields;
+        private final HttpFields _baseHttpFields;
+
+        private HttpServletRequestHttpFields(HttpServletRequest httpServletRequest, HttpFields httpFields)
+        {
+            _httpServletRequest = httpServletRequest;
+            _baseHttpFields = httpFields;
+            _fields = new ArrayList<>();
+            Enumeration<String> headerNames = _httpServletRequest.getHeaderNames();
+            while (headerNames.hasMoreElements())
+            {
+                String name = headerNames.nextElement();
+                Enumeration<String> values = _httpServletRequest.getHeaders(name);
+                while (values.hasMoreElements())
+                {
+                    String value = values.nextElement();
+                    _fields.add(new HttpField(name, value));
+                }
+            }
+        }
+
+        @Override
+        public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+        {
+            return new QuotedQualityCSV(_baseHttpFields, secondaryOrdering);
+        }
+
+        @Override
+        public QuotedCSV newQuotedCSV(boolean keepQuotes)
+        {
+            return new QuotedCSV(_baseHttpFields, keepQuotes);
+        }
+
+        @Override
+        public HttpField getField(String name)
+        {
+            String value = _httpServletRequest.getHeader(name);
+            if (value == null)
+                return null;
+            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            return new HttpField(name, value);
+        }
+
+        @Override
+        public HttpField getField(HttpHeader header)
+        {
+            String name = header.asString();
+            String value = _httpServletRequest.getHeader(header.asString());
+            if (value == null)
+                return null;
+            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            return new HttpField(name, value);
+        }
+
+        @Override
+        public String get(String name)
+        {
+            return _httpServletRequest.getHeader(name);
+        }
+
+        @Override
+        public String getLast(HttpHeader header)
+        {
+            return HttpFields.super.getLast(header);
+        }
+
+        @Override
+        public String get(HttpHeader header)
+        {
+            return _httpServletRequest.getHeader(header.asString());
+        }
+
+        @Override
+        public HttpFields asImmutable()
+        {
+            return this;
+        }
+
+        @Override
+        public ListIterator<HttpField> listIterator(int index)
+        {
+            return Collections.unmodifiableList(_fields).listIterator(index);
         }
     }
 }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequest.java
@@ -417,7 +417,7 @@ public class ServletCoreRequest implements Request
             String value = _httpServletRequest.getHeader(name);
             if (value == null)
                 return null;
-            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            // If getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
             return new HttpField(name, value);
         }
 
@@ -428,7 +428,7 @@ public class ServletCoreRequest implements Request
             String value = _httpServletRequest.getHeader(header.asString());
             if (value == null)
                 return null;
-            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            // If getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
             return new HttpField(name, value);
         }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletCoreResponse.java
@@ -21,6 +21,7 @@ import java.util.ListIterator;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
@@ -28,6 +29,8 @@ import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
+import org.eclipse.jetty.http.QuotedCSV;
+import org.eclipse.jetty.http.QuotedQualityCSV;
 import org.eclipse.jetty.io.ByteBufferInputStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -61,7 +64,7 @@ public class ServletCoreResponse implements Response
         _httpServletResponse = httpServletResponse;
         _servletContextResponse = ServletContextResponse.getServletContextResponse(httpServletResponse);
         _wrapped = !(httpServletResponse instanceof ServletApiResponse);
-        HttpFields.Mutable fields = new HttpServletResponseHttpFields(httpServletResponse);
+        HttpFields.Mutable fields = new HttpServletResponseHttpFields(httpServletResponse, _servletContextResponse.getHeaders());
         if (included)
         {
             // If included, accept but ignore mutations.
@@ -222,16 +225,30 @@ public class ServletCoreResponse implements Response
     @Override
     public String toString()
     {
-        return "%s@%x{%s,%s}".formatted(TypeUtil.toShortName(this.getClass()), hashCode(), this._coreRequest, _httpServletResponse);
+        return "%s@%x{%s,%s}".formatted(TypeUtil.toShortName(getClass()), hashCode(), _coreRequest, _httpServletResponse);
     }
 
     private static class HttpServletResponseHttpFields implements HttpFields.Mutable
     {
-        private final HttpServletResponse _response;
+        private final HttpServletResponse _httpServletResponse;
+        private final HttpFields _baseHttpFields;
 
-        private HttpServletResponseHttpFields(HttpServletResponse response)
+        private HttpServletResponseHttpFields(HttpServletResponse response, HttpFields httpFields)
         {
-            _response = response;
+            _httpServletResponse = response;
+            _baseHttpFields = httpFields;
+        }
+
+        @Override
+        public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+        {
+            return new QuotedQualityCSV(_baseHttpFields, secondaryOrdering);
+        }
+
+        @Override
+        public QuotedCSV newQuotedCSV(boolean keepQuotes)
+        {
+            return new QuotedCSV(_baseHttpFields, keepQuotes);
         }
 
         @Override
@@ -239,8 +256,8 @@ public class ServletCoreResponse implements Response
         {
             // The minimum requirement is to implement the listIterator, but it is inefficient.
             // Other methods are implemented for efficiency.
-            final ListIterator<HttpField> list = _response.getHeaderNames().stream()
-                .map(n -> new HttpField(n, _response.getHeader(n)))
+            final ListIterator<HttpField> list = _httpServletResponse.getHeaderNames().stream()
+                .map(n -> new HttpField(n, _httpServletResponse.getHeader(n)))
                 .collect(Collectors.toList())
                 .listIterator(index);
 
@@ -291,7 +308,7 @@ public class ServletCoreResponse implements Response
                     {
                         // This is not exactly the right semantic for repeated field names
                         list.remove();
-                        _response.setHeader(_last.getName(), null);
+                        _httpServletResponse.setHeader(_last.getName(), null);
                     }
                 }
 
@@ -299,14 +316,14 @@ public class ServletCoreResponse implements Response
                 public void set(HttpField httpField)
                 {
                     list.set(httpField);
-                    _response.setHeader(httpField.getName(), httpField.getValue());
+                    _httpServletResponse.setHeader(httpField.getName(), httpField.getValue());
                 }
 
                 @Override
                 public void add(HttpField httpField)
                 {
                     list.add(httpField);
-                    _response.addHeader(httpField.getName(), httpField.getValue());
+                    _httpServletResponse.addHeader(httpField.getName(), httpField.getValue());
                 }
             };
         }
@@ -314,56 +331,56 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable add(String name, String value)
         {
-            _response.addHeader(name, value);
+            _httpServletResponse.addHeader(name, value);
             return this;
         }
 
         @Override
         public Mutable add(HttpHeader header, HttpHeaderValue value)
         {
-            _response.addHeader(header.asString(), value.asString());
+            _httpServletResponse.addHeader(header.asString(), value.asString());
             return this;
         }
 
         @Override
         public Mutable add(HttpHeader header, String value)
         {
-            _response.addHeader(header.asString(), value);
+            _httpServletResponse.addHeader(header.asString(), value);
             return this;
         }
 
         @Override
         public Mutable add(HttpField field)
         {
-            _response.addHeader(field.getName(), field.getValue());
+            _httpServletResponse.addHeader(field.getName(), field.getValue());
             return this;
         }
 
         @Override
         public Mutable put(HttpField field)
         {
-            _response.setHeader(field.getName(), field.getValue());
+            _httpServletResponse.setHeader(field.getName(), field.getValue());
             return this;
         }
 
         @Override
         public Mutable put(String name, String value)
         {
-            _response.setHeader(name, value);
+            _httpServletResponse.setHeader(name, value);
             return this;
         }
 
         @Override
         public Mutable put(HttpHeader header, HttpHeaderValue value)
         {
-            _response.setHeader(header.asString(), value.asString());
+            _httpServletResponse.setHeader(header.asString(), value.asString());
             return this;
         }
 
         @Override
         public Mutable put(HttpHeader header, String value)
         {
-            _response.setHeader(header.asString(), value);
+            _httpServletResponse.setHeader(header.asString(), value);
             return this;
         }
 
@@ -376,9 +393,9 @@ public class ServletCoreResponse implements Response
             for (String s : list)
             {
                 if (first)
-                    _response.setHeader(name, s);
+                    _httpServletResponse.setHeader(name, s);
                 else
-                    _response.addHeader(name, s);
+                    _httpServletResponse.addHeader(name, s);
                 first = false;
             }
             return this;
@@ -387,7 +404,7 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable remove(HttpHeader header)
         {
-            _response.setHeader(header.asString(), null);
+            _httpServletResponse.setHeader(header.asString(), null);
             return this;
         }
 
@@ -402,7 +419,7 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable remove(String name)
         {
-            _response.setHeader(name, null);
+            _httpServletResponse.setHeader(name, null);
             return this;
         }
     }

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletHandler.java
@@ -1591,7 +1591,20 @@ public class ServletHandler extends Handler.Wrapper
         @Override
         public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException
         {
-            _filterHolder.doFilter(request, response, _filterChain);
+            ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
+            ServletRequest oldRequest = servletContextRequest.getServletRequest();
+            ServletResponse oldResponse = servletContextRequest.getServletResponse();
+            try
+            {
+                servletContextRequest.setServletRequest(request);
+                servletContextRequest.setServletResponse(response);
+                _filterHolder.doFilter(request, response, _filterChain);
+            }
+            finally
+            {
+                servletContextRequest.setServletRequest(oldRequest);
+                servletContextRequest.setServletResponse(oldResponse);
+            }
         }
 
         @Override
@@ -1619,7 +1632,20 @@ public class ServletHandler extends Handler.Wrapper
         @Override
         public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException
         {
-            _servletHolder.handle(request, response);
+            ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
+            ServletRequest oldRequest = servletContextRequest.getServletRequest();
+            ServletResponse oldResponse = servletContextRequest.getServletResponse();
+            try
+            {
+                servletContextRequest.setServletRequest(request);
+                servletContextRequest.setServletResponse(response);
+                _servletHolder.handle(request, response);
+            }
+            finally
+            {
+                servletContextRequest.setServletRequest(oldRequest);
+                servletContextRequest.setServletResponse(oldResponse);
+            }
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequestTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ServletCoreRequestTest.java
@@ -1,0 +1,142 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class ServletCoreRequestTest
+{
+    private Server _server;
+    private LocalConnector _connector;
+    private TestViolationListener _violationListener;
+
+    public void startServer(HttpCompliance httpCompliance, HttpServlet servlet) throws Exception
+    {
+        _server = new Server();
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setHttpCompliance(httpCompliance);
+        _violationListener = new TestViolationListener();
+        httpConfiguration.addComplianceViolationListener(_violationListener);
+
+        _connector = new LocalConnector(_server, new HttpConnectionFactory(httpConfiguration));
+        _server.addConnector(_connector);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(servlet, "/");
+        _server.setHandler(context);
+
+        _server.start();
+    }
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(_server);
+    }
+
+    private static class TestViolationListener implements ComplianceViolation.Listener
+    {
+        List<ComplianceViolation.Event> events = new ArrayList<>();
+
+        @Override
+        public void onComplianceViolation(ComplianceViolation.Event event)
+        {
+            events.add(event);
+        }
+    }
+
+    public enum CsvType
+    {
+        QUOTED_CSV,
+        QUOTED_QUALITY_CSV
+    }
+
+    public static Stream<Arguments> cases()
+    {
+        return Stream.of(
+            arguments(CsvType.QUOTED_CSV),
+            arguments(CsvType.QUOTED_QUALITY_CSV)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("cases")
+    public void testHttpCompliance(CsvType csvType) throws Exception
+    {
+        // The default RFC9110 mode does not allow whitespace, however RFC7230 does.
+        String value = "token;q =0.5";
+        startServer(HttpCompliance.RFC7230, new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            {
+                // Wrap the HttpServletResponse to ServletCoreRequest to verify that
+                // the HttpCompliance and ViolationListener are transferred to the wrapped Request.
+                Request coreRequest = ServletCoreRequest.wrap(request);
+                HttpFields fields = coreRequest.getHeaders();
+                if (csvType == CsvType.QUOTED_CSV)
+                    fields.newQuotedCSV(false).addValue(value);
+                else
+                    fields.newQuotedQualityCSV(null).addValue(value);
+            }
+        });
+
+        String rawRequest = """
+            GET / HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """;
+
+        // Using RFC7230 should allow this whitespace violation and return a 200 response.
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+
+        // We should have been notified about the violation in the listener.
+        assertThat(_violationListener.events, hasSize(1));
+        ComplianceViolation.Event event = _violationListener.events.get(0);
+        assertThat(event.mode(), equalTo(HttpCompliance.RFC7230));
+        assertThat(event.violation(), equalTo(HttpCompliance.Violation.WHITESPACE_IN_PARAMETER));
+        assertThat(event.allowed(), equalTo(true));
+    }
+}

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/AuthenticateTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/AuthenticateTest.java
@@ -14,14 +14,23 @@
 package org.eclipse.jetty.ee10.servlet.security;
 
 import java.io.IOException;
+import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import jakarta.servlet.AsyncContext;
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
@@ -32,10 +41,12 @@ import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.URIUtil;
@@ -45,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class AuthenticateTest
 {
@@ -182,6 +194,251 @@ public class AuthenticateTest
         response = _connector.getResponse("GET /ctx/?username=admin&password=password HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("UserPrincipal: admin"));
+    }
+
+    private static class TestHeaderAuthenticator extends LoginAuthenticator
+    {
+        @Override
+        public String getAuthenticationType()
+        {
+            return "CUSTOM";
+        }
+
+        @Override
+        public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
+        {
+            String username = request.getHeaders().get("X-Username");
+            String password = request.getHeaders().get("X-Password");
+            if (username != null && password != null)
+            {
+                UserIdentity user = login(username, Credential.getCredential(password), request, response);
+                if (user == null)
+                {
+                    if (response.isCommitted())
+                        return null;
+                    return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+                }
+                return new UserAuthenticationSucceeded(getAuthenticationType(), user);
+            }
+
+            if (response.isCommitted())
+                return null;
+
+            return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+        }
+    }
+
+    @Test
+    public void testWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            servletContextHandler.addFilter(new HttpFilter()
+            {
+                @Override
+                protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException, ServletException
+                {
+                    String pathInContext = URIUtil.addPaths(req.getServletPath(), req.getPathInfo());
+                    if (pathInContext.startsWith("/authenticate"))
+                    {
+                        // The request is wrapped to override some headers.
+                        req = new HttpServletRequestWrapper(req)
+                        {
+                            @Override
+                            public String getHeader(String name)
+                            {
+                                if ("X-Username".equalsIgnoreCase(name))
+                                    return "admin";
+                                if ("X-Password".equalsIgnoreCase(name))
+                                    return "password";
+                                return super.getHeader(name);
+                            }
+                        };
+                    }
+                    chain.doFilter(req, res);
+                }
+            }, "/*", EnumSet.allOf(DispatcherType.class));
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    boolean authenticate = req.authenticate(resp);
+                    if (!authenticate)
+                        return;
+                    resp.getWriter().println("UserPrincipal: " + req.getUserPrincipal());
+                }
+            }, "/");
+        });
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncRunnableWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    // The request is wrapped to override some headers.
+                    HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+
+                    AsyncContext asyncContext = req.startAsync(wrappedRequest, resp);
+                    asyncContext.start(() ->
+                    {
+                        try
+                        {
+                            boolean authenticate = wrappedRequest.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + wrappedRequest.getUserPrincipal());
+                            asyncContext.complete();
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                    });
+                }
+            }, "/");
+        });
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncDispatchWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    if (req.getDispatcherType() ==  DispatcherType.ASYNC)
+                    {
+                        try
+                        {
+                            boolean authenticate = req.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + req.getUserPrincipal());
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                        return;
+                    }
+
+                    // The request is wrapped to override some headers then async dispatched.
+                    req = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    asyncContext.dispatch();
+                }
+            }, "/");
+        });
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncNewThreadWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            AtomicInteger scopeCount = new AtomicInteger();
+            servletContextHandler.addEventListener(new ContextHandler.ContextScopeListener()
+            {
+                @Override
+                public void enterScope(Context context, Request request)
+                {
+                    scopeCount.incrementAndGet();
+                }
+
+                @Override
+                public void exitScope(Context context, Request request)
+                {
+                    scopeCount.decrementAndGet();
+                }
+            });
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    // The request is wrapped to override some headers then async dispatched.
+                    HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+
+                    AsyncContext asyncContext = req.startAsync(wrappedRequest, resp);
+                    new Thread(() ->
+                    {
+                        // Await exiting the scope.
+                        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).until(() -> scopeCount.get() == 0);
+                        try
+                        {
+                            boolean authenticate = wrappedRequest.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + wrappedRequest.getUserPrincipal());
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                        finally
+                        {
+                            asyncContext.complete();
+                        }
+                    }).start();
+                }
+            }, "/");
+        });
+
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -276,7 +276,8 @@ public class ServletApiRequest implements HttpServletRequest
         AuthenticationState authenticationState = getAuthenticationState();
         if (authenticationState instanceof AuthenticationState.Deferred deferred)
         {
-            AuthenticationState undeferred = deferred.authenticate(getRequest());
+            Request wrappedCoreRequest = ServletCoreRequest.wrap(_servletContextRequest.getHttpServletRequest());
+            AuthenticationState undeferred = deferred.authenticate(wrappedCoreRequest);
             if (undeferred != null)
                 authenticationState = undeferred;
         }
@@ -291,8 +292,11 @@ public class ServletApiRequest implements HttpServletRequest
             AuthenticationState undeferred;
             try (Blocker.Callback callback = Blocker.callback())
             {
-                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, false);
-                undeferred = deferred.authenticate(getRequest(), wrappedCoreResponse, callback);
+                HttpServletRequest httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                boolean included = httpServletRequest.getDispatcherType() == DispatcherType.INCLUDE;
+                Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
+                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, included);
+                undeferred = deferred.authenticate(wrappedCoreRequest, wrappedCoreResponse, callback);
                 if (undeferred instanceof AuthenticationState.ResponseSent)
                     callback.block();
                 else

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -292,7 +292,20 @@ public class ServletApiRequest implements HttpServletRequest
             AuthenticationState undeferred;
             try (Blocker.Callback callback = Blocker.callback())
             {
-                HttpServletRequest httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                // Find the most wrapped HttpServletRequest to use for the authentication.
+                HttpServletRequest httpServletRequest;
+                if (_async == null)
+                {
+                    httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                }
+                else
+                {
+                    if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
+                        httpServletRequest = asyncHttpServletRequest;
+                    else
+                        httpServletRequest = _servletContextRequest.getHttpServletRequest();
+                }
+
                 boolean included = httpServletRequest.getDispatcherType() == DispatcherType.INCLUDE;
                 Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
                 Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, included);

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -276,7 +276,8 @@ public class ServletApiRequest implements HttpServletRequest
         AuthenticationState authenticationState = getAuthenticationState();
         if (authenticationState instanceof AuthenticationState.Deferred deferred)
         {
-            Request wrappedCoreRequest = ServletCoreRequest.wrap(_servletContextRequest.getHttpServletRequest());
+            HttpServletRequest httpServletRequest = getWrappedRequest();
+            Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
             AuthenticationState undeferred = deferred.authenticate(wrappedCoreRequest);
             if (undeferred != null)
                 authenticationState = undeferred;
@@ -292,23 +293,11 @@ public class ServletApiRequest implements HttpServletRequest
             AuthenticationState undeferred;
             try (Blocker.Callback callback = Blocker.callback())
             {
-                // Find the most wrapped HttpServletRequest to use for the authentication.
-                HttpServletRequest httpServletRequest;
-                if (_async == null)
-                {
-                    httpServletRequest = _servletContextRequest.getHttpServletRequest();
-                }
-                else
-                {
-                    if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
-                        httpServletRequest = asyncHttpServletRequest;
-                    else
-                        httpServletRequest = _servletContextRequest.getHttpServletRequest();
-                }
-
+                // Find the outermost wrapped HttpServletRequest to use for the authentication.
+                HttpServletRequest httpServletRequest = getWrappedRequest();
                 boolean included = httpServletRequest.getDispatcherType() == DispatcherType.INCLUDE;
                 Request wrappedCoreRequest = ServletCoreRequest.wrap(httpServletRequest);
-                Response wrappedCoreResponse = ServletCoreResponse.wrap(getRequest(), response, included);
+                Response wrappedCoreResponse = ServletCoreResponse.wrap(wrappedCoreRequest, response, included);
                 undeferred = deferred.authenticate(wrappedCoreRequest, wrappedCoreResponse, callback);
                 if (undeferred instanceof AuthenticationState.ResponseSent)
                     callback.block();
@@ -320,6 +309,23 @@ public class ServletApiRequest implements HttpServletRequest
                 authenticationState = undeferred;
         }
         return authenticationState;
+    }
+
+    private HttpServletRequest getWrappedRequest()
+    {
+        HttpServletRequest httpServletRequest;
+        if (_async == null)
+        {
+            httpServletRequest = _servletContextRequest.getHttpServletRequest();
+        }
+        else
+        {
+            if (_async.getRequest() instanceof HttpServletRequest asyncHttpServletRequest)
+                httpServletRequest = asyncHttpServletRequest;
+            else
+                httpServletRequest = _servletContextRequest.getHttpServletRequest();
+        }
+        return httpServletRequest;
     }
 
     @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
@@ -25,6 +25,8 @@ import jakarta.servlet.DispatcherType;
 import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletRequestAttributeListener;
 import jakarta.servlet.ServletRequestWrapper;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.http.HttpCookie;
 import org.eclipse.jetty.http.HttpFields;
@@ -78,6 +80,8 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
 
     static final Fields NO_PARAMS = new Fields(Collections.emptyMap());
     static final Fields BAD_PARAMS = new Fields(Collections.emptyMap());
+    private ServletRequest _servletRequest;
+    private ServletResponse _servletResponse;
 
     public static ServletContextRequest getServletContextRequest(ServletRequest request)
     {
@@ -390,9 +394,47 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
         return _servletApiRequest;
     }
 
-    public HttpServletResponse getHttpServletResponse()
+    public ServletApiResponse getServletApiResponse()
     {
         return _response.getServletApiResponse();
+    }
+
+    public HttpServletRequest getHttpServletRequest()
+    {
+        if (_servletRequest == null)
+            return getServletApiRequest();
+        if (!(_servletRequest instanceof HttpServletRequest httpServletRequest))
+            throw new IllegalStateException("Not an HTTP request");
+        return httpServletRequest;
+    }
+
+    public HttpServletResponse getHttpServletResponse()
+    {
+        if (_servletResponse == null)
+            return getServletApiResponse();
+        if  (!(_servletResponse instanceof HttpServletResponse httpServletResponse))
+            throw new IllegalStateException("Not an HTTP response");
+        return httpServletResponse;
+    }
+
+    public ServletRequest getServletRequest()
+    {
+        return _servletRequest;
+    }
+
+    public ServletResponse getServletResponse()
+    {
+        return _servletResponse;
+    }
+
+    public void setServletRequest(ServletRequest servletRequest)
+    {
+        _servletRequest = servletRequest;
+    }
+
+    public void setServletResponse(ServletResponse servletResponse)
+    {
+        _servletResponse = servletResponse;
     }
 
     public String getServletName()

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
@@ -401,18 +401,20 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
 
     public HttpServletRequest getHttpServletRequest()
     {
-        if (_servletRequest == null)
+        ServletRequest servletRequest = getServletRequest();
+        if (servletRequest == null)
             return getServletApiRequest();
-        if (!(_servletRequest instanceof HttpServletRequest httpServletRequest))
+        if (!(servletRequest instanceof HttpServletRequest httpServletRequest))
             throw new IllegalStateException("Not an HTTP request");
         return httpServletRequest;
     }
 
     public HttpServletResponse getHttpServletResponse()
     {
-        if (_servletResponse == null)
+        ServletResponse servletResponse = getServletResponse();
+        if (servletResponse == null)
             return getServletApiResponse();
-        if  (!(_servletResponse instanceof HttpServletResponse httpServletResponse))
+        if  (!(servletResponse instanceof HttpServletResponse httpServletResponse))
             throw new IllegalStateException("Not an HTTP response");
         return httpServletResponse;
     }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextRequest.java
@@ -80,8 +80,6 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
 
     static final Fields NO_PARAMS = new Fields(Collections.emptyMap());
     static final Fields BAD_PARAMS = new Fields(Collections.emptyMap());
-    private ServletRequest _servletRequest;
-    private ServletResponse _servletResponse;
 
     public static ServletContextRequest getServletContextRequest(ServletRequest request)
     {
@@ -118,6 +116,8 @@ public class ServletContextRequest extends ContextRequest implements ServletCont
     private HttpFields _trailers;
     private ManagedSession _managedSession;
     AbstractSessionManager.RequestedSession _requestedSession;
+    private ServletRequest _servletRequest;
+    private ServletResponse _servletResponse;
 
     protected ServletContextRequest(
         ServletContextHandler.ServletContextApi servletContextApi,

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
@@ -14,21 +14,32 @@
 package org.eclipse.jetty.ee11.servlet;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashSet;
+import java.util.List;
+import java.util.ListIterator;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletInputStream;
 import jakarta.servlet.http.HttpServletRequest;
+import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.QuotedCSV;
+import org.eclipse.jetty.http.QuotedQualityCSV;
 import org.eclipse.jetty.io.ByteBufferPool;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.RetainableByteBuffer;
@@ -71,25 +82,7 @@ public class ServletCoreRequest implements Request
         _wrapped = !(request instanceof ServletApiRequest);
         _servletContextRequest = ServletContextRequest.getServletContextRequest(_servletRequest);
         _attributes = attributes == null ? _servletContextRequest : attributes;
-
-        // Copy the original headers to carry over the
-        // HttpCompliance and the violation listener.
-        HttpFields.Mutable fields = HttpFields.build(_servletContextRequest.getHeaders());
-        fields.clear();
-
-        Enumeration<String> headerNames = request.getHeaderNames();
-        while (headerNames.hasMoreElements())
-        {
-            String headerName = headerNames.nextElement();
-            Enumeration<String> headerValues = request.getHeaders(headerName);
-            while (headerValues.hasMoreElements())
-            {
-                String headerValue = headerValues.nextElement();
-                fields.add(new HttpField(headerName, headerValue));
-            }
-        }
-
-        _httpFields = fields.asImmutable();
+        _httpFields = new HttpServletRequestHttpFields(request, _servletContextRequest.getHeaders());
         String includedServletPath = (String)request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH);
         boolean included = includedServletPath != null;
 
@@ -364,7 +357,9 @@ public class ServletCoreRequest implements Request
                 set = new HashSet<>();
                 Enumeration<String> e = _servletRequest.getAttributeNames();
                 while (e.hasMoreElements())
+                {
                     set.add(e.nextElement());
+                }
                 _attributeNames = set;
             }
             return set;
@@ -381,4 +376,91 @@ public class ServletCoreRequest implements Request
             }
         }
     }
+
+    private static final class HttpServletRequestHttpFields implements HttpFields
+        {
+            private final HttpServletRequest _httpServletRequest;
+            private final HttpCompliance _httpCompliance;
+            private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
+            private final List<HttpField> _fields;
+
+            private HttpServletRequestHttpFields(HttpServletRequest httpServletRequest, HttpFields httpFields)
+            {
+                _httpServletRequest = httpServletRequest;
+                _httpCompliance = HttpFields.copyHttpCompliance(httpFields);
+                _listenerSupplier = HttpFields.copyComplianceListener(httpFields);
+                _fields = new ArrayList<>();
+                Enumeration<String> headerNames = _httpServletRequest.getHeaderNames();
+                while (headerNames.hasMoreElements())
+                {
+                    String name = headerNames.nextElement();
+                    Enumeration<String> values = _httpServletRequest.getHeaders(name);
+                    while (values.hasMoreElements())
+                    {
+                        _fields.add(new HttpField(name, values.nextElement()));
+                    }
+                }
+            }
+
+            @Override
+            public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+            {
+                return new QuotedQualityCSV(_httpCompliance, _listenerSupplier.get(), secondaryOrdering);
+            }
+
+            @Override
+            public QuotedCSV newQuotedCSV(boolean b)
+            {
+                return new QuotedCSV(_httpCompliance, _listenerSupplier.get(), b);
+            }
+
+            @Override
+            public HttpField getField(String name)
+            {
+                String value = _httpServletRequest.getHeader(name);
+                if (value == null)
+                    return null;
+                return new HttpField(name, value);
+            }
+
+            @Override
+            public HttpField getField(HttpHeader header)
+            {
+                String name = header.asString();
+                String value = _httpServletRequest.getHeader(header.asString());
+                if (value == null)
+                    return null;
+                return new HttpField(name, value);
+            }
+
+            @Override
+            public String get(String name)
+            {
+                return _httpServletRequest.getHeader(name);
+            }
+
+            @Override
+            public String getLast(HttpHeader header)
+            {
+                return HttpFields.super.getLast(header);
+            }
+
+            @Override
+            public String get(HttpHeader header)
+            {
+                return _httpServletRequest.getHeader(header.asString());
+            }
+
+            @Override
+            public HttpFields asImmutable()
+            {
+                return this;
+            }
+
+            @Override
+            public ListIterator<HttpField> listIterator(int index)
+            {
+                return Collections.unmodifiableList(_fields).listIterator(index);
+            }
+        }
 }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
@@ -406,9 +406,9 @@ public class ServletCoreRequest implements Request
         }
 
         @Override
-        public QuotedCSV newQuotedCSV(boolean b)
+        public QuotedCSV newQuotedCSV(boolean keepQuotes)
         {
-            return new QuotedCSV(_baseHttpFields, b);
+            return new QuotedCSV(_baseHttpFields, keepQuotes);
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
@@ -417,7 +417,7 @@ public class ServletCoreRequest implements Request
             String value = _httpServletRequest.getHeader(name);
             if (value == null)
                 return null;
-            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            // If getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
             return new HttpField(name, value);
         }
 
@@ -428,7 +428,7 @@ public class ServletCoreRequest implements Request
             String value = _httpServletRequest.getHeader(header.asString());
             if (value == null)
                 return null;
-            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            // If getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
             return new HttpField(name, value);
         }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequest.java
@@ -25,15 +25,13 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.function.Supplier;
 import java.util.function.ToIntFunction;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.ServletRequest;
 import jakarta.servlet.http.HttpServletRequest;
-import org.eclipse.jetty.http.ComplianceViolation;
-import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -59,7 +57,7 @@ import static org.eclipse.jetty.util.URIUtil.addEncodedPaths;
 import static org.eclipse.jetty.util.URIUtil.encodePath;
 
 /**
- * Wraps a {@link jakarta.servlet.ServletRequest} as a core {@link Request}.
+ * Wraps a {@link ServletRequest} as a core {@link Request}.
  */
 public class ServletCoreRequest implements Request
 {
@@ -378,89 +376,90 @@ public class ServletCoreRequest implements Request
     }
 
     private static final class HttpServletRequestHttpFields implements HttpFields
-        {
-            private final HttpServletRequest _httpServletRequest;
-            private final HttpCompliance _httpCompliance;
-            private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
-            private final List<HttpField> _fields;
+    {
+        private final HttpServletRequest _httpServletRequest;
+        private final List<HttpField> _fields;
+        private final HttpFields _baseHttpFields;
 
-            private HttpServletRequestHttpFields(HttpServletRequest httpServletRequest, HttpFields httpFields)
+        private HttpServletRequestHttpFields(HttpServletRequest httpServletRequest, HttpFields httpFields)
+        {
+            _httpServletRequest = httpServletRequest;
+            _baseHttpFields = httpFields;
+            _fields = new ArrayList<>();
+            Enumeration<String> headerNames = _httpServletRequest.getHeaderNames();
+            while (headerNames.hasMoreElements())
             {
-                _httpServletRequest = httpServletRequest;
-                _httpCompliance = HttpFields.copyHttpCompliance(httpFields);
-                _listenerSupplier = HttpFields.copyComplianceListener(httpFields);
-                _fields = new ArrayList<>();
-                Enumeration<String> headerNames = _httpServletRequest.getHeaderNames();
-                while (headerNames.hasMoreElements())
+                String name = headerNames.nextElement();
+                Enumeration<String> values = _httpServletRequest.getHeaders(name);
+                while (values.hasMoreElements())
                 {
-                    String name = headerNames.nextElement();
-                    Enumeration<String> values = _httpServletRequest.getHeaders(name);
-                    while (values.hasMoreElements())
-                    {
-                        _fields.add(new HttpField(name, values.nextElement()));
-                    }
+                    String value = values.nextElement();
+                    _fields.add(new HttpField(name, value));
                 }
             }
-
-            @Override
-            public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
-            {
-                return new QuotedQualityCSV(_httpCompliance, _listenerSupplier.get(), secondaryOrdering);
-            }
-
-            @Override
-            public QuotedCSV newQuotedCSV(boolean b)
-            {
-                return new QuotedCSV(_httpCompliance, _listenerSupplier.get(), b);
-            }
-
-            @Override
-            public HttpField getField(String name)
-            {
-                String value = _httpServletRequest.getHeader(name);
-                if (value == null)
-                    return null;
-                return new HttpField(name, value);
-            }
-
-            @Override
-            public HttpField getField(HttpHeader header)
-            {
-                String name = header.asString();
-                String value = _httpServletRequest.getHeader(header.asString());
-                if (value == null)
-                    return null;
-                return new HttpField(name, value);
-            }
-
-            @Override
-            public String get(String name)
-            {
-                return _httpServletRequest.getHeader(name);
-            }
-
-            @Override
-            public String getLast(HttpHeader header)
-            {
-                return HttpFields.super.getLast(header);
-            }
-
-            @Override
-            public String get(HttpHeader header)
-            {
-                return _httpServletRequest.getHeader(header.asString());
-            }
-
-            @Override
-            public HttpFields asImmutable()
-            {
-                return this;
-            }
-
-            @Override
-            public ListIterator<HttpField> listIterator(int index)
-            {
-                return Collections.unmodifiableList(_fields).listIterator(index);
-            }
         }
+
+        @Override
+        public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+        {
+            return new QuotedQualityCSV(_baseHttpFields, secondaryOrdering);
+        }
+
+        @Override
+        public QuotedCSV newQuotedCSV(boolean b)
+        {
+            return new QuotedCSV(_baseHttpFields, b);
+        }
+
+        @Override
+        public HttpField getField(String name)
+        {
+            String value = _httpServletRequest.getHeader(name);
+            if (value == null)
+                return null;
+            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            return new HttpField(name, value);
+        }
+
+        @Override
+        public HttpField getField(HttpHeader header)
+        {
+            String name = header.asString();
+            String value = _httpServletRequest.getHeader(header.asString());
+            if (value == null)
+                return null;
+            // If if getHeader() was overridden without also getHeaderNames() then _fields may not have the correct header value.
+            return new HttpField(name, value);
+        }
+
+        @Override
+        public String get(String name)
+        {
+            return _httpServletRequest.getHeader(name);
+        }
+
+        @Override
+        public String getLast(HttpHeader header)
+        {
+            return HttpFields.super.getLast(header);
+        }
+
+        @Override
+        public String get(HttpHeader header)
+        {
+            return _httpServletRequest.getHeader(header.asString());
+        }
+
+        @Override
+        public HttpFields asImmutable()
+        {
+            return this;
+        }
+
+        @Override
+        public ListIterator<HttpField> listIterator(int index)
+        {
+            return Collections.unmodifiableList(_fields).listIterator(index);
+        }
+    }
 }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
@@ -25,8 +25,6 @@ import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
-import org.eclipse.jetty.http.ComplianceViolation;
-import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
@@ -233,26 +231,24 @@ public class ServletCoreResponse implements Response
     private static class HttpServletResponseHttpFields implements HttpFields.Mutable
     {
         private final HttpServletResponse _httpServletResponse;
-        private final HttpCompliance _httpCompliance;
-        private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
+        private final HttpFields _baseHttpFields;
 
         private HttpServletResponseHttpFields(HttpServletResponse response, HttpFields httpFields)
         {
             _httpServletResponse = response;
-            _httpCompliance = HttpFields.copyHttpCompliance(httpFields);
-            _listenerSupplier = HttpFields.copyComplianceListener(httpFields);
+            _baseHttpFields = httpFields;
         }
 
         @Override
         public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
         {
-            return new QuotedQualityCSV(_httpCompliance, _listenerSupplier.get(), secondaryOrdering);
+            return new QuotedQualityCSV(_baseHttpFields, secondaryOrdering);
         }
 
         @Override
         public QuotedCSV newQuotedCSV(boolean b)
         {
-            return new QuotedCSV(_httpCompliance, _listenerSupplier.get(), b);
+            return new QuotedCSV(_baseHttpFields, b);
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
@@ -246,9 +246,9 @@ public class ServletCoreResponse implements Response
         }
 
         @Override
-        public QuotedCSV newQuotedCSV(boolean b)
+        public QuotedCSV newQuotedCSV(boolean keepQuotes)
         {
-            return new QuotedCSV(_baseHttpFields, b);
+            return new QuotedCSV(_baseHttpFields, keepQuotes);
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletCoreResponse.java
@@ -21,13 +21,18 @@ import java.util.ListIterator;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
+import java.util.function.ToIntFunction;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpCompliance;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpHeaderValue;
+import org.eclipse.jetty.http.QuotedCSV;
+import org.eclipse.jetty.http.QuotedQualityCSV;
 import org.eclipse.jetty.io.ByteBufferInputStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
@@ -61,7 +66,7 @@ public class ServletCoreResponse implements Response
         _httpServletResponse = httpServletResponse;
         _servletContextResponse = ServletContextResponse.getServletContextResponse(httpServletResponse);
         _wrapped = !(httpServletResponse instanceof ServletApiResponse);
-        HttpFields.Mutable fields = new HttpServletResponseHttpFields(httpServletResponse);
+        HttpFields.Mutable fields = new HttpServletResponseHttpFields(httpServletResponse, _servletContextResponse.getHeaders());
         if (included)
         {
             // If included, accept but ignore mutations.
@@ -222,16 +227,32 @@ public class ServletCoreResponse implements Response
     @Override
     public String toString()
     {
-        return "%s@%x{%s,%s}".formatted(TypeUtil.toShortName(this.getClass()), hashCode(), this._coreRequest, _httpServletResponse);
+        return "%s@%x{%s,%s}".formatted(TypeUtil.toShortName(this.getClass()), hashCode(), _coreRequest, _httpServletResponse);
     }
 
     private static class HttpServletResponseHttpFields implements HttpFields.Mutable
     {
-        private final HttpServletResponse _response;
+        private final HttpServletResponse _httpServletResponse;
+        private final HttpCompliance _httpCompliance;
+        private final Supplier<ComplianceViolation.Listener> _listenerSupplier;
 
-        private HttpServletResponseHttpFields(HttpServletResponse response)
+        private HttpServletResponseHttpFields(HttpServletResponse response, HttpFields httpFields)
         {
-            _response = response;
+            _httpServletResponse = response;
+            _httpCompliance = HttpFields.copyHttpCompliance(httpFields);
+            _listenerSupplier = HttpFields.copyComplianceListener(httpFields);
+        }
+
+        @Override
+        public QuotedQualityCSV newQuotedQualityCSV(ToIntFunction<String> secondaryOrdering)
+        {
+            return new QuotedQualityCSV(_httpCompliance, _listenerSupplier.get(), secondaryOrdering);
+        }
+
+        @Override
+        public QuotedCSV newQuotedCSV(boolean b)
+        {
+            return new QuotedCSV(_httpCompliance, _listenerSupplier.get(), b);
         }
 
         @Override
@@ -239,8 +260,8 @@ public class ServletCoreResponse implements Response
         {
             // The minimum requirement is to implement the listIterator, but it is inefficient.
             // Other methods are implemented for efficiency.
-            final ListIterator<HttpField> list = _response.getHeaderNames().stream()
-                .map(n -> new HttpField(n, _response.getHeader(n)))
+            final ListIterator<HttpField> list = _httpServletResponse.getHeaderNames().stream()
+                .map(n -> new HttpField(n, _httpServletResponse.getHeader(n)))
                 .collect(Collectors.toList())
                 .listIterator(index);
 
@@ -291,7 +312,7 @@ public class ServletCoreResponse implements Response
                     {
                         // This is not exactly the right semantic for repeated field names
                         list.remove();
-                        _response.setHeader(_last.getName(), null);
+                        _httpServletResponse.setHeader(_last.getName(), null);
                     }
                 }
 
@@ -299,14 +320,14 @@ public class ServletCoreResponse implements Response
                 public void set(HttpField httpField)
                 {
                     list.set(httpField);
-                    _response.setHeader(httpField.getName(), httpField.getValue());
+                    _httpServletResponse.setHeader(httpField.getName(), httpField.getValue());
                 }
 
                 @Override
                 public void add(HttpField httpField)
                 {
                     list.add(httpField);
-                    _response.addHeader(httpField.getName(), httpField.getValue());
+                    _httpServletResponse.addHeader(httpField.getName(), httpField.getValue());
                 }
             };
         }
@@ -314,56 +335,56 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable add(String name, String value)
         {
-            _response.addHeader(name, value);
+            _httpServletResponse.addHeader(name, value);
             return this;
         }
 
         @Override
         public Mutable add(HttpHeader header, HttpHeaderValue value)
         {
-            _response.addHeader(header.asString(), value.asString());
+            _httpServletResponse.addHeader(header.asString(), value.asString());
             return this;
         }
 
         @Override
         public Mutable add(HttpHeader header, String value)
         {
-            _response.addHeader(header.asString(), value);
+            _httpServletResponse.addHeader(header.asString(), value);
             return this;
         }
 
         @Override
         public Mutable add(HttpField field)
         {
-            _response.addHeader(field.getName(), field.getValue());
+            _httpServletResponse.addHeader(field.getName(), field.getValue());
             return this;
         }
 
         @Override
         public Mutable put(HttpField field)
         {
-            _response.setHeader(field.getName(), field.getValue());
+            _httpServletResponse.setHeader(field.getName(), field.getValue());
             return this;
         }
 
         @Override
         public Mutable put(String name, String value)
         {
-            _response.setHeader(name, value);
+            _httpServletResponse.setHeader(name, value);
             return this;
         }
 
         @Override
         public Mutable put(HttpHeader header, HttpHeaderValue value)
         {
-            _response.setHeader(header.asString(), value.asString());
+            _httpServletResponse.setHeader(header.asString(), value.asString());
             return this;
         }
 
         @Override
         public Mutable put(HttpHeader header, String value)
         {
-            _response.setHeader(header.asString(), value);
+            _httpServletResponse.setHeader(header.asString(), value);
             return this;
         }
 
@@ -376,9 +397,9 @@ public class ServletCoreResponse implements Response
             for (String s : list)
             {
                 if (first)
-                    _response.setHeader(name, s);
+                    _httpServletResponse.setHeader(name, s);
                 else
-                    _response.addHeader(name, s);
+                    _httpServletResponse.addHeader(name, s);
                 first = false;
             }
             return this;
@@ -387,7 +408,7 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable remove(HttpHeader header)
         {
-            _response.setHeader(header.asString(), null);
+            _httpServletResponse.setHeader(header.asString(), null);
             return this;
         }
 
@@ -402,7 +423,7 @@ public class ServletCoreResponse implements Response
         @Override
         public Mutable remove(String name)
         {
-            _response.setHeader(name, null);
+            _httpServletResponse.setHeader(name, null);
             return this;
         }
     }

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletHandler.java
@@ -1637,7 +1637,20 @@ public class ServletHandler extends Handler.Wrapper
         @Override
         public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException
         {
-            _filterHolder.doFilter(request, response, _filterChain);
+            ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
+            ServletRequest oldRequest = servletContextRequest.getServletRequest();
+            ServletResponse oldResponse = servletContextRequest.getServletResponse();
+            try
+            {
+                servletContextRequest.setServletRequest(request);
+                servletContextRequest.setServletResponse(response);
+                _filterHolder.doFilter(request, response, _filterChain);
+            }
+            finally
+            {
+                servletContextRequest.setServletRequest(oldRequest);
+                servletContextRequest.setServletResponse(oldResponse);
+            }
         }
 
         @Override
@@ -1665,7 +1678,20 @@ public class ServletHandler extends Handler.Wrapper
         @Override
         public void doFilter(ServletRequest request, ServletResponse response) throws IOException, ServletException
         {
-            _servletHolder.handle(request, response);
+            ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
+            ServletRequest oldRequest = servletContextRequest.getServletRequest();
+            ServletResponse oldResponse = servletContextRequest.getServletResponse();
+            try
+            {
+                servletContextRequest.setServletRequest(request);
+                servletContextRequest.setServletResponse(response);
+                _servletHolder.handle(request, response);
+            }
+            finally
+            {
+                servletContextRequest.setServletRequest(oldRequest);
+                servletContextRequest.setServletResponse(oldResponse);
+            }
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequestTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ServletCoreRequestTest.java
@@ -1,0 +1,142 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.ComplianceViolation;
+import org.eclipse.jetty.http.HttpCompliance;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+public class ServletCoreRequestTest
+{
+    private Server _server;
+    private LocalConnector _connector;
+    private TestViolationListener _violationListener;
+
+    public void startServer(HttpCompliance httpCompliance, HttpServlet servlet) throws Exception
+    {
+        _server = new Server();
+
+        HttpConfiguration httpConfiguration = new HttpConfiguration();
+        httpConfiguration.setHttpCompliance(httpCompliance);
+        _violationListener = new TestViolationListener();
+        httpConfiguration.addComplianceViolationListener(_violationListener);
+
+        _connector = new LocalConnector(_server, new HttpConnectionFactory(httpConfiguration));
+        _server.addConnector(_connector);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(servlet, "/");
+        _server.setHandler(context);
+
+        _server.start();
+    }
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(_server);
+    }
+
+    private static class TestViolationListener implements ComplianceViolation.Listener
+    {
+        List<ComplianceViolation.Event> events = new ArrayList<>();
+
+        @Override
+        public void onComplianceViolation(ComplianceViolation.Event event)
+        {
+            events.add(event);
+        }
+    }
+
+    public enum CsvType
+    {
+        QUOTED_CSV,
+        QUOTED_QUALITY_CSV
+    }
+
+    public static Stream<Arguments> cases()
+    {
+        return Stream.of(
+            arguments(CsvType.QUOTED_CSV),
+            arguments(CsvType.QUOTED_QUALITY_CSV)
+        );
+    }
+
+    @ParameterizedTest()
+    @MethodSource("cases")
+    public void testHttpCompliance(CsvType csvType) throws Exception
+    {
+        // The default RFC9110 mode does not allow whitespace, however RFC7230 does.
+        String value = "token;q =0.5";
+        startServer(HttpCompliance.RFC7230, new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response)
+            {
+                // Wrap the HttpServletResponse to ServletCoreRequest to verify that
+                // the HttpCompliance and ViolationListener are transferred to the wrapped Request.
+                Request coreRequest = ServletCoreRequest.wrap(request);
+                HttpFields fields = coreRequest.getHeaders();
+                if (csvType == CsvType.QUOTED_CSV)
+                    fields.newQuotedCSV(false).addValue(value);
+                else
+                    fields.newQuotedQualityCSV(null).addValue(value);
+            }
+        });
+
+        String rawRequest = """
+            GET / HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """;
+
+        // Using RFC7230 should allow this whitespace violation and return a 200 response.
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse(rawRequest));
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+
+        // We should have been notified about the violation in the listener.
+        assertThat(_violationListener.events, hasSize(1));
+        ComplianceViolation.Event event = _violationListener.events.get(0);
+        assertThat(event.mode(), equalTo(HttpCompliance.RFC7230));
+        assertThat(event.violation(), equalTo(HttpCompliance.Violation.WHITESPACE_IN_PARAMETER));
+        assertThat(event.allowed(), equalTo(true));
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
@@ -30,6 +30,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.HttpURI;
 import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
@@ -55,6 +56,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class AuthenticateTest
 {
@@ -268,11 +270,10 @@ public class AuthenticateTest
                 }
             }, "/");
         });
-        String response;
 
-        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString("UserPrincipal: admin"));
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
     }
 
     @Test
@@ -317,11 +318,10 @@ public class AuthenticateTest
                 }
             }, "/");
         });
-        String response;
 
-        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString("UserPrincipal: admin"));
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
     }
 
     @Test
@@ -367,11 +367,10 @@ public class AuthenticateTest
                 }
             }, "/");
         });
-        String response;
 
-        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString("UserPrincipal: admin"));
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
@@ -14,11 +14,16 @@
 package org.eclipse.jetty.ee11.servlet.security;
 
 import java.io.IOException;
+import java.util.EnumSet;
 import java.util.function.Consumer;
 
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.HttpStatus;
@@ -180,6 +185,85 @@ public class AuthenticateTest
 
         // If we have correct credentials we will be able to get a valid user principal.
         response = _connector.getResponse("GET /ctx/?username=admin&password=password HTTP/1.0\r\n\r\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testWrappedRequest() throws Exception
+    {
+        configureServer(new LoginAuthenticator()
+        {
+            @Override
+            public String getAuthenticationType()
+            {
+                return "CUSTOM";
+            }
+
+            @Override
+            public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
+            {
+                String username = request.getHeaders().get("X-Username");
+                String password = request.getHeaders().get("X-Password");
+                if (username != null && password != null)
+                {
+                    UserIdentity user = login(username, Credential.getCredential(password), request, response);
+                    if (user == null)
+                    {
+                        if (response.isCommitted())
+                            return null;
+                        return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+                    }
+                    return new UserAuthenticationSucceeded(getAuthenticationType(), user);
+                }
+
+                if (response.isCommitted())
+                    return null;
+
+                return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+            }
+        }, servletContextHandler ->
+        {
+            servletContextHandler.addFilter(new HttpFilter()
+            {
+                @Override
+                protected void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException, ServletException
+                {
+                    String pathInContext = URIUtil.addPaths(req.getServletPath(), req.getPathInfo());
+                    if (pathInContext.startsWith("/authenticate"))
+                    {
+                        // The request is wrapped to override some headers.
+                        req = new HttpServletRequestWrapper(req)
+                        {
+                            @Override
+                            public String getHeader(String name)
+                            {
+                                if ("X-Username".equalsIgnoreCase(name))
+                                    return "admin";
+                                if ("X-Password".equalsIgnoreCase(name))
+                                    return "password";
+                                return super.getHeader(name);
+                            }
+                        };
+                    }
+                    chain.doFilter(req, res);
+                }
+            }, "/*", EnumSet.allOf(DispatcherType.class));
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    boolean authenticate = req.authenticate(resp);
+                    if (!authenticate)
+                        return;
+                    resp.getWriter().println("UserPrincipal: " + req.getUserPrincipal());
+                }
+            }, "/");
+        });
+        String response;
+
+        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("UserPrincipal: admin"));
     }

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
@@ -435,11 +435,10 @@ public class AuthenticateTest
                 }
             }, "/");
         });
-        String response;
 
-        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
-        assertThat(response, containsString("HTTP/1.1 200 OK"));
-        assertThat(response, containsString("UserPrincipal: admin"));
+        HttpTester.Response response = HttpTester.parseResponse(_connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n"));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.getContent(), containsString("UserPrincipal: admin"));
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/AuthenticateTest.java
@@ -15,8 +15,10 @@ package org.eclipse.jetty.ee11.servlet.security;
 
 import java.io.IOException;
 import java.util.EnumSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
+import jakarta.servlet.AsyncContext;
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -25,6 +27,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletRequestWrapper;
 import jakarta.servlet.http.HttpServletResponse;
+import org.awaitility.Awaitility;
 import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpURI;
@@ -37,10 +40,12 @@ import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.security.UserStore;
 import org.eclipse.jetty.security.authentication.BasicAuthenticator;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.URIUtil;
@@ -189,40 +194,42 @@ public class AuthenticateTest
         assertThat(response, containsString("UserPrincipal: admin"));
     }
 
+    private static class TestHeaderAuthenticator extends LoginAuthenticator
+    {
+        @Override
+        public String getAuthenticationType()
+        {
+            return "CUSTOM";
+        }
+
+        @Override
+        public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
+        {
+            String username = request.getHeaders().get("X-Username");
+            String password = request.getHeaders().get("X-Password");
+            if (username != null && password != null)
+            {
+                UserIdentity user = login(username, Credential.getCredential(password), request, response);
+                if (user == null)
+                {
+                    if (response.isCommitted())
+                        return null;
+                    return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+                }
+                return new UserAuthenticationSucceeded(getAuthenticationType(), user);
+            }
+
+            if (response.isCommitted())
+                return null;
+
+            return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
+        }
+    }
+
     @Test
     public void testWrappedRequest() throws Exception
     {
-        configureServer(new LoginAuthenticator()
-        {
-            @Override
-            public String getAuthenticationType()
-            {
-                return "CUSTOM";
-            }
-
-            @Override
-            public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
-            {
-                String username = request.getHeaders().get("X-Username");
-                String password = request.getHeaders().get("X-Password");
-                if (username != null && password != null)
-                {
-                    UserIdentity user = login(username, Credential.getCredential(password), request, response);
-                    if (user == null)
-                    {
-                        if (response.isCommitted())
-                            return null;
-                        return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
-                    }
-                    return new UserAuthenticationSucceeded(getAuthenticationType(), user);
-                }
-
-                if (response.isCommitted())
-                    return null;
-
-                return AuthenticationState.writeError(request, response, callback, HttpStatus.FORBIDDEN_403);
-            }
-        }, servletContextHandler ->
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
         {
             servletContextHandler.addFilter(new HttpFilter()
             {
@@ -258,6 +265,174 @@ public class AuthenticateTest
                     if (!authenticate)
                         return;
                     resp.getWriter().println("UserPrincipal: " + req.getUserPrincipal());
+                }
+            }, "/");
+        });
+        String response;
+
+        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncRunnableWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    // The request is wrapped to override some headers.
+                    HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+
+                    AsyncContext asyncContext = req.startAsync(wrappedRequest, resp);
+                    asyncContext.start(() ->
+                    {
+                        try
+                        {
+                            boolean authenticate = wrappedRequest.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + wrappedRequest.getUserPrincipal());
+                            asyncContext.complete();
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                    });
+                }
+            }, "/");
+        });
+        String response;
+
+        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncDispatchWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    if (req.getDispatcherType() ==  DispatcherType.ASYNC)
+                    {
+                        try
+                        {
+                            boolean authenticate = req.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + req.getUserPrincipal());
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                        return;
+                    }
+
+                    // The request is wrapped to override some headers then async dispatched.
+                    req = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+                    AsyncContext asyncContext = req.startAsync(req, resp);
+                    asyncContext.dispatch();
+                }
+            }, "/");
+        });
+        String response;
+
+        response = _connector.getResponse("GET /ctx/authenticate HTTP/1.0\r\n\r\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("UserPrincipal: admin"));
+    }
+
+    @Test
+    public void testAsyncNewThreadWrappedRequest() throws Exception
+    {
+        configureServer(new TestHeaderAuthenticator(), servletContextHandler ->
+        {
+            AtomicInteger scopeCount = new AtomicInteger();
+            servletContextHandler.addEventListener(new ContextHandler.ContextScopeListener()
+            {
+                @Override
+                public void enterScope(Context context, Request request)
+                {
+                    scopeCount.incrementAndGet();
+                }
+
+                @Override
+                public void exitScope(Context context, Request request)
+                {
+                    scopeCount.decrementAndGet();
+                }
+            });
+            servletContextHandler.addServlet(new HttpServlet()
+            {
+                @Override
+                protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException, ServletException
+                {
+                    // The request is wrapped to override some headers then async dispatched.
+                    HttpServletRequest wrappedRequest = new HttpServletRequestWrapper(req)
+                    {
+                        @Override
+                        public String getHeader(String name)
+                        {
+                            if ("X-Username".equalsIgnoreCase(name))
+                                return "admin";
+                            if ("X-Password".equalsIgnoreCase(name))
+                                return "password";
+                            return super.getHeader(name);
+                        }
+                    };
+
+                    AsyncContext asyncContext = req.startAsync(wrappedRequest, resp);
+                    new Thread(() ->
+                    {
+                        // Await exiting the scope.
+                        Awaitility.await().atMost(5, java.util.concurrent.TimeUnit.SECONDS).until(() -> scopeCount.get() == 0);
+                        try
+                        {
+                            boolean authenticate = wrappedRequest.authenticate(resp);
+                            if (authenticate)
+                                resp.getWriter().println("UserPrincipal: " + wrappedRequest.getUserPrincipal());
+                        }
+                        catch (Throwable t)
+                        {
+                            throw new RuntimeException(t);
+                        }
+                        finally
+                        {
+                            asyncContext.complete();
+                        }
+                    }).start();
                 }
             }, "/");
         });


### PR DESCRIPTION
## Closes #15156

If `HttpServletRequest.authenticate()` is called, it wraps the `HttpServletRequest` as a jetty-core `Request` to pass it through to the `Authenticator`.

However since the implementation of this is on `ServletApiRequest` it doesn't know about the wrappers on top of it, so it loses any custom headers which were added/modified through the wrapping of the `HttpServletRequest`.

This PR aims to ensure that the wrapped `HttpServletRequest` at the time of calling `request.authenticate()` is used instead of the base `ServletApiRequest`.