### PR TITLE
13.0.x: Add RFC 10008 (The HTTP QUERY Method) support

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpRedirector.java
@@ -263,7 +263,7 @@ public class HttpRedirector
         {
             case HttpStatus.MOVED_PERMANENTLY_301 ->
             {
-                if (HttpMethod.GET.is(method) || HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method))
+                if (HttpMethod.GET.is(method) || HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method) || HttpMethod.QUERY.is(method))
                     yield method;
                 else if (HttpMethod.POST.is(method))
                     yield HttpMethod.GET.asString();
@@ -271,7 +271,7 @@ public class HttpRedirector
             }
             case HttpStatus.MOVED_TEMPORARILY_302 ->
             {
-                if (HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method))
+                if (HttpMethod.HEAD.is(method) || HttpMethod.PUT.is(method) || HttpMethod.QUERY.is(method))
                     yield method;
                 else
                     yield HttpMethod.GET.asString();

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientRedirectTest.java
@@ -439,6 +439,41 @@ public class HttpClientRedirectTest extends AbstractHttpClientServerTest
 
     @ParameterizedTest
     @ArgumentsSource(ScenarioProvider.class)
+    public void testQUERY301(Scenario scenario) throws Exception
+    {
+        testSameMethodRedirect(scenario, HttpMethod.QUERY, HttpStatus.MOVED_PERMANENTLY_301);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testQUERY302(Scenario scenario) throws Exception
+    {
+        testSameMethodRedirect(scenario, HttpMethod.QUERY, HttpStatus.FOUND_302);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testQUERY303(Scenario scenario) throws Exception
+    {
+        testGETRedirect(scenario, HttpMethod.QUERY, HttpStatus.SEE_OTHER_303);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testQUERY307(Scenario scenario) throws Exception
+    {
+        testSameMethodRedirect(scenario, HttpMethod.QUERY, HttpStatus.TEMPORARY_REDIRECT_307);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testQUERY308(Scenario scenario) throws Exception
+    {
+        testSameMethodRedirect(scenario, HttpMethod.QUERY, HttpStatus.PERMANENT_REDIRECT_308);
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
     public void testHttpRedirector(Scenario scenario) throws Exception
     {
         start(scenario, new RedirectHandler());

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpGenerator.java
@@ -56,6 +56,7 @@ public class HttpGenerator
         .caseSensitive(false)
         .with(HttpMethod.POST.asString(), Boolean.TRUE)
         .with(HttpMethod.PUT.asString(), Boolean.TRUE)
+        .with(HttpMethod.QUERY.asString(), Boolean.TRUE)
         .build();
 
     // states

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpHeader.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpHeader.java
@@ -88,6 +88,7 @@ public enum HttpHeader
     /**
      * Response Fields.
      */
+    ACCEPT_QUERY("Accept-Query"),
     ACCEPT_RANGES("Accept-Ranges"),
     ACCESS_CONTROL_ALLOW_ORIGIN("Access-Control-Allow-Origin"),
     ACCESS_CONTROL_ALLOW_METHODS("Access-Control-Allow-Methods"),

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpMethod.java
@@ -52,6 +52,7 @@ public enum HttpMethod
     PROPFIND(Type.SAFE),
     PROPPATCH(Type.IDEMPOTENT),
     PUT(Type.IDEMPOTENT),
+    QUERY(Type.SAFE),
     REBIND(Type.IDEMPOTENT),
     REPORT(Type.SAFE),
     SEARCH(Type.SAFE),

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/HttpConfiguration.java
@@ -125,6 +125,7 @@ public class HttpConfiguration implements Dumpable
     {
         _formEncodedMethods.put(HttpMethod.POST.asString(), Boolean.TRUE);
         _formEncodedMethods.put(HttpMethod.PUT.asString(), Boolean.TRUE);
+        _formEncodedMethods.put(HttpMethod.QUERY.asString(), Boolean.TRUE);
     }
 
     /**

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/BufferedResponseHandler.java
@@ -80,6 +80,7 @@ public class BufferedResponseHandler extends ConditionalHandler.Abstract
         super(handler);
 
         includeMethod(HttpMethod.GET.asString());
+        includeMethod(HttpMethod.QUERY.asString());
 
         // Mimetypes are not a condition on the ConditionalHandler as they
         // are also check during response generation, once the type is known.

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/gzip/GzipHandler.java
@@ -84,6 +84,7 @@ public class GzipHandler extends Handler.Wrapper implements GzipFactory
         super(handler);
         _methods.include(HttpMethod.GET.asString());
         _methods.include(HttpMethod.POST.asString());
+        _methods.include(HttpMethod.QUERY.asString());
         for (String type : MimeTypes.DEFAULTS.getMimeMap().values())
         {
             if ("image/svg+xml".equals(type))

--- a/jetty-ee/jetty-ee-servlet/src/test/java/org/eclipse/jetty/ee/servlet/RequestTest.java
+++ b/jetty-ee/jetty-ee-servlet/src/test/java/org/eclipse/jetty/ee/servlet/RequestTest.java
@@ -713,6 +713,50 @@ public class RequestTest
             """));
     }
 
+    @Test
+    public void testQueryParameters() throws Exception
+    {
+        final AtomicReference<String> parameterMap = new AtomicReference<>();
+
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse resp) throws IOException
+            {
+                parameterMap.set(request.getParameterMap().toString());
+                PrintWriter out = resp.getWriter();
+                out.println(request.getParameter("a"));
+                out.println(request.getParameterValues("a")[1]);
+                out.println(request.getParameterValues("a")[2]);
+                out.println(Arrays.asList(request.getParameterValues("b")));
+                out.println(Arrays.asList(request.getParameterValues("c")));
+                out.println(Arrays.asList(request.getParameterValues("d")));
+            }
+        });
+
+        String rawResponse = _connector.getResponse(
+            """
+                QUERY /test/parameters?a=1&a=2&b=one&c= HTTP/1.1\r
+                Host: localhost\r
+                Connection: close\r
+                Content-Type: application/x-www-form-urlencoded\r
+                Content-Length: 23\r
+                \r
+                a=3&b=two&b=three&d=xyz\r
+                """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(parameterMap.get(), is("{a=[1, 2, 3],b=[one, two, three],c=[],d=[xyz]}"));
+        assertThat(response.getContent().replace("\r\n", "\n"), is("""
+            1
+            2
+            3
+            [one, two, three]
+            []
+            [xyz]
+            """));
+    }
+
     static Stream<Arguments> suspiciousCharactersLegacy()
     {
         return Stream.of(

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/BufferedResponseHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/BufferedResponseHandler.java
@@ -64,6 +64,7 @@ public class BufferedResponseHandler extends HandlerWrapper
     public BufferedResponseHandler()
     {
         _methods.include(HttpMethod.GET.asString());
+        _methods.include(HttpMethod.QUERY.asString());
         for (String type : MimeTypes.DEFAULTS.getMimeMap().values())
         {
             if (type.startsWith("image/") ||


### PR DESCRIPTION
This change adds support for RFC 10008 (QUERY HTTP Method).

Changes applied:
  1. HttpMethod: Registered QUERY safe/idempotent method.
  2. HttpHeader: Registered Accept-Query response header.
  3. HttpGenerator: Registered QUERY as an assumed-content method.
  4. HttpConfiguration: Added QUERY to default `_formEncodedMethods` to support form parameter extraction in body.
  5. HttpRedirector: Implemented QUERY redirection rules (keeps same method on 301/302, falls back to GET on 303).
  6. GzipHandler: Added QUERY to default compressed methods.
  7. BufferedResponseHandler: Added QUERY to default buffered methods.
  
  The tests location is a bit confusing but I tried to match the locations based on what is being tested.