### PR TITLE
Upgrade quiche to version 0.29.2

### DIFF
--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-foreign/src/main/java/org/eclipse/jetty/quic/quiche/foreign/quiche_h.java
@@ -30,7 +30,7 @@ import static org.eclipse.jetty.quic.quiche.foreign.NativeHelper.C_POINTER;
 
 public class quiche_h
 {
-    private static final String EXPECTED_QUICHE_VERSION = "0.29.1";
+    private static final String EXPECTED_QUICHE_VERSION = "0.29.2";
     private static final Logger LOG = LoggerFactory.getLogger(quiche_h.class);
 
     static void initialize()
@@ -779,14 +779,6 @@ public class quiche_h
                 C_INT,
                 C_POINTER,
                 C_INT
-            ));
-        private static final MethodHandle quiche_conn_retired_scid_next = NativeHelper.downcallHandle(
-            "quiche_conn_retired_scid_next",
-            FunctionDescriptor.of(
-                C_BOOL,
-                C_POINTER,
-                C_POINTER,
-                C_POINTER
             ));
         private static final MethodHandle quiche_conn_retired_scids = NativeHelper.downcallHandle(
             "quiche_conn_retired_scids",
@@ -2166,18 +2158,6 @@ public class quiche_h
         try
         {
             return (long)DowncallHandles.quiche_conn_send_ack_eliciting_on_path.invokeExact(conn, local, local_len, peer, peer_len);
-        }
-        catch (Throwable x)
-        {
-            throw new AssertionError("should not reach here", x);
-        }
-    }
-
-    public static boolean quiche_conn_retired_scid_next(MemorySegment conn, MemorySegment out, MemorySegment out_len)
-    {
-        try
-        {
-            return (byte)DowncallHandles.quiche_conn_retired_scid_next.invokeExact(conn, out, out_len) != 0;
         }
         catch (Throwable x)
         {

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-jna/src/main/java/org/eclipse/jetty/quic/quiche/jna/LibQuiche.java
@@ -30,7 +30,7 @@ public interface LibQuiche extends Library
 {
     // This interface is a translation of the quiche.h header of a specific version.
     // It needs to be reviewed each time the native lib version changes.
-    String EXPECTED_QUICHE_VERSION = "0.29.1";
+    String EXPECTED_QUICHE_VERSION = "0.29.2";
 
     // The charset used to convert java.lang.String to char * and vice versa.
     Charset CHARSET = StandardCharsets.UTF_8;

--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <jboss.logging.processor.version>3.0.4.Final</jboss.logging.processor.version>
     <jboss.logging.version>3.6.3.Final</jboss.logging.version>
     <jetty-assembly-descriptors.version>1.1</jetty-assembly-descriptors.version>
-    <jetty-quiche-native.version>0.29.1</jetty-quiche-native.version>
+    <jetty-quiche-native.version>0.29.2</jetty-quiche-native.version>
     <jetty-test-policy.version>1.2</jetty-test-policy.version>
     <jetty-version.maven.plugin.version>2.7</jetty-version.maven.plugin.version>
     <jetty.perf-helper.version>1.0.7</jetty.perf-helper.version>


### PR DESCRIPTION
There was a breaking change in the C API, but it was only mapped by the Foreign binding and we don't use that method, so the mapping was simply removed. See: https://github.com/cloudflare/quiche/compare/0.29.1...0.29.2

Fixes https://github.com/jetty/jetty.project/issues/15333