### PR TITLE
Issue #15289 - Workaround bug in FileSystem.getPath(String).toUri() with unicode paths

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/FileSystemPool.java
@@ -135,7 +135,9 @@ public class FileSystemPool implements Dumpable
                 throw new IllegalArgumentException("Unable to mount FileSystem from unsupported URI: " + jarURIRoot, pnfe);
             }
             // use root FS URI so that pool key/release/sweep is sane
-            URI rootURI = fileSystem.getPath("/").toUri();
+            Path rootPath = fileSystem.getPath("/");
+            // To work around bug identified in https://github.com/jetty/jetty.project/issues/15289
+            URI rootURI = URI.create(rootPath.toUri().toASCIIString());
             Mount mount = new Mount(rootURI, new MountedPathResource(jarURIRoot));
             retain(rootURI, fileSystem, mount);
             return mount;

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/resource/MountedPathResourceTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.zip.ZipFile;
 
 import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.IO;
 import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
@@ -52,7 +53,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @Isolated
 public class MountedPathResourceTest
 {
-
     @BeforeEach
     public void beforeEach()
     {
@@ -84,15 +84,48 @@ public class MountedPathResourceTest
     }
 
     @Test
-    public void testNewResourceByUrlHasCorrectUri() throws Exception
+    public void testNewResourceByUrlHasCorrectUrl() throws Exception
     {
         Path testZip = MavenPaths.findTestResourceFile("jar-file-resource.jar");
-        URL url = testZip.toUri().toURL();
+        URL originalUrl = testZip.toUri().toURL();
         try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
         {
-            Resource r = resourceFactory.newResource(url);
+            Resource r = resourceFactory.newResource(originalUrl);
             URI uri = r.getURI();
-            assertThat(uri.toASCIIString(), is(URIUtil.correctURI(uri).toASCIIString()));
+            assertThat(uri.toASCIIString(), is(URIUtil.correctURI(originalUrl.toURI()).toASCIIString()));
+        }
+    }
+
+    @Test
+    public void testNewResourceByUriHasCorrectUri() throws Exception
+    {
+        Path testZip = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        URI originalUri = testZip.toUri();
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Resource r = resourceFactory.newResource(originalUri);
+            URI actualURI = r.getURI();
+            assertThat(actualURI.toASCIIString(), is(URIUtil.correctURI(originalUri).toASCIIString()));
+        }
+    }
+
+    @Test
+    public void testNewResourceByUriWithUnicode(WorkDir workDir) throws Exception
+    {
+        Path sourceJar = MavenPaths.findTestResourceFile("jar-file-resource.jar");
+        Path testDir = workDir.getEmptyPathDir();
+        Path unicodeDir = testDir.resolve("dés");
+        FS.ensureDirExists(unicodeDir);
+        Path jarFile = unicodeDir.resolve("test.jar");
+        IO.copy(sourceJar, jarFile);
+
+        URI originalUri = jarFile.toUri();
+        URI originalJarFileURI = URIUtil.toJarFileUri(originalUri);
+        try (ResourceFactory.Closeable resourceFactory = ResourceFactory.closeable())
+        {
+            Resource r = resourceFactory.newJarFileResource(originalUri);
+            URI actualURI = r.getURI();
+            assertThat(actualURI.toASCIIString(), is(originalJarFileURI.toASCIIString()));
         }
     }
 


### PR DESCRIPTION
Workaround for bug in java's `FileSystem.getPath(String).toUri()` when working with unicode paths.

Closes #15289