### PR TITLE
Cleanups of HTTP2Flusher, HTTP2Session and HttpStreamOverHTTP2.

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2Session.java
@@ -26,6 +26,7 @@ import java.util.EventListener;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -863,6 +864,11 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
         return getParser().rateControlOnEvent(event);
     }
 
+    /**
+     * @param callback the callback to notify when the flush is complete
+     * @deprecated no replacement
+     */
+    @Deprecated(since = "12.1.10", forRemoval = true)
     public void flush(Callback callback)
     {
         Entry entry = new Entry(new FlushFrame(), null, callback)
@@ -2450,14 +2456,16 @@ public abstract class HTTP2Session extends AbstractLifeCycle implements Session,
                 LOG.debug("Terminating {}", HTTP2Session.this);
 
             CompletableFuture<Void> completable;
+            Throwable cause;
             try (AutoLock ignored = lock.lock())
             {
                 completable = shutdownCallback;
+                cause = failure;
             }
             if (completable != null)
                 completable.complete(null);
 
-            HTTP2Session.this.terminate(failure);
+            HTTP2Session.this.terminate(Objects.requireNonNullElseGet(cause, ClosedChannelException::new));
             notifyClose(HTTP2Session.this, frame, callback);
             notifyLifeCycleClose();
         }

--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/internal/HTTP2Flusher.java
@@ -36,6 +36,7 @@ import org.eclipse.jetty.http2.hpack.HpackException;
 import org.eclipse.jetty.io.EndPoint;
 import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.io.RetainableByteBuffer;
+import org.eclipse.jetty.util.ExceptionUtil;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.thread.AutoLock;
@@ -96,7 +97,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
             {
                 entries.offerFirst(entry);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Prepended {}, entries={}", entry, entries.size());
+                    LOG.debug("Prepended {}, entries={} on {}", entry, entries.size(), this);
                 return true;
             }
         }
@@ -121,7 +122,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
             {
                 entries.offer(entry);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Appended {}, entries={}, {}", entry, entries.size(), this);
+                    LOG.debug("Appended {}, entries={} on {}", entry, entries.size(), this);
                 return true;
             }
         }
@@ -139,7 +140,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
             {
                 list.forEach(entries::offer);
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Appended {}, entries={} {}", list, entries.size(), this);
+                    LOG.debug("Appended {}, entries={} on {}", list, entries.size(), this);
                 return true;
             }
         }
@@ -211,7 +212,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         if (pendingEntries.isEmpty())
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("Flushed {} {}", session, this);
+                LOG.debug("Flushed {} on {}", session, this);
             return Action.IDLE;
         }
 
@@ -227,14 +228,14 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
             {
                 HTTP2Session.Entry entry = pending.next();
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Processing {}", entry);
+                    LOG.debug("Processing {} on {}", entry, this);
 
                 // If the stream has been reset or removed,
                 // don't send the frame and fail it here.
                 if (entry.shouldBeDropped())
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Dropped {}", entry);
+                        LOG.debug("Dropped {} on {}", entry, this);
                     entry.closeAndFail(new EofException("dropped"));
                     pending.remove();
                     continue;
@@ -245,7 +246,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
                     if (entry.generate(accumulator))
                     {
                         if (LOG.isDebugEnabled())
-                            LOG.debug("Generated {} frame bytes for {}", entry.getFrameBytesGenerated(), entry);
+                            LOG.debug("Generated {} frame bytes for {} on {}", entry.getFrameBytesGenerated(), entry, this);
 
                         progress = true;
 
@@ -266,7 +267,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
                         {
                             stalledEntry = entry;
                             if (LOG.isDebugEnabled())
-                                LOG.debug("Flow control stalled at {}", entry);
+                                LOG.debug("Flow control stalled at {} on {}", entry, this);
                             // Continue to process control frames.
                         }
                     }
@@ -274,14 +275,14 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
                 catch (HpackException.StreamException failure)
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Failure generating {}", entry, failure);
+                        LOG.debug("Failure generating {} on {}", entry, this, failure);
                     entry.resetAndFail(failure);
                     pending.remove();
                 }
                 catch (HpackException.SessionException failure)
                 {
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Failure generating {}", entry, failure);
+                        LOG.debug("Failure generating {} on {}", entry, this, failure);
                     onSessionFailure(failure);
                     // The method above will try to send
                     // a GOAWAY, so we will iterate again.
@@ -291,7 +292,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
                 {
                     // Failure to generate the entry is catastrophic.
                     if (LOG.isDebugEnabled())
-                        LOG.debug("Failure generating {}", entry, failure);
+                        LOG.debug("Failure generating {} on {}", entry, this, failure);
                     failed(failure);
                     return Action.SCHEDULED;
                 }
@@ -307,7 +308,7 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
             if (accumulator.size() >= writeThreshold)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("Write threshold {} exceeded", writeThreshold);
+                    LOG.debug("Write threshold {} exceeded on {}", writeThreshold, this);
                 break;
             }
         }
@@ -321,12 +322,13 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         session.notifyOutgoingFrames(processedEntries);
 
         if (LOG.isDebugEnabled())
-            LOG.debug("Writing {} bytes - entries processed/pending {}/{}: {}/{}",
+            LOG.debug("Writing {} bytes - entries processed/pending {}/{}: {}/{} on {}",
                 accumulator.size(),
                 processedEntries.size(),
                 pendingEntries.size(),
                 processedEntries,
-                pendingEntries);
+                pendingEntries,
+                this);
 
         accumulator.writeTo(session.getEndPoint(), false, this);
         return Action.SCHEDULED;
@@ -336,11 +338,12 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
     protected void onSuccess()
     {
         if (LOG.isDebugEnabled())
-            LOG.debug("Written - entries processed/pending {}/{}: {}/{}",
+            LOG.debug("Written - entries processed/pending {}/{}: {}/{} on {}",
                 processedEntries.size(),
                 pendingEntries.size(),
                 processedEntries,
-                pendingEntries);
+                pendingEntries,
+                this);
         finish();
     }
 
@@ -379,13 +382,13 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         try (AutoLock ignored = lock.lock())
         {
             closed = terminated;
-            terminated = x;
+            terminated = ExceptionUtil.combine(terminated, x);
             if (LOG.isDebugEnabled())
-                LOG.debug("{}, entries processed/pending/queued={}/{}/{}",
+                LOG.debug("{}, entries processed/pending/queued={}/{}/{} on {}",
                     closed != null ? "Closing" : "Failing",
                     processedEntries.size(),
                     pendingEntries.size(),
-                    entries.size(), x);
+                    entries.size(), this, x);
             allEntries = new HashSet<>(entries);
             entries.clear();
         }
@@ -417,13 +420,13 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         try (AutoLock ignored = lock.lock())
         {
             closed = terminated;
-            terminated = x;
+            terminated = ExceptionUtil.combine(terminated, x);
             if (LOG.isDebugEnabled())
-                LOG.debug("{}, entries processed/pending/queued={}/{}/{}",
+                LOG.debug("{}, entries processed/pending/queued={}/{}/{} on {}",
                     closed != null ? "Closing" : "Failing",
                     processedEntries.size(),
                     pendingEntries.size(),
-                    entries.size(), x);
+                    entries.size(), this, x);
             allEntries = new HashSet<>(entries);
             entries.clear();
         }
@@ -444,9 +447,9 @@ public class HTTP2Flusher extends IteratingCallback implements Dumpable
         try (AutoLock ignored = lock.lock())
         {
             closed = terminated;
-            terminated = cause;
+            terminated = ExceptionUtil.combine(terminated, cause);
             if (LOG.isDebugEnabled())
-                LOG.debug("{} {}", closed != null ? "Terminated" : "Terminating", this);
+                LOG.debug("{} on {}", closed != null ? "Terminated" : "Terminating", this);
         }
         if (closed == null)
             iterate();

--- a/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-server/src/main/java/org/eclipse/jetty/http2/server/internal/HttpStreamOverHTTP2.java
@@ -443,14 +443,13 @@ public class HttpStreamOverHTTP2 implements HttpStream, HTTP2Channel.Server
     {
         // Append a ResetFrame into the H2 flusher and complete the appCallback once all the frames
         // up to and including the reset one have been flushed; it is needed to wait to make sure
-        // the completion listeners aren't called while a write is still pending.
+        // the completion listeners aren't called while a write operation is still pending.
         return () ->
         {
-            _stream.reset(new ResetFrame(_stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.NOOP);
-            _stream.getSession().flush(Callback.from(() ->
+            _stream.reset(new ResetFrame(_stream.getId(), ErrorCode.CANCEL_STREAM_ERROR.code), Callback.from(() ->
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("cancelSend reset and flushed");
+                    LOG.debug("cancelSend reset and flushed for {}", _stream);
                 appCallback.failed(cause);
             }));
         };

--- a/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
+++ b/jetty-core/jetty-io/src/main/java/org/eclipse/jetty/io/WriteFlusher.java
@@ -329,7 +329,7 @@ public abstract class WriteFlusher
         catch (Throwable e)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("write exception", e);
+                LOG.debug("write exception {}", this, e);
             if (updateState(__FLUSHING, new FailedState(e)))
                 callback.failed(e);
             else
@@ -364,10 +364,6 @@ public abstract class WriteFlusher
 
                 case IDLE:
                 case CANCELLING:
-                    for (Throwable t : suppressed)
-                    {
-                        LOG.warn("Failed Write Cause", t);
-                    }
                     return;
 
                 default:
@@ -422,7 +418,7 @@ public abstract class WriteFlusher
             if (buffers != null)
             {
                 if (LOG.isDebugEnabled())
-                    LOG.debug("flushed incomplete {}", BufferUtil.toDetailString(buffers));
+                    LOG.debug("flushed incomplete {} {}", BufferUtil.toDetailString(buffers), this);
                 if (buffers != pending._buffers)
                     pending = new PendingState(callback, address, buffers);
                 if (updateState(__COMPLETING, pending))
@@ -440,7 +436,7 @@ public abstract class WriteFlusher
         catch (Throwable e)
         {
             if (LOG.isDebugEnabled())
-                LOG.debug("completeWrite exception", e);
+                LOG.debug("completeWrite exception {}", this, e);
             if (updateState(__COMPLETING, new FailedState(e)))
                 callback.failed(e);
             else
@@ -524,12 +520,8 @@ public abstract class WriteFlusher
                 case CANCEL:
                 case CANCELLING:
                 case FAILED:
-                    if (LOG.isDebugEnabled())
-                    {
-                        LOG.debug("ignored: {} {}", cause, this);
-                        if (LOG.isTraceEnabled())
-                            LOG.trace("IGNORED", cause);
-                    }
+                    if (LOG.isTraceEnabled())
+                        LOG.trace("IGNORED {}", this, cause);
                     return false;
 
                 case PENDING:


### PR DESCRIPTION
* Improved logging.
* Using ExceptionUtil to combine exceptions.
* Deprecated HTTP2Session.flush(), used only once and not necessary.