### PR TITLE
Issue #15234 - Review error response codes from EagerContentHandler and FormFields

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -18,9 +18,12 @@ import java.nio.charset.CharacterCodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.io.Content;
 import org.eclipse.jetty.io.content.ContentSourceCompletableFuture;
@@ -136,12 +139,8 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static Fields getFields(Request request, int maxFields, int maxLength)
     {
-        if (maxFields < 0)
-            maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        if (maxLength < 0)
-            maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         Charset charset = getFormEncodedCharset(request);
-        return from(request, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength).join();
+        return join(from(request, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength));
     }
 
     /**
@@ -163,14 +162,59 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @see #onFields(Request, Promise.Invocable)
      * @see #onFields(Request, Charset, Promise.Invocable)
      * @see #getFields(Request)
+     * @deprecated use {@link #getFields(Content.Source, Request, Charset, int, int)} instead.
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     public static Fields getFields(Content.Source source, Attributes attributes, Charset charset, int maxFields, int maxLength)
     {
-        if (maxFields < 0)
-            maxFields = FormFields.MAX_FIELDS_DEFAULT;
-        if (maxLength < 0)
-            maxLength = FormFields.MAX_FIELDS_DEFAULT;
-        return from(source, InvocationType.NON_BLOCKING, attributes, charset, maxFields, maxLength).join();
+        if (attributes instanceof Request request)
+            return join(from(source, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength));
+        else
+            return join(from(source, InvocationType.NON_BLOCKING, attributes, null, charset, maxFields, maxLength));
+    }
+
+    /**
+     * Get the Fields from a request. If the Fields have not been set, then attempt to parse them
+     * from the Request content, blocking if necessary.   If the Fields have previously been read asynchronously
+     * by {@link #onFields(Request, Promise.Invocable)} or similar, then those field will return
+     * and this method will not block.
+     * <p>
+     * Calls to {@code onFields} and {@code getFields} methods are idempotent, and
+     * can be called multiple times, with subsequent calls returning the results of the first call.
+     * @param source The {@link Content.Source} from which to read the fields.
+     * @param request The {@link Request} in which to look for an existing {@link CompletableFuture} of
+     *                   {@link FormFields}, using the classname as the attribute name.  If not found the attribute
+     *                   is set with the created {@link CompletableFuture} of {@link FormFields}.
+     * @param charset the {@link Charset} to use for byte to string conversion.
+     * @param maxFields The maximum number of fields to accept or -1 for a default.
+     * @param maxLength The maximum length of fields or -1 for a default.
+     * @return the Fields
+     * @see #onFields(Request, Promise.Invocable)
+     * @see #onFields(Request, Charset, Promise.Invocable)
+     * @see #getFields(Request)
+     */
+    public static Fields getFields(Content.Source source, Request request, Charset charset, int maxFields, int maxLength)
+    {
+        return join(from(source, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength));
+    }
+
+    private static Fields join(CompletableFuture<Fields> fields)
+    {
+        try
+        {
+            return fields.join();
+        }
+        catch (CompletionException e)
+        {
+            Throwable cause = e.getCause();
+            if (cause instanceof RuntimeException runtimeException)
+                throw runtimeException;
+            if (cause instanceof Error error)
+                throw error;
+            if (cause instanceof HttpException httpException)
+                throw new HttpException.RuntimeException(httpException.getCode(), httpException.getReason(), cause);
+            throw e;
+        }
     }
 
     /**
@@ -219,10 +263,6 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      */
     public static void onFields(Request request, Charset charset, int maxFields, int maxLength, Promise.Invocable<Fields> promise)
     {
-        if (maxFields < 0)
-            maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        if (maxLength < 0)
-            maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         from(request, promise.getInvocationType(), request, charset, maxFields, maxLength).whenComplete(Promise.Invocable.toBiConsumer(promise));
     }
 
@@ -302,11 +342,25 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     @Deprecated(forRemoval = true, since = "12.0.15")
     public static CompletableFuture<Fields> from(Request request, Charset charset, int maxFields, int maxLength)
     {
-        if (maxFields < 0)
-            maxFields = getContextAttribute(request.getContext(), FormFields.MAX_FIELDS_ATTRIBUTE, FormFields.MAX_FIELDS_DEFAULT);
-        if (maxLength < 0)
-            maxLength = getContextAttribute(request.getContext(), FormFields.MAX_LENGTH_ATTRIBUTE, FormFields.MAX_LENGTH_DEFAULT);
         return from(request, InvocationType.NON_BLOCKING, request, charset, maxFields, maxLength);
+    }
+
+    /**
+     * Find or create a {@link FormFields} from a {@link Content.Source}.
+     * @param source The {@link Content.Source} from which to read the fields.
+     * @param invocationType The invocation type to use for demand callbacks
+     * @param request The {@link Request} in which to look for an existing {@link CompletableFuture} of
+     *                   {@link FormFields}, using the classname as the attribute name.  If not found the attribute
+     *                   is set with the created {@link CompletableFuture} of {@link FormFields}.
+     *                   And is used to look for default values for maxFields and maxLength.
+     * @param charset the {@link Charset} to use for byte to string conversion.
+     * @param maxFields The maximum number of fields to be parsed or -1 for a default.
+     * @param maxLength The maximum total size of the fields or -1 for a default.
+     * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
+     */
+    static CompletableFuture<Fields> from(Content.Source source, InvocationType invocationType, Request request, Charset charset, int maxFields, int maxLength)
+    {
+        return from(source, invocationType, request, request, charset, maxFields, maxLength);
     }
 
     /**
@@ -316,13 +370,19 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
      * @param attributes The {@link Attributes} in which to look for an existing {@link CompletableFuture} of
      *                   {@link FormFields}, using the classname as the attribute name.  If not found the attribute
      *                   is set with the created {@link CompletableFuture} of {@link FormFields}.
+     * @param request The {@link Request} in which to look for default values for maxFields and maxLength.
      * @param charset the {@link Charset} to use for byte to string conversion.
-     * @param maxFields The maximum number of fields to be parsed or -1 for unlimited.
-     * @param maxLength The maximum total size of the fields or -1 for unlimited.
+     * @param maxFields The maximum number of fields to be parsed or -1 for a default.
+     * @param maxLength The maximum total size of the fields or -1 for a default.
      * @return A {@link CompletableFuture} that will provide the {@link Fields} or a failure.
      */
