### PR TITLE
12.1.x: Fix deadlock in `HttpOutput.close()`

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -493,7 +493,8 @@ public class HttpOutput extends ServletOutputStream
     public void close() throws IOException
     {
         RetainableByteBuffer content = null;
-        Blocker.Callback blocker = null;
+        boolean acquireBlocker = false;
+        boolean combineClosedCallback = false;
         try (AutoLock ignored = _channelState.lock())
         {
             if (_softClose)
@@ -522,8 +523,8 @@ public class HttpOutput extends ServletOutputStream
                         case BLOCKING:
                         case BLOCKED:
                             // block until CLOSED state reached.
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         default:
@@ -540,7 +541,7 @@ public class HttpOutput extends ServletOutputStream
                             // Output is idle blocking state, but we still do an async close
                             _apiState = ApiState.BLOCKED;
                             _state = State.CLOSING;
-                            blocker = _writeBlocker.callback();
+                            acquireBlocker = true;
                             aggregate = _aggregate;
                             if (aggregate != null && aggregate.hasRemaining())
                             {
@@ -559,8 +560,8 @@ public class HttpOutput extends ServletOutputStream
                             // then trigger a close from onWriteComplete
                             _state = State.CLOSE;
                             // and block until it is complete
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         case ASYNC:
@@ -590,9 +591,36 @@ public class HttpOutput extends ServletOutputStream
                     }
                     break;
             }
+        }
 
-            if (LOG.isDebugEnabled())
+        // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
+        Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
+
+        if (combineClosedCallback)
+        {
+            try (AutoLock ignored = _channelState.lock())
+            {
+                // Check if onWriteComplete fired while the lock was not held; when it does,
+                // it nulls _closedCallback so no blocking is needed anymore.
+                if (_closedCallback != null)
+                {
+                    _closedCallback = Callback.combine(_closedCallback, blocker);
+                }
+                else
+                {
+                    blocker.succeeded();
+                    blocker.close();
+                    blocker = null;
+                }
+            }
+        }
+
+        if (LOG.isDebugEnabled())
+        {
+            try (AutoLock ignored = _channelState.lock())
+            {
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
+            }
         }
 
         if (content == null)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -596,26 +596,28 @@ public class HttpOutput extends ServletOutputStream
         // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
         Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
 
+        boolean releaseBlocker = false;
         try (AutoLock ignored = _channelState.lock())
         {
             if (combineClosedCallback)
             {
-                // Check if onWriteComplete fired while the lock was not held; when it does,
-                // it nulls _closedCallback so no blocking is needed anymore.
+                // Check if onWriteComplete() fired while the lock was not held; if it did, it nulled the
+                // _closedCallback field so blocking is not necessary anymore, and the blocker can be released.
                 if (_closedCallback != null)
-                {
                     _closedCallback = Callback.combine(_closedCallback, blocker);
-                }
                 else
-                {
-                    blocker.succeeded();
-                    blocker.close();
-                    blocker = null;
-                }
+                    releaseBlocker = true;
             }
 
             if (LOG.isDebugEnabled())
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
+        }
+
+        if (releaseBlocker)
+        {
+            blocker.succeeded();
+            blocker.close();
+            blocker = null;
         }
 
         if (content == null)
@@ -624,7 +626,8 @@ public class HttpOutput extends ServletOutputStream
                 // nothing to do or block for.
                 return;
 
-            // Just wait for some other close to finish.
+            // Just wait for some other close()/complete(Callback) to finish,
+            // as the blocker has been combined into the _closedCallback field.
             try (Blocker.Callback cb = blocker)
             {
                 cb.block();
@@ -634,14 +637,14 @@ public class HttpOutput extends ServletOutputStream
         {
             if (blocker == null)
             {
-                // Do an async close
+                // Do an async close.
                 Callback callback = new WriteCompleteCB();
                 callback = Callback.from(callback, content::release);
                 channelWrite(content, true, callback);
             }
             else
             {
-                // Do a blocking close
+                // Do a blocking close.
                 try (Blocker.Callback b = blocker)
                 {
                     channelWrite(content, true, blocker);

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -596,9 +596,9 @@ public class HttpOutput extends ServletOutputStream
         // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
         Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
 
-        if (combineClosedCallback)
+        try (AutoLock ignored = _channelState.lock())
         {
-            try (AutoLock ignored = _channelState.lock())
+            if (combineClosedCallback)
             {
                 // Check if onWriteComplete fired while the lock was not held; when it does,
                 // it nulls _closedCallback so no blocking is needed anymore.
@@ -613,14 +613,9 @@ public class HttpOutput extends ServletOutputStream
                     blocker = null;
                 }
             }
-        }
 
-        if (LOG.isDebugEnabled())
-        {
-            try (AutoLock ignored = _channelState.lock())
-            {
+            if (LOG.isDebugEnabled())
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
-            }
         }
 
         if (content == null)

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputBlockingTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputBlockingTest.java
@@ -1,0 +1,129 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HttpOutputBlockingTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        executorService = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        executorService.shutdownNow();
+        server.stop();
+    }
+
+    @Test
+    public void testConcurrentCloseDeadlock() throws Exception
+    {
+        final int concurrentCloses = 100;
+        final int concurrentRequests = 100;
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        ServletContextHandler handler = new ServletContextHandler("/");
+        handler.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                OutputStream out = resp.getOutputStream();
+                out.write("OK".getBytes(StandardCharsets.UTF_8));
+
+                for (int i = 0; i < concurrentCloses; i++)
+                {
+                    Future<Object> f = executorService.submit(() ->
+                    {
+                        out.close();
+                        return null;
+                    });
+                    futures.add(f);
+                }
+
+                for (Future<?> future : futures)
+                {
+                    try
+                    {
+                        future.get();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }), "/path/*");
+        server.setHandler(handler);
+        server.start();
+
+        StringBuilder request = new StringBuilder();
+        request.append("GET /path/ HTTP/1.1\r\n")
+            .append("Host: localhost\r\n")
+            .append("\r\n");
+
+        int port = connector.getLocalPort();
+        try (Socket socket = new Socket("localhost", port))
+        {
+            socket.setSoTimeout(10000);
+            for (int i = 0; i < concurrentRequests; i++)
+            {
+                OutputStream out = socket.getOutputStream();
+                out.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+
+                HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+                assertThat(response, notNullValue());
+                assertThat(response.getStatus(), is(200));
+                assertThat(response.getContent(), containsString("OK"));
+            }
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> futures.stream().allMatch(Future::isDone));
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -609,9 +609,9 @@ public class HttpOutput extends ServletOutputStream
         // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
         Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
 
-        if (combineClosedCallback)
+        try (AutoLock ignored = _channelState.lock())
         {
-            try (AutoLock ignored = _channelState.lock())
+            if (combineClosedCallback)
             {
                 // Check if onWriteComplete fired while the lock was not held; when it does,
                 // it nulls _closedCallback so no blocking is needed anymore.
@@ -626,14 +626,9 @@ public class HttpOutput extends ServletOutputStream
                     blocker = null;
                 }
             }
-        }
 
-        if (LOG.isDebugEnabled())
-        {
-            try (AutoLock ignored = _channelState.lock())
-            {
+            if (LOG.isDebugEnabled())
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
-            }
         }
 
         if (content == null)

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -609,26 +609,28 @@ public class HttpOutput extends ServletOutputStream
         // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
         Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
 
+        boolean releaseBlocker = false;
         try (AutoLock ignored = _channelState.lock())
         {
             if (combineClosedCallback)
             {
-                // Check if onWriteComplete fired while the lock was not held; when it does,
-                // it nulls _closedCallback so no blocking is needed anymore.
+                // Check if onWriteComplete() fired while the lock was not held; if it did, it nulled the
+                // _closedCallback field so blocking is not necessary anymore, and the blocker can be released.
                 if (_closedCallback != null)
-                {
                     _closedCallback = Callback.combine(_closedCallback, blocker);
-                }
                 else
-                {
-                    blocker.succeeded();
-                    blocker.close();
-                    blocker = null;
-                }
+                    releaseBlocker = true;
             }
 
             if (LOG.isDebugEnabled())
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
+        }
+
+        if (releaseBlocker)
+        {
+            blocker.succeeded();
+            blocker.close();
+            blocker = null;
         }
 
         if (content == null)
@@ -637,7 +639,8 @@ public class HttpOutput extends ServletOutputStream
                 // nothing to do or block for.
                 return;
 
-            // Just wait for some other close to finish.
+            // Just wait for some other close()/complete(Callback) to finish,
+            // as the blocker has been combined into the _closedCallback field.
             try (Blocker.Callback cb = blocker)
             {
                 cb.block();
@@ -647,14 +650,14 @@ public class HttpOutput extends ServletOutputStream
         {
             if (blocker == null)
             {
-                // Do an async close
+                // Do an async close.
                 Callback callback = new WriteCompleteCB();
                 callback = Callback.from(callback, content::release);
                 channelWrite(content, true, callback);
             }
             else
             {
-                // Do a blocking close
+                // Do a blocking close.
                 try (Blocker.Callback b = blocker)
                 {
                     channelWrite(content, true, blocker);

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -159,7 +159,7 @@ public class HttpOutput extends ServletOutputStream
 
     /**
      * @return The bytes written via the {@link jakarta.servlet.http.HttpServletResponse} API.  This
-     * may differ from the bytes reported by {@link org.eclipse.jetty.server.Response#getContentBytesWritten(Response)}
+     * may differ from the bytes reported by {@link Response#getContentBytesWritten(Response)}
      * due to buffering, compression, other interception or writes that bypass the servlet API.
      */
     public long getWritten()
@@ -362,7 +362,7 @@ public class HttpOutput extends ServletOutputStream
 
     public ByteBuffer takeContentAndClose()
     {
-        try (AutoLock l = _channelState.lock())
+        try (AutoLock ignored = _channelState.lock())
         {
             if (_state != State.OPEN)
                 throw new IllegalStateException(lockedStateString());
@@ -506,7 +506,8 @@ public class HttpOutput extends ServletOutputStream
     public void close() throws IOException
     {
         RetainableByteBuffer content = null;
-        Blocker.Callback blocker = null;
+        boolean acquireBlocker = false;
+        boolean combineClosedCallback = false;
         try (AutoLock ignored = _channelState.lock())
         {
             if (_softClose)
@@ -535,8 +536,8 @@ public class HttpOutput extends ServletOutputStream
                         case BLOCKING:
                         case BLOCKED:
                             // block until CLOSED state reached.
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         default:
@@ -553,7 +554,7 @@ public class HttpOutput extends ServletOutputStream
                             // Output is idle blocking state, but we still do an async close
                             _apiState = ApiState.BLOCKED;
                             _state = State.CLOSING;
-                            blocker = _writeBlocker.callback();
+                            acquireBlocker = true;
                             aggregate = _aggregate;
                             if (aggregate != null && aggregate.hasRemaining())
                             {
@@ -572,8 +573,8 @@ public class HttpOutput extends ServletOutputStream
                             // then trigger a close from onWriteComplete
                             _state = State.CLOSE;
                             // and block until it is complete
-                            blocker = _writeBlocker.callback();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         case ASYNC:
@@ -603,9 +604,36 @@ public class HttpOutput extends ServletOutputStream
                     }
                     break;
             }
+        }
 
-            if (LOG.isDebugEnabled())
+        // Do not call _writeBlocker.callback() from within a lock as it itself also takes a lock.
+        Blocker.Callback blocker = acquireBlocker ? _writeBlocker.callback() : null;
+
+        if (combineClosedCallback)
+        {
+            try (AutoLock ignored = _channelState.lock())
+            {
+                // Check if onWriteComplete fired while the lock was not held; when it does,
+                // it nulls _closedCallback so no blocking is needed anymore.
+                if (_closedCallback != null)
+                {
+                    _closedCallback = Callback.combine(_closedCallback, blocker);
+                }
+                else
+                {
+                    blocker.succeeded();
+                    blocker.close();
+                    blocker = null;
+                }
+            }
+        }
+
+        if (LOG.isDebugEnabled())
+        {
+            try (AutoLock ignored = _channelState.lock())
+            {
                 LOG.debug("close() {} c={} b={}", lockedStateString(), content, blocker);
+            }
         }
 
         if (content == null)

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputBlockingTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputBlockingTest.java
@@ -1,0 +1,129 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HttpOutputBlockingTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        executorService = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        executorService.shutdownNow();
+        server.stop();
+    }
+
+    @Test
+    public void testConcurrentCloseDeadlock() throws Exception
+    {
+        final int concurrentCloses = 100;
+        final int concurrentRequests = 100;
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        ServletContextHandler handler = new ServletContextHandler("/");
+        handler.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException
+            {
+                OutputStream out = resp.getOutputStream();
+                out.write("OK".getBytes(StandardCharsets.UTF_8));
+
+                for (int i = 0; i < concurrentCloses; i++)
+                {
+                    Future<Object> f = executorService.submit(() ->
+                    {
+                        out.close();
+                        return null;
+                    });
+                    futures.add(f);
+                }
+
+                for (Future<?> future : futures)
+                {
+                    try
+                    {
+                        future.get();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        }), "/path/*");
+        server.setHandler(handler);
+        server.start();
+
+        StringBuilder request = new StringBuilder();
+        request.append("GET /path/ HTTP/1.1\r\n")
+            .append("Host: localhost\r\n")
+            .append("\r\n");
+
+        int port = connector.getLocalPort();
+        try (Socket socket = new Socket("localhost", port))
+        {
+            socket.setSoTimeout(10000);
+            for (int i = 0; i < concurrentRequests; i++)
+            {
+                OutputStream out = socket.getOutputStream();
+                out.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+
+                HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+                assertThat(response, notNullValue());
+                assertThat(response.getStatus(), is(200));
+                assertThat(response.getContent(), containsString("OK"));
+            }
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> futures.stream().allMatch(Future::isDone));
+    }
+}

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -606,28 +606,28 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         // Do not call _writeBlocker.acquire() from within a lock as it itself also takes a lock.
         Blocker blocker = acquireBlocker ? _writeBlocker.acquire() : null;
 
+        boolean releaseBlocker = false;
         try (AutoLock l = _channelState.lock())
         {
             if (combineClosedCallback)
             {
-                // Check if onWriteComplete fired while the lock was not held; when it does,
-                // it nulls _closedCallback so no blocking is needed anymore.
+                // Check if onWriteComplete() fired while the lock was not held; if it did, it nulled the
+                // _closedCallback field so blocking is not necessary anymore, and the blocker can be released.
                 if (_closedCallback != null)
-                {
                     _closedCallback = Callback.combine(_closedCallback, blocker);
-                }
                 else
-                {
-                    // Here, combineClosedCallback is only ever true if acquireBlocker is also true,
-                    // so blocker can never be null.
-                    blocker.succeeded();
-                    blocker.close();
-                    blocker = null;
-                }
+                    releaseBlocker = true;
             }
 
             if (LOG.isDebugEnabled())
                 LOG.debug("close() {} c={} b={}", stateString(), BufferUtil.toDetailString(content), blocker);
+        }
+
+        if (releaseBlocker)
+        {
+            blocker.succeeded();
+            blocker.close();
+            blocker = null;
         }
 
         if (content == null)
@@ -636,7 +636,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                 // nothing to do or block for.
                 return;
 
-            // Just wait for some other close to finish.
+            // Just wait for some other close()/complete(Callback) to finish,
+            // as the blocker has been combined into the _closedCallback field.
             try (Blocker b = blocker)
             {
                 b.block();
@@ -646,12 +647,12 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         {
             if (blocker == null)
             {
-                // Do an async close
+                // Do an async close.
                 channelWrite(content, true, new WriteCompleteCB());
             }
             else
             {
-                // Do a blocking close
+                // Do a blocking close.
                 try (Blocker b = blocker)
                 {
                     channelWrite(content, true, blocker);

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -525,7 +525,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     public void close() throws IOException
     {
         ByteBuffer content = null;
-        Blocker blocker = null;
+        boolean acquireBlocker = false;
+        boolean combineClosedCallback = false;
         try (AutoLock l = _channelState.lock())
         {
             if (_onError != null)
@@ -551,8 +552,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                         case BLOCKING:
                         case BLOCKED:
                             // block until CLOSED state reached.
-                            blocker = _writeBlocker.acquire();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         default:
@@ -568,7 +569,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             // Output is idle blocking state, but we still do an async close
                             _apiState = ApiState.BLOCKED;
                             _state = State.CLOSING;
-                            blocker = _writeBlocker.acquire();
+                            acquireBlocker = true;
                             content = _aggregate != null && _aggregate.hasRemaining() ? _aggregate.getByteBuffer() : BufferUtil.EMPTY_BUFFER;
                             break;
 
@@ -578,8 +579,8 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             // then trigger a close from onWriteComplete
                             _state = State.CLOSE;
                             // and block until it is complete
-                            blocker = _writeBlocker.acquire();
-                            _closedCallback = Callback.combine(_closedCallback, blocker);
+                            acquireBlocker = true;
+                            combineClosedCallback = true;
                             break;
 
                         case ASYNC:
@@ -599,6 +600,30 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                             break;
                     }
                     break;
+            }
+        }
+
+        // Do not call _writeBlocker.acquire() from within a lock as it itself also takes a lock.
+        Blocker blocker = acquireBlocker ? _writeBlocker.acquire() : null;
+
+        if (combineClosedCallback)
+        {
+            try (AutoLock l = _channelState.lock())
+            {
+                // Check if onWriteComplete fired while the lock was not held; when it does,
+                // it nulls _closedCallback so no blocking is needed anymore.
+                if (_closedCallback != null)
+                {
+                    _closedCallback = Callback.combine(_closedCallback, blocker);
+                }
+                else
+                {
+                    // Here, combineClosedCallback is only ever true if acquireBlocker is also true,
+                    // so blocker can never be null.
+                    blocker.succeeded();
+                    blocker.close();
+                    blocker = null;
+                }
             }
         }
 

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -606,9 +606,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         // Do not call _writeBlocker.acquire() from within a lock as it itself also takes a lock.
         Blocker blocker = acquireBlocker ? _writeBlocker.acquire() : null;
 
-        if (combineClosedCallback)
+        try (AutoLock l = _channelState.lock())
         {
-            try (AutoLock l = _channelState.lock())
+            if (combineClosedCallback)
             {
                 // Check if onWriteComplete fired while the lock was not held; when it does,
                 // it nulls _closedCallback so no blocking is needed anymore.
@@ -625,10 +625,10 @@ public class HttpOutput extends ServletOutputStream implements Runnable
                     blocker = null;
                 }
             }
-        }
 
-        if (LOG.isDebugEnabled())
-            LOG.debug("close() {} c={} b={}", stateString(), BufferUtil.toDetailString(content), blocker);
+            if (LOG.isDebugEnabled())
+                LOG.debug("close() {} c={} b={}", stateString(), BufferUtil.toDetailString(content), blocker);
+        }
 
         if (content == null)
         {

--- a/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputBlockingTest.java
+++ b/jetty-ee9/jetty-ee9-nested/src/test/java/org/eclipse/jetty/ee9/nested/HttpOutputBlockingTest.java
@@ -1,0 +1,132 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.nested;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.core.Is.is;
+
+public class HttpOutputBlockingTest
+{
+    private Server server;
+    private ServerConnector connector;
+    private ContextHandler context;
+    private ExecutorService executorService;
+
+    @BeforeEach
+    public void setUp()
+    {
+        server = new Server();
+        connector = new ServerConnector(server);
+        server.addConnector(connector);
+
+        context = new ContextHandler(server, "/ctx");
+        executorService = Executors.newFixedThreadPool(16);
+    }
+
+    @AfterEach
+    public void tearDown() throws Exception
+    {
+        executorService.shutdownNow();
+        server.stop();
+    }
+
+    @Test
+    public void testConcurrentCloseDeadlock() throws Exception
+    {
+        final int concurrentCloses = 100;
+        final int concurrentRequests = 100;
+        List<Future<?>> futures = new CopyOnWriteArrayList<>();
+        AbstractHandler handler = new AbstractHandler()
+        {
+            @Override
+            public void handle(String target, Request baseRequest, HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                baseRequest.setHandled(true);
+                HttpOutput out = (HttpOutput)response.getOutputStream();
+                out.write("OK".getBytes(StandardCharsets.UTF_8));
+
+
+                for (int i = 0; i < concurrentCloses; i++)
+                {
+                    Future<Object> f = executorService.submit(() ->
+                    {
+                        out.close();
+                        return null;
+                    });
+                    futures.add(f);
+                }
+
+                for (Future<?> future : futures)
+                {
+                    try
+                    {
+                        future.get();
+                    }
+                    catch (Exception e)
+                    {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+        };
+
+        context.setHandler(handler);
+        server.start();
+
+        StringBuilder request = new StringBuilder();
+        request.append("GET /ctx/path/info HTTP/1.1\r\n")
+            .append("Host: localhost\r\n")
+            .append("\r\n");
+
+        int port = connector.getLocalPort();
+        try (Socket socket = new Socket("localhost", port))
+        {
+            socket.setSoTimeout(10000);
+            for (int i = 0; i < concurrentRequests; i++)
+            {
+                OutputStream out = socket.getOutputStream();
+                out.write(request.toString().getBytes(StandardCharsets.ISO_8859_1));
+
+                HttpTester.Response response = HttpTester.parseResponse(socket.getInputStream());
+                assertThat(response, notNullValue());
+                assertThat(response.getStatus(), is(200));
+                assertThat(response.getContent(), containsString("OK"));
+            }
+        }
+        await().atMost(5, TimeUnit.SECONDS).until(() -> futures.stream().allMatch(Future::isDone));
+    }
+}


### PR DESCRIPTION
Port https://github.com/jetty/jetty.project/pull/15270 to 12.1.x

Closes #15226