-    static CompletableFuture<Fields> from(Content.Source source, InvocationType invocationType, Attributes attributes, Charset charset, int maxFields, int maxLength)
+    static CompletableFuture<Fields> from(Content.Source source, InvocationType invocationType, Attributes attributes, Request request, Charset charset, int maxFields, int maxLength)
     {
+        if (maxFields < 0)
+            maxFields = findDefaultMaxFields(request);
+        if (maxLength < 0)
+            maxLength = findDefaultMaxLength(request);
+
         Object attr = attributes.getAttribute(FormFields.class.getName());
         if (attr instanceof FormFields futureFormFields)
             return futureFormFields;
@@ -338,18 +398,55 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         return futureFormFields;
     }
 
-    private static int getContextAttribute(Context context, String attribute, int defValue)
+    private static int findDefaultMaxFields(Request request)
     {
-        Object value = context.getAttribute(attribute);
+        int maxLength;
+        if (request != null)
+        {
+            maxLength = parse(request.getContext().getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
+            if (maxLength != -1)
+                return maxLength;
+        }
+
+        // Use value from the system property if it is set.
+        String property = System.getProperty(FormFields.MAX_FIELDS_ATTRIBUTE);
+        maxLength = parse(property);
+        if (maxLength != -1)
+            return maxLength;
+
+        return FormFields.MAX_FIELDS_DEFAULT;
+    }
+
+    private static int findDefaultMaxLength(Request request)
+    {
+        int maxLength;
+        if (request != null)
+        {
+            maxLength = parse(request.getContext().getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
+            if (maxLength != -1)
+                return maxLength;
+        }
+
+        // Use value from the system property if it is set.
+        String property = System.getProperty(FormFields.MAX_LENGTH_ATTRIBUTE);
+        maxLength = parse(property);
+        if (maxLength != -1)
+            return maxLength;
+
+        return FormFields.MAX_LENGTH_DEFAULT;
+    }
+
+    private static int parse(Object value)
+    {
         if (value == null)
-            return defValue;
+            return -1;
         try
         {
             return Integer.parseInt(value.toString());
         }
         catch (NumberFormatException x)
         {
-            return defValue;
+            return -1;
         }
     }
 
@@ -370,92 +467,98 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         _builder = CharsetStringBuilder.forCharset(charset);
         _fields = new Fields(true);
         if (_maxLength > 0 && source.getLength() > _maxLength)
-            throw new IllegalStateException("form too large > " + _maxLength);
+            throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form too large > " + _maxLength);
     }
 
     @Override
-    protected Fields parse(Content.Chunk chunk) throws CharacterCodingException
+    protected Fields parse(Content.Chunk chunk)
     {
         if (_maxLength >= 0)
         {
             _length += chunk.remaining();
             if (_length > _maxLength)
-                throw new IllegalStateException("form too large > " + _maxLength);
+                throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form too large > " + _maxLength);
         }
 
-        ByteBuffer buffer = chunk.getByteBuffer();
-
-        while (BufferUtil.hasContent(buffer))
+        try
         {
-            byte b = buffer.get();
-            switch (_percent)
+            ByteBuffer buffer = chunk.getByteBuffer();
+            while (BufferUtil.hasContent(buffer))
             {
-                case 1 ->
+                byte b = buffer.get();
+                switch (_percent)
                 {
-                    _percentCode = b;
-                    _percent++;
-                    continue;
+                    case 1 ->
+                    {
+                        _percentCode = b;
+                        _percent++;
+                        continue;
+                    }
+                    case 2 ->
+                    {
+                        _percent = 0;
+                        _builder.append(decodeHexByte((char)_percentCode, (char)b));
+                        continue;
+                    }
                 }
-                case 2 ->
+
+                if (_name == null)
                 {
-                    _percent = 0;
-                    _builder.append(decodeHexByte((char)_percentCode, (char)b));
-                    continue;
+                    switch (b)
+                    {
+                        case '&' ->
+                        {
+                            String name = _builder.build();
+                            onNewField(name, "");
+                        }
+                        case '=' -> _name = _builder.build();
+                        case '+' -> _builder.append(' ');
+                        case '%' -> _percent++;
+                        default ->
+                        {
+                            _builder.append(b);
+                        }
+                    }
+                }
+                else
+                {
+                    switch (b)
+                    {
+                        case '&' ->
+                        {
+                            String value = _builder.build();
+                            onNewField(_name, value);
+                            _name = null;
+                        }
+                        case '+' -> _builder.append(' ');
+                        case '%' -> _percent++;
+                        default -> _builder.append(b);
+                    }
                 }
             }
+
+            if (!chunk.isLast())
+                return null;
+
+            // Append any remaining %x.
+            if (_percent > 0)
+                throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "invalid percent encoding");
+            String value = _builder.build();
 
             if (_name == null)
             {
-                switch (b)
-                {
-                    case '&' ->
-                    {
-                        String name = _builder.build();
-                        onNewField(name, "");
-                    }
-                    case '=' -> _name = _builder.build();
-                    case '+' -> _builder.append(' ');
-                    case '%' -> _percent++;
-                    default ->
-                    {
-                        _builder.append(b);
-                    }
-                }
+                if (!value.isEmpty())
+                    onNewField(value, "");
+                return _fields;
             }
-            else
-            {
-                switch (b)
-                {
-                    case '&' ->
-                    {
-                        String value = _builder.build();
-                        onNewField(_name, value);
-                        _name = null;
-                    }
-                    case '+' -> _builder.append(' ');
-                    case '%' -> _percent++;
-                    default -> _builder.append(b);
-                }
-            }
-        }
 
-        if (!chunk.isLast())
-            return null;
-
-        // Append any remaining %x.
-        if (_percent > 0)
-            throw new IllegalStateException("invalid percent encoding");
-        String value = _builder.build();
-
-        if (_name == null)
-        {
-            if (!value.isEmpty())
-                onNewField(value, "");
+            onNewField(_name, value);
             return _fields;
         }
-
-        onNewField(_name, value);
-        return _fields;
+        catch (CharacterCodingException e)
+        {
+            throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "invalid form encoding", e);
+        }
     }
 
     private void onNewField(String name, String value)
@@ -463,6 +566,6 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         Fields.Field field = new Fields.Field(name, value);
         _fields.add(field);
         if (_maxFields >= 0 && _fields.getSize() > _maxFields)
-            throw new IllegalStateException("form with too many fields > " + _maxFields);
+            throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form with too many fields > " + _maxFields);
     }
 }

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -400,19 +400,23 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
 
     private static int findDefaultMaxFields(Request request)
     {
-        int maxLength;
+        int maxFields;
         if (request != null)
         {
-            maxLength = parse(request.getContext().getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
-            if (maxLength != -1)
-                return maxLength;
+            maxFields = parse(request.getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
+            if (maxFields != -1)
+                return maxFields;
+
+            maxFields = parse(request.getContext().getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
+            if (maxFields != -1)
+                return maxFields;
         }
 
         // Use value from the system property if it is set.
         String property = System.getProperty(FormFields.MAX_FIELDS_ATTRIBUTE);
-        maxLength = parse(property);
-        if (maxLength != -1)
-            return maxLength;
+        maxFields = parse(property);
+        if (maxFields != -1)
+            return maxFields;
 
         return FormFields.MAX_FIELDS_DEFAULT;
     }
@@ -422,6 +426,10 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         int maxLength;
         if (request != null)
         {
+            maxLength = parse(request.getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
+            if (maxLength != -1)
+                return maxLength;
+
             maxLength = parse(request.getContext().getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
             if (maxLength != -1)
                 return maxLength;
@@ -450,6 +458,7 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
         }
     }
 
+    private final Content.Source _content;
     private final Fields _fields;
     private final CharsetStringBuilder _builder;
     private final int _maxFields;
@@ -462,12 +471,11 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     private FormFields(Content.Source source, InvocationType invocationType, Charset charset, int maxFields, int maxSize)
     {
         super(source, invocationType);
+        _content = source;
         _maxFields = maxFields;
         _maxLength = maxSize;
         _builder = CharsetStringBuilder.forCharset(charset);
         _fields = new Fields(true);
-        if (_maxLength > 0 && source.getLength() > _maxLength)
-            throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form too large > " + _maxLength);
     }
 
     @Override
@@ -475,6 +483,10 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     {
         if (_maxLength >= 0)
         {
+            // Fast fail here if content-length is known.
+            if (_length == 0 && _content.getLength() > _maxLength)
+                throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form too large > " + _maxLength);
+
             _length += chunk.remaining();
             if (_length > _maxLength)
                 throw new HttpException.IllegalStateException(HttpStatus.PAYLOAD_TOO_LARGE_413, "form too large > " + _maxLength);

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/FormFields.java
@@ -401,18 +401,21 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     private static int findDefaultMaxFields(Request request)
     {
         int maxFields;
+
         if (request != null)
         {
+            // Use the per-request configuration if available.
             maxFields = parse(request.getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
             if (maxFields != -1)
                 return maxFields;
 
+            // Use the default per-context configuration.
             maxFields = parse(request.getContext().getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
             if (maxFields != -1)
                 return maxFields;
         }
 
-        // Use value from the system property if it is set.
+        // Use the system-wide default from the system property if it is set.
         String property = System.getProperty(FormFields.MAX_FIELDS_ATTRIBUTE);
         maxFields = parse(property);
         if (maxFields != -1)
@@ -424,18 +427,21 @@ public class FormFields extends ContentSourceCompletableFuture<Fields>
     private static int findDefaultMaxLength(Request request)
     {
         int maxLength;
+
         if (request != null)
         {
+            // Use the per-request configuration if available.
             maxLength = parse(request.getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
             if (maxLength != -1)
                 return maxLength;
 
+            // Use the default per-context configuration.
             maxLength = parse(request.getContext().getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
             if (maxLength != -1)
                 return maxLength;
         }
 
-        // Use value from the system property if it is set.
+        // Use the system-wide default from the system property if it is set.
         String property = System.getProperty(FormFields.MAX_LENGTH_ATTRIBUTE);
         maxLength = parse(property);
         if (maxLength != -1)

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EagerContentHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/EagerContentHandler.java
@@ -248,7 +248,7 @@ public class EagerContentHandler extends ConditionalHandler.ElseNext
         /**
          * Called to initiate eager loading of the content.  The content may be loaded within the scope
          * of this method, or within the scope of a callback as a result of a {@link Request#demand(Runnable)} call made by
-         * this methhod.
+         * this method.
          * @throws Exception If there is a problem
          */
         protected abstract void load() throws Exception;

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/FormFieldsTest.java
@@ -73,7 +73,7 @@ public class FormFieldsTest
     {
         AsyncContent source = new AsyncContent();
         Attributes attributes = new Attributes.Mapped();
-        CompletableFuture<Fields> futureFields = FormFields.from(source, Invocable.InvocationType.NON_BLOCKING, attributes, charset, maxFields, maxLength);
+        CompletableFuture<Fields> futureFields = FormFields.from(source, Invocable.InvocationType.NON_BLOCKING, attributes, null, charset, maxFields, maxLength);
         assertFalse(futureFields.isDone());
 
         int last = chunks.size() - 1;
@@ -139,7 +139,7 @@ public class FormFieldsTest
     public void testInvalidFormFields(List<String> chunks, Charset charset, int maxFields, int maxLength, Class<? extends Exception> expectedException)
     {
         AsyncContent source = new AsyncContent();
-        CompletableFuture<Fields> futureFields = FormFields.from(source, Invocable.InvocationType.NON_BLOCKING, new Attributes.Mapped(), charset, maxFields, maxLength);
+        CompletableFuture<Fields> futureFields = FormFields.from(source, Invocable.InvocationType.NON_BLOCKING, new Attributes.Mapped(), null, charset, maxFields, maxLength);
         assertFalse(futureFields.isDone());
         int last = chunks.size() - 1;
         for (int i = 0; i <= last; i++)

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
@@ -18,11 +18,13 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.net.Socket;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
+import org.eclipse.jetty.http.HttpException;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpTester;
@@ -46,6 +48,7 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
@@ -527,6 +530,131 @@ public class EagerContentHandlerTest
             content = new String(response.getContentBytes(), StandardCharsets.UTF_8);
             assertThat(content, containsString("name=[value]"));
             assertThat(content, containsString("x=[1, 2, 3]"));
+        }
+    }
+
+    @Test
+    public void testEagerFormFieldsLimits() throws Exception
+    {
+        // Set the global form limits for maxFormContentSize.
+        System.setProperty("org.eclipse.jetty.server.Request.maxFormKeys", "-1");
+        System.setProperty("org.eclipse.jetty.server.Request.maxFormContentSize", "15");
+
+        CountDownLatch processing = new CountDownLatch(1);
+        CompletableFuture<Throwable> contentLoaderErrorFuture = new CompletableFuture<>();
+        CompletableFuture<Throwable> handlerErrorFuture = new CompletableFuture<>();
+        EagerContentHandler eagerContentHandler = new EagerContentHandler(new EagerContentHandler.FormContentLoaderFactory()
+        {
+            @Override
+            public EagerContentHandler.ContentLoader newContentLoader(String contentType, String mimeType, Handler handler, Request request, Response response, Callback callback)
+            {
+                EagerContentHandler.ContentLoader contentLoader = super.newContentLoader(contentType, mimeType, handler, request, response, callback);
+                return new EagerContentHandler.ContentLoader(handler, request, response, callback)
+                {
+                    @Override
+                    protected void load() throws Exception
+                    {
+                        try
+                        {
+                            contentLoader.load();
+                            processing.countDown();
+                        }
+                        catch (Throwable t)
+                        {
+                            contentLoaderErrorFuture.complete(t);
+                            throw t;
+                        }
+                    }
+                };
+            }
+        });
+        _server.setHandler(eagerContentHandler);
+        eagerContentHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                try
+                {
+                    Fields fields = FormFields.getFields(request);
+                    Content.Sink.write(response, true, String.valueOf(fields), callback);
+                    return true;
+                }
+                catch (Throwable t)
+                {
+                    handlerErrorFuture.complete(t);
+                    throw t;
+                }
+            }
+        });
+        _server.start();
+
+        // Test when the content-length is known so the failure is triggered directly from EagerContentHandler.
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            // Write the first request content which does not exceed the form limits.
+            String request = """
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """;
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // The EagerContentHandler's ContentLoader should throw so we never reach the handler.
+            Throwable throwable = contentLoaderErrorFuture.get(5, TimeUnit.SECONDS);
+            assertThat(throwable, instanceOf(HttpException.IllegalStateException.class));
+
+            // The response code should be 413 PAYLOAD_TOO_LARGE.
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            HttpTester.Response response = HttpTester.parseResponse(input);
+            assertThat(response.getStatus(), is(HttpStatus.PAYLOAD_TOO_LARGE_413));
+            assertThat(response.getContent(), containsString("form too large"));
+        }
+
+        // Test when the content-length is not known so the failure is triggered from the Handler trying to access the form.
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            // Write the first request content which does not exceed the form limits.
+            String request = """
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                Content-Type: application/x-www-form-urlencoded\r
+                Transfer-Encoding: chunked\r
+                \r
+                D\r
+                param1=value1\r
+                """;
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // Assert we reach the handler and didn't fail in EagerContentHandler.
+            assertTrue(processing.await(5, TimeUnit.SECONDS));
+
+            // Write remaining form content which exceeds the limit.
+            String requestContinued = """
+                E\r
+                &param2=value2\r
+                0\r
+                \r
+                """;
+            output.write(requestContinued.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // After writing the final bytes of the request we fail in the handler.
+            Throwable throwable = handlerErrorFuture.get(5, TimeUnit.SECONDS);
+            assertThat(throwable, instanceOf(HttpException.IllegalStateException.class));
+
+            // The response code should be 413 PAYLOAD_TOO_LARGE.
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            HttpTester.Response response = HttpTester.parseResponse(input);
+            assertThat(response.getStatus(), is(HttpStatus.PAYLOAD_TOO_LARGE_413));
+            assertThat(response.getContent(), containsString("form too large"));
         }
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Exchanger;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
 
 import org.awaitility.Awaitility;
 import org.eclipse.jetty.http.HttpException;
@@ -44,6 +45,9 @@ import org.eclipse.jetty.util.Fields;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -536,12 +540,10 @@ public class EagerContentHandlerTest
     @Test
     public void testEagerFormFieldsLimits() throws Exception
     {
-        // Set the global form limits for maxFormContentSize.
-        System.setProperty("org.eclipse.jetty.server.Request.maxFormKeys", "-1");
-        System.setProperty("org.eclipse.jetty.server.Request.maxFormContentSize", "15");
+        // Set the server context limit for maxFormContentSize.
+        _server.getContext().setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", "15");
 
-        CountDownLatch processing = new CountDownLatch(1);
-        CompletableFuture<Throwable> contentLoaderErrorFuture = new CompletableFuture<>();
+        CountDownLatch processing = new CountDownLatch(2);
         CompletableFuture<Throwable> handlerErrorFuture = new CompletableFuture<>();
         EagerContentHandler eagerContentHandler = new EagerContentHandler(new EagerContentHandler.FormContentLoaderFactory()
         {
@@ -554,16 +556,8 @@ public class EagerContentHandlerTest
                     @Override
                     protected void load() throws Exception
                     {
-                        try
-                        {
-                            contentLoader.load();
-                            processing.countDown();
-                        }
-                        catch (Throwable t)
-                        {
-                            contentLoaderErrorFuture.complete(t);
-                            throw t;
-                        }
+                        contentLoader.load();
+                        processing.countDown();
                     }
                 };
             }
@@ -605,8 +599,8 @@ public class EagerContentHandlerTest
             output.write(request.getBytes(StandardCharsets.UTF_8));
             output.flush();
 
-            // The EagerContentHandler's ContentLoader should throw so we never reach the handler.
-            Throwable throwable = contentLoaderErrorFuture.get(5, TimeUnit.SECONDS);
+            // The failure should not be thrown from the content loader but the handler.
+            Throwable throwable = handlerErrorFuture.get(5, TimeUnit.SECONDS);
             assertThat(throwable, instanceOf(HttpException.IllegalStateException.class));
 
             // The response code should be 413 PAYLOAD_TOO_LARGE.
@@ -655,6 +649,76 @@ public class EagerContentHandlerTest
             HttpTester.Response response = HttpTester.parseResponse(input);
             assertThat(response.getStatus(), is(HttpStatus.PAYLOAD_TOO_LARGE_413));
             assertThat(response.getContent(), containsString("form too large"));
+        }
+    }
+
+    public static Stream<Arguments> formLimitsProvider()
+    {
+        // The form content has a size of 27 bytes with 2 fields.
+        return Stream.of(
+            Arguments.of(-1, -1, HttpStatus.OK_200),
+            Arguments.of(100, 100, HttpStatus.OK_200),
+            Arguments.of(2, -1, HttpStatus.OK_200),
+            Arguments.of(1, -1, HttpStatus.PAYLOAD_TOO_LARGE_413),
+            Arguments.of(-1, 27, HttpStatus.OK_200),
+            Arguments.of(-1, 26, HttpStatus.PAYLOAD_TOO_LARGE_413)
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("formLimitsProvider")
+    public void perRequestFormLimitsTest(int maxFormFields, int maxFormLength, int expectedStatusCode) throws Exception
+    {
+        _server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                String maxFieldsAttribute = request.getHeaders().get(FormFields.MAX_FIELDS_ATTRIBUTE);
+                if (maxFieldsAttribute != null)
+                    request.setAttribute(FormFields.MAX_FIELDS_ATTRIBUTE, maxFieldsAttribute);
+
+                String maxLengthAttribute = request.getHeaders().get(FormFields.MAX_LENGTH_ATTRIBUTE);
+                if (maxLengthAttribute != null)
+                    request.setAttribute(FormFields.MAX_LENGTH_ATTRIBUTE, maxLengthAttribute);
+
+                Fields fields = FormFields.getFields(request);
+                Content.Sink.write(response, true, String.valueOf(fields), callback);
+                return true;
+            }
+        });
+        _server.start();
+
+        HttpTester.Response response = getResponse(maxFormFields, maxFormLength);
+        assertThat(response.getStatus(), is(expectedStatusCode));
+    }
+
+    private HttpTester.Response getResponse(int maxFormFields, int maxFormLength) throws Exception
+    {
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            // Write the first request content which does not exceed the form limits.
+            StringBuilder request = new StringBuilder();
+            request.append("""
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                """);
+            if (maxFormFields != -1)
+                request.append(FormFields.MAX_FIELDS_ATTRIBUTE).append(": ").append(maxFormFields).append("\r\n");
+            if (maxFormLength != -1)
+                request.append(FormFields.MAX_LENGTH_ATTRIBUTE).append(": ").append(maxFormLength).append("\r\n");
+            request.append("""
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """);
+            OutputStream output = socket.getOutputStream();
+            output.write(request.toString().getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            return HttpTester.parseResponse(input);
         }
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/EagerContentHandlerTest.java
@@ -586,7 +586,6 @@ public class EagerContentHandlerTest
         // Test when the content-length is known so the failure is triggered directly from EagerContentHandler.
         try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
         {
-            // Write the first request content which does not exceed the form limits.
             String request = """
                 POST /foo HTTP/1.1\r
                 Host: localhost\r
@@ -697,7 +696,6 @@ public class EagerContentHandlerTest
     {
         try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
         {
-            // Write the first request content which does not exceed the form limits.
             StringBuilder request = new StringBuilder();
             request.append("""
                 POST /foo HTTP/1.1\r

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/FormTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/FormTest.java
@@ -46,6 +46,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
@@ -59,10 +60,10 @@ public class FormTest extends AbstractTest
         List<Arguments> results = new ArrayList<>();
         transportsNoFCGI().forEach(transportType ->
         {
-            results.add(arguments(transportType, null, FormFields.MAX_LENGTH_DEFAULT + 1, HttpStatus.BAD_REQUEST_400));
+            results.add(arguments(transportType, null, FormFields.MAX_LENGTH_DEFAULT + 1, HttpStatus.PAYLOAD_TOO_LARGE_413));
             results.add(arguments(transportType, -1, null, HttpStatus.OK_200));
-            results.add(arguments(transportType, 0, null, HttpStatus.BAD_REQUEST_400));
-            results.add(arguments(transportType, MAX_FORM_CONTENT_SIZE, FormFields.MAX_LENGTH_DEFAULT + 1, HttpStatus.BAD_REQUEST_400));
+            results.add(arguments(transportType, 0, null, HttpStatus.PAYLOAD_TOO_LARGE_413));
+            results.add(arguments(transportType, MAX_FORM_CONTENT_SIZE, FormFields.MAX_LENGTH_DEFAULT + 1, HttpStatus.PAYLOAD_TOO_LARGE_413));
         });
         return results.stream();
     }
@@ -85,6 +86,7 @@ public class FormTest extends AbstractTest
         BytesRequestContent formContent = new BytesRequestContent(
             MimeTypes.Type.FORM_ENCODED.asString(),
             newContent(contentSize));
+        assertThat(formContent.getLength(), equalTo((long)contentSize));
 
         AtomicReference<Result> resultRef = new AtomicReference<>();
 
@@ -101,7 +103,7 @@ public class FormTest extends AbstractTest
     private byte[] newContent(int size)
     {
         byte[] key = "foo=".getBytes(US_ASCII);
-        byte[] buf = new byte[size + key.length];
+        byte[] buf = new byte[(size - key.length) + key.length];
         Arrays.fill(buf, (byte)'x');
         System.arraycopy(key, 0, buf, 0, key.length);
         return buf;
@@ -151,7 +153,7 @@ public class FormTest extends AbstractTest
             .timeout(5, TimeUnit.SECONDS)
             .send();
 
-        assertEquals(HttpStatus.BAD_REQUEST_400, response.getStatus());
+        assertEquals(HttpStatus.PAYLOAD_TOO_LARGE_413, response.getStatus());
     }
 
     @ParameterizedTest
@@ -226,10 +228,6 @@ public class FormTest extends AbstractTest
                     out.printf("field.%s=%s\n", field.getName(), field.getValue()));
                 out.flush();
                 Content.Sink.write(response, true, writer.toString(), callback);
-            }
-            catch (IllegalStateException e)
-            {
-                Response.writeError(request, response, callback, HttpStatus.BAD_REQUEST_400, "Bad Form", e);
             }
             return true;
         }

--- a/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/FormTest.java
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/src/test/java/org/eclipse/jetty/test/client/transport/FormTest.java
@@ -103,7 +103,7 @@ public class FormTest extends AbstractTest
     private byte[] newContent(int size)
     {
         byte[] key = "foo=".getBytes(US_ASCII);
-        byte[] buf = new byte[(size - key.length) + key.length];
+        byte[] buf = new byte[size];
         Arrays.fill(buf, (byte)'x');
         System.arraycopy(key, 0, buf, 0, key.length);
         return buf;

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiRequest.java
@@ -1079,9 +1079,18 @@ public class ServletApiRequest implements HttpServletRequest
                         try
                         {
                             ServletContextHandler contextHandler = getServletRequestInfo().getServletContextHandler();
-                            int maxKeys = contextHandler.getMaxFormKeys();
-                            int maxContentSize = contextHandler.getMaxFormContentSize();
-                            _contentParameters = FormFields.getFields(getRequest(), maxKeys, maxContentSize);
+
+                            // Try per-request and per-context max form fields.
+                            int maxFields = parse(getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
+                            if (maxFields == -1)
+                                maxFields = contextHandler.getMaxFormKeys();
+
+                            // Try per-request and per-context max form length.
+                            int maxLength = parse(getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
+                            if (maxLength == -1)
+                                maxLength = contextHandler.getMaxFormContentSize();
+
+                            _contentParameters = FormFields.getFields(getRequest(), maxFields, maxLength);
                         }
                         catch (IllegalStateException | IllegalArgumentException | CompletionException e)
                         {
@@ -1137,6 +1146,20 @@ public class ServletApiRequest implements HttpServletRequest
             {
                 throw new BadMessageException("Unable to parse form content", e);
             }
+        }
+    }
+
+    private static int parse(Object value)
+    {
+        if (value == null)
+            return -1;
+        try
+        {
+            return Integer.parseInt(value.toString());
+        }
+        catch (NumberFormatException x)
+        {
+            return -1;
         }
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/EagerContentHandlerServletTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/EagerContentHandlerServletTest.java
@@ -1,0 +1,205 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.BadMessageException;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.FormFields;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.EagerContentHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class EagerContentHandlerServletTest
+{
+    private Server _server;
+    private ServerConnector _connector;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _server.stop();
+    }
+
+    @Test
+    public void testEagerFormFieldsLimits() throws Exception
+    {
+        // Set the server context limit for maxFormContentSize.
+        _server.getContext().setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", "15");
+
+        CountDownLatch processing = new CountDownLatch(2);
+        CompletableFuture<Throwable> handlerErrorFuture = new CompletableFuture<>();
+        EagerContentHandler eagerContentHandler = new EagerContentHandler(new EagerContentHandler.FormContentLoaderFactory());
+        _server.setHandler(eagerContentHandler);
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        eagerContentHandler.setHandler(servletContextHandler);
+        servletContextHandler.addServlet(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp)
+            {
+                try
+                {
+                    processing.countDown();
+                    req.getParameterMap();
+                }
+                catch (Throwable t)
+                {
+                    handlerErrorFuture.complete(t);
+                    throw t;
+                }
+            }
+        }, "/");
+        _server.start();
+
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            String request = """
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """;
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // Expect an error from calling getParameterMap().
+            Throwable throwable = handlerErrorFuture.get(5, TimeUnit.SECONDS);
+            assertThat(throwable, instanceOf(BadMessageException.class));
+
+            // The response code should be 400 BAD_REQUEST.
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            HttpTester.Response response = HttpTester.parseResponse(input);
+            assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
+            assertThat(response.getContent(), containsString("Unable to parse form content"));
+        }
+    }
+
+    public static Stream<Arguments> formLimitsProvider()
+    {
+        // The form content has a size of 27 bytes with 2 fields.
+        return Stream.of(
+            Arguments.of(-1, -1, HttpStatus.OK_200),
+            Arguments.of(100, 100, HttpStatus.OK_200),
+            Arguments.of(2, -1, HttpStatus.OK_200),
+            Arguments.of(1, -1, HttpStatus.BAD_REQUEST_400),
+            Arguments.of(-1, 27, HttpStatus.OK_200),
+            Arguments.of(-1, 26, HttpStatus.BAD_REQUEST_400)
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("formLimitsProvider")
+    public void perRequestFormLimitsTest(int maxFormFields, int maxFormLength, int expectedStatusCode) throws Exception
+    {
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        _server.setHandler(servletContextHandler);
+        servletContextHandler.addFilter(new HttpFilter()
+        {
+            @Override
+            public void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException, ServletException
+            {
+                String maxFieldsAttribute = req.getHeader(FormFields.MAX_FIELDS_ATTRIBUTE);
+                if (maxFieldsAttribute != null)
+                    req.setAttribute(FormFields.MAX_FIELDS_ATTRIBUTE, maxFieldsAttribute);
+
+                String maxLengthAttribute = req.getHeader(FormFields.MAX_LENGTH_ATTRIBUTE);
+                if (maxLengthAttribute != null)
+                    req.setAttribute(FormFields.MAX_LENGTH_ATTRIBUTE, maxLengthAttribute);
+
+                chain.doFilter(req, res);
+            }
+        }, "/*", EnumSet.allOf(DispatcherType.class));
+        servletContextHandler.addServlet(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp)
+            {
+                req.getParameterMap();
+            }
+        }, "/");
+
+        _server.start();
+
+        HttpTester.Response response = getResponse(maxFormFields, maxFormLength);
+        assertThat(response.getStatus(), is(expectedStatusCode));
+    }
+
+    private HttpTester.Response getResponse(int maxFormFields, int maxFormLength) throws Exception
+    {
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            StringBuilder request = new StringBuilder();
+            request.append("""
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                """);
+            if (maxFormFields != -1)
+                request.append(FormFields.MAX_FIELDS_ATTRIBUTE).append(": ").append(maxFormFields).append("\r\n");
+            if (maxFormLength != -1)
+                request.append(FormFields.MAX_LENGTH_ATTRIBUTE).append(": ").append(maxFormLength).append("\r\n");
+            request.append("""
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """);
+            OutputStream output = socket.getOutputStream();
+            output.write(request.toString().getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            return HttpTester.parseResponse(input);
+        }
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiRequest.java
@@ -1085,9 +1085,18 @@ public class ServletApiRequest implements HttpServletRequest
                         try
                         {
                             ServletContextHandler contextHandler = getServletRequestInfo().getServletContextHandler();
-                            int maxKeys = contextHandler.getMaxFormKeys();
-                            int maxContentSize = contextHandler.getMaxFormContentSize();
-                            _contentParameters = FormFields.getFields(getRequest(), maxKeys, maxContentSize);
+
+                            // Try per-request and per-context max form fields.
+                            int maxFields = parse(getAttribute(FormFields.MAX_FIELDS_ATTRIBUTE));
+                            if (maxFields == -1)
+                                maxFields = contextHandler.getMaxFormKeys();
+
+                            // Try per-request and per-context max form length.
+                            int maxLength = parse(getAttribute(FormFields.MAX_LENGTH_ATTRIBUTE));
+                            if (maxLength == -1)
+                                maxLength = contextHandler.getMaxFormContentSize();
+
+                            _contentParameters = FormFields.getFields(getRequest(), maxFields, maxLength);
                         }
                         catch (IllegalStateException | IllegalArgumentException | CompletionException e)
                         {
@@ -1144,6 +1153,20 @@ public class ServletApiRequest implements HttpServletRequest
                 HttpException.throwIfHttpException(e);
                 throw new HttpException.IllegalStateException(HttpStatus.BAD_REQUEST_400, "Unable to parse form content", e);
             }
+        }
+    }
+
+    private static int parse(Object value)
+    {
+        if (value == null)
+            return -1;
+        try
+        {
+            return Integer.parseInt(value.toString());
+        }
+        catch (NumberFormatException x)
+        {
+            return -1;
         }
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/EagerContentHandlerServletTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/EagerContentHandlerServletTest.java
@@ -1,0 +1,205 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.EnumSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import jakarta.servlet.DispatcherType;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpFilter;
+import jakarta.servlet.http.HttpServlet;
+ import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpException;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.FormFields;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.handler.EagerContentHandler;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+public class EagerContentHandlerServletTest
+{
+    private Server _server;
+    private ServerConnector _connector;
+
+    @BeforeEach
+    public void before() throws Exception
+    {
+        _server = new Server();
+        _connector = new ServerConnector(_server);
+        _server.addConnector(_connector);
+    }
+
+    @AfterEach
+    public void after() throws Exception
+    {
+        _server.stop();
+    }
+
+    @Test
+    public void testEagerFormFieldsLimits() throws Exception
+    {
+        // Set the server context limit for maxFormContentSize.
+        _server.getContext().setAttribute("org.eclipse.jetty.server.Request.maxFormContentSize", "15");
+
+        CountDownLatch processing = new CountDownLatch(2);
+        CompletableFuture<Throwable> handlerErrorFuture = new CompletableFuture<>();
+        EagerContentHandler eagerContentHandler = new EagerContentHandler(new EagerContentHandler.FormContentLoaderFactory());
+        _server.setHandler(eagerContentHandler);
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        eagerContentHandler.setHandler(servletContextHandler);
+        servletContextHandler.addServlet(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp)
+            {
+                try
+                {
+                    processing.countDown();
+                    req.getParameterMap();
+                }
+                catch (Throwable t)
+                {
+                    handlerErrorFuture.complete(t);
+                    throw t;
+                }
+            }
+        }, "/");
+        _server.start();
+
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            String request = """
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """;
+            OutputStream output = socket.getOutputStream();
+            output.write(request.getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            // Expect an error from calling getParameterMap().
+            Throwable throwable = handlerErrorFuture.get(5, TimeUnit.SECONDS);
+            assertThat(throwable, instanceOf(HttpException.IllegalStateException.class));
+
+            // The response code should be 400 BAD_REQUEST.
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            HttpTester.Response response = HttpTester.parseResponse(input);
+            assertThat(response.getStatus(), is(HttpStatus.BAD_REQUEST_400));
+            assertThat(response.getContent(), containsString("Unable to parse form content"));
+        }
+    }
+
+    public static Stream<Arguments> formLimitsProvider()
+    {
+        // The form content has a size of 27 bytes with 2 fields.
+        return Stream.of(
+            Arguments.of(-1, -1, HttpStatus.OK_200),
+            Arguments.of(100, 100, HttpStatus.OK_200),
+            Arguments.of(2, -1, HttpStatus.OK_200),
+            Arguments.of(1, -1, HttpStatus.BAD_REQUEST_400),
+            Arguments.of(-1, 27, HttpStatus.OK_200),
+            Arguments.of(-1, 26, HttpStatus.BAD_REQUEST_400)
+            );
+    }
+
+    @ParameterizedTest
+    @MethodSource("formLimitsProvider")
+    public void perRequestFormLimitsTest(int maxFormFields, int maxFormLength, int expectedStatusCode) throws Exception
+    {
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        _server.setHandler(servletContextHandler);
+        servletContextHandler.addFilter(new HttpFilter()
+        {
+            @Override
+            public void doFilter(HttpServletRequest req, HttpServletResponse res, FilterChain chain) throws IOException, ServletException
+            {
+                String maxFieldsAttribute = req.getHeader(FormFields.MAX_FIELDS_ATTRIBUTE);
+                if (maxFieldsAttribute != null)
+                    req.setAttribute(FormFields.MAX_FIELDS_ATTRIBUTE, maxFieldsAttribute);
+
+                String maxLengthAttribute = req.getHeader(FormFields.MAX_LENGTH_ATTRIBUTE);
+                if (maxLengthAttribute != null)
+                    req.setAttribute(FormFields.MAX_LENGTH_ATTRIBUTE, maxLengthAttribute);
+
+                chain.doFilter(req, res);
+            }
+        }, "/*", EnumSet.allOf(DispatcherType.class));
+        servletContextHandler.addServlet(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest req, HttpServletResponse resp)
+            {
+                req.getParameterMap();
+            }
+        }, "/");
+
+        _server.start();
+
+        HttpTester.Response response = getResponse(maxFormFields, maxFormLength);
+        assertThat(response.getStatus(), is(expectedStatusCode));
+    }
+
+    private HttpTester.Response getResponse(int maxFormFields, int maxFormLength) throws Exception
+    {
+        try (Socket socket = new Socket("localhost", _connector.getLocalPort()))
+        {
+            StringBuilder request = new StringBuilder();
+            request.append("""
+                POST /foo HTTP/1.1\r
+                Host: localhost\r
+                """);
+            if (maxFormFields != -1)
+                request.append(FormFields.MAX_FIELDS_ATTRIBUTE).append(": ").append(maxFormFields).append("\r\n");
+            if (maxFormLength != -1)
+                request.append(FormFields.MAX_LENGTH_ATTRIBUTE).append(": ").append(maxFormLength).append("\r\n");
+            request.append("""
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 27\r
+                \r
+                param1=value1&param2=value2\
+                """);
+            OutputStream output = socket.getOutputStream();
+            output.write(request.toString().getBytes(StandardCharsets.UTF_8));
+            output.flush();
+
+            HttpTester.Input input = HttpTester.from(socket.getInputStream());
+            return HttpTester.parseResponse(input);
+        }
+    }
+}


### PR DESCRIPTION
## Closes #15234

 - Throw `HttpException`s from `FormFields` so that the correct HTTP status codes can be returned.
 - Unwrap the `CompletionException` for the blocking `getFields()` methods, because if an `HttpException` was wrapped it would still give a 500 response code instead of the one contained in the `HttpException`.
 - Ensure that `FormFields` also uses the server default for the maxFields and maxLength from the system properties.
 - Introduce a per-request form limits via request attribute.