### PR TITLE
Jetty 13.0.x - Reworked EE/Servlet/Websocket Version classes/enums

### DIFF
--- a/jetty-ee/jetty-ee-annotations/src/main/java/org/eclipse/jetty/ee/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee/jetty-ee-annotations/src/main/java/org/eclipse/jetty/ee/annotations/ResourceAnnotationHandler.java
@@ -24,7 +24,6 @@ import javax.naming.NamingException;
 
 import jakarta.annotation.Resource;
 import org.eclipse.jetty.ee.annotations.AnnotationIntrospector.AbstractIntrospectableAnnotationHandler;
-import org.eclipse.jetty.ee.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee.webapp.MetaData;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
 import org.eclipse.jetty.plus.annotation.Injection;
@@ -162,7 +161,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try environment scope next
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.getEnvironmentName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(_context.getEnvironmentName(), name, mappedName);
                     
                     //try Server scope next
                     if (!bound)
@@ -319,7 +318,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try the environment's scope
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.getEnvironmentName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(_context.getEnvironmentName(), name, mappedName);
                     
                     //try the server's scope
                     if (!bound)

--- a/jetty-ee/jetty-ee-annotations/src/main/java/org/eclipse/jetty/ee/annotations/ResourceAnnotationHandler.java
+++ b/jetty-ee/jetty-ee-annotations/src/main/java/org/eclipse/jetty/ee/annotations/ResourceAnnotationHandler.java
@@ -162,7 +162,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try environment scope next
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.ENVIRONMENT.getName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.getEnvironmentName(), name, mappedName);
                     
                     //try Server scope next
                     if (!bound)
@@ -319,7 +319,7 @@ public class ResourceAnnotationHandler extends AbstractIntrospectableAnnotationH
                     
                     //try the environment's scope
                     if (!bound)
-                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.ENVIRONMENT.getName(), name, mappedName);
+                        bound = NamingEntryUtil.bindToENC(ServletContextHandler.getEnvironmentName(), name, mappedName);
                     
                     //try the server's scope
                     if (!bound)

--- a/jetty-ee/jetty-ee-annotations/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-annotations/src/test/resources/jetty-logging.properties
@@ -4,6 +4,8 @@
 #org.eclipse.jetty.util.MultiReleaseJarFile.LEVEL=DEBUG
 #org.eclipse.jetty.util.resources.LEVEL=DEBUG
 #org.eclipse.jetty.ee.annotations.AnnotationParser.LEVEL=DEBUG
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN

--- a/jetty-ee/jetty-ee-apache-jsp/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-apache-jsp/src/test/resources/jetty-logging.properties
@@ -1,0 +1,4 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.webapp.LEVEL=DEBUG
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN

--- a/jetty-ee/jetty-ee-common/pom.xml
+++ b/jetty-ee/jetty-ee-common/pom.xml
@@ -46,6 +46,8 @@
         <extensions>true</extensions>
         <configuration>
           <instructions>
+            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.processor)";resolution:=optional,
+              osgi.serviceloader; filter:="(osgi.serviceloader=org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service)";resolution:=optional;cardinality:=multiple</Require-Capability>
             <DynamicImport-Package>jakarta.*</DynamicImport-Package>
           </instructions>
         </configuration>

--- a/jetty-ee/jetty-ee-common/src/main/java/module-info.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/module-info.java
@@ -20,4 +20,6 @@ module org.eclipse.jetty.ee.common
     requires java.instrument;
 
     exports org.eclipse.jetty.ee.common;
+
+    uses org.eclipse.jetty.ee.common.EnterpriseEditionVersion.Service;
 }

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/EnterpriseEditionVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/EnterpriseEditionVersion.java
@@ -13,23 +13,80 @@
 
 package org.eclipse.jetty.ee.common;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+
+import org.eclipse.jetty.util.TypeUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public enum EnterpriseEditionVersion
 {
-    ee10(10),
-    ee11(11);
+    /**
+     * EE10 is in use.
+     */
+    EE10(10, "ee10"),
+    /**
+     * EE11 is in use.
+     */
+    EE11(11, "ee11"),
+    /**
+     * EE12 is in use.
+     */
+    EE12(12, "ee12");
 
-    public static final EnterpriseEditionVersion currentVersion = initEnterpriseEditionVersion();
+    private static final Logger LOG = LoggerFactory.getLogger(EnterpriseEditionVersion.class);
 
+    /**
+     * Interface for service (via {@link java.util.ServiceLoader} to provide the {@link EnterpriseEditionVersion}.
+     */
+    public interface Service
+    {
+        /**
+         * Get the version.
+         *
+         * @return the {@link EnterpriseEditionVersion} if able to be returned, or {@code null} if this
+         * service is unable to provide the version.
+         */
+        EnterpriseEditionVersion getVersion();
+    }
+
+    /**
+     * Get the Jakarta EE Version.
+     *
+     * <p>
+     *     This version DOES NOT CACHE the result and will lookup the version every call.
+     *     It is strongly recommended that you do not store this value in a static variable, as that
+     *     can lead to improper/invalid caching of the value on OSGi.
+     * </p>
+     * @return the Jakarta EE Version.
+     */
     public static EnterpriseEditionVersion getEnterpriseEditionVersion()
     {
-        return currentVersion;
+        // Resolve lazily. A too-early lookup (eg: during OSGi boot bundle activation, before
+        // SPIFly has registered the EnterpriseEditionVersion.Service providers) finds nothing
+        // and must not be cached, otherwise the wrong default would be frozen forever.
+        EnterpriseEditionVersion version = lookupEnterpriseEditionVersion();
+        if (version != null)
+            return version;
+        // Default if no version discovered during lookup.
+        return EnterpriseEditionVersion.EE11;
     }
 
     private final int version;
+    private final String environmentName;
 
-    EnterpriseEditionVersion(int version)
+    EnterpriseEditionVersion(int version, String environmentName)
     {
         this.version = version;
+        this.environmentName = environmentName;
     }
 
     public int version()
@@ -37,20 +94,126 @@ public enum EnterpriseEditionVersion
         return version;
     }
 
-    private static EnterpriseEditionVersion initEnterpriseEditionVersion()
+    public String environmentName()
     {
+        return this.environmentName;
+    }
+
+    /**
+     * The classpath resource that, when present in an environment's {@link ClassLoader}, declares the
+     * Jakarta {@link EnterpriseEditionVersion} of that environment via an {@code environment=<name>}
+     * property (eg: {@code environment=ee11}). It is contributed by the per-environment modules
+     * (eg: {@code jetty-ee11-servlet}).
+     */
+    public static final String ENVIRONMENT_PROPERTIES = "META-INF/org.eclipse.jetty/env.properties";
+
+    private static EnterpriseEditionVersion lookupEnterpriseEditionVersion()
+    {
+        // (1) Standard and JPMS distributions declare the environment with the ENVIRONMENT_PROPERTIES
+        //     marker placed in the per-environment ClassLoader. It MUST be read via the thread context
+        //     ClassLoader: during deployment, configuration and request handling that is the
+        //     per-environment ClassLoader. The ClassLoader that defined this class cannot be relied on,
+        //     because under JPMS jetty-ee-common is a single shared module whose ClassLoader cannot see
+        //     the per-environment marker (it lives in a child environment layer).
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        EnterpriseEditionVersion version = fromEnvironmentMarker(contextClassLoader);
+        if (version == null)
+        {
+            ClassLoader localClassLoader = EnterpriseEditionVersion.class.getClassLoader();
+            if (localClassLoader != contextClassLoader)
+                version = fromEnvironmentMarker(localClassLoader);
+        }
+        if (version != null)
+            return version;
+
+        // (2) OSGi registers EnterpriseEditionVersion.Service providers (eg: EnterpriseEdition11Service)
+        //     per environment bundle via SPIFly. Discover them via ServiceLoader against the context
+        //     ClassLoader. serviceStream(...) skips (rather than aborts on) any provider that a foreign
+        //     ClassLoader makes ServiceLoader reject (eg: "not a subtype" / "Provider not found").
+        version = TypeUtil.serviceStream(ServiceLoader.load(Service.class, contextClassLoader))
+            .map(Service::getVersion)
+            .filter(Objects::nonNull)
+            .findFirst()
+            .orElse(null);
+        if (version != null)
+            return version;
+
+        // No environment discovered during lookup.
+        if (LOG.isInfoEnabled())
+            LOG.info("EnterpriseEditionVersion not found in environment and/or classloader, defaulting to EE11");
+        return null;
+    }
+
+    /**
+     * Detect the {@link EnterpriseEditionVersion} from the {@link #ENVIRONMENT_PROPERTIES} marker
+     * visible to the given {@link ClassLoader}.
+     *
+     * @param classLoader the ClassLoader to inspect, may be {@code null}
+     * @return the detected version, or {@code null} if no single, recognized marker was found
+     */
+    public static EnterpriseEditionVersion fromEnvironmentMarker(ClassLoader classLoader)
+    {
+        if (classLoader == null)
+            return null;
+
         try
         {
-            return switch (ServletApiVersion.getServletApiVersion())
+            List<URL> hits = Collections.list(classLoader.getResources(ENVIRONMENT_PROPERTIES));
+            if (hits.isEmpty())
             {
-                case v6_0 -> ee10;
-                case v6_1 -> ee11;
-                default -> null;
-            };
+                if (LOG.isDebugEnabled())
+                    LOG.debug("No {} resources found in {}", ENVIRONMENT_PROPERTIES, classLoader);
+                return null;
+            }
+            if (hits.size() > 1)
+            {
+                // Multiple environments visible to a single ClassLoader is ambiguous: do not guess.
+                if (LOG.isWarnEnabled())
+                    LOG.warn("Multiple environments detected in the same classloader: {}",
+                        hits.stream().map(URL::toString).collect(Collectors.joining(", ")));
+                return null;
+            }
+
+            URL url = hits.getFirst();
+            Properties props = new Properties();
+            try (InputStream in = url.openStream())
+            {
+                props.load(in);
+            }
+            String name = props.getProperty("environment");
+            EnterpriseEditionVersion version = fromEnvironmentName(name);
+            if (version == null)
+            {
+                if (LOG.isWarnEnabled())
+                    LOG.warn("Unrecognized Jetty environment [{}] in {}", name, url);
+            }
+            else if (LOG.isDebugEnabled())
+            {
+                LOG.debug("Found declared [environment={}] in {}", name, url);
+            }
+            return version;
         }
-        catch (Throwable e)
+        catch (IOException e)
         {
-            throw new RuntimeException(e);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Unable to read {} from {}", ENVIRONMENT_PROPERTIES, classLoader, e);
+            return null;
         }
+    }
+
+    /**
+     * @param environmentName the environment name (eg: {@code ee11}), case-insensitive
+     * @return the matching {@link EnterpriseEditionVersion}, or {@code null} if {@code null} or unrecognized
+     */
+    public static EnterpriseEditionVersion fromEnvironmentName(String environmentName)
+    {
+        if (environmentName == null)
+            return null;
+        for (EnterpriseEditionVersion version : values())
+        {
+            if (version.environmentName.equalsIgnoreCase(environmentName))
+                return version;
+        }
+        return null;
     }
 }

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/EnterpriseEditionVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/EnterpriseEditionVersion.java
@@ -76,6 +76,9 @@ public enum EnterpriseEditionVersion
         EnterpriseEditionVersion version = lookupEnterpriseEditionVersion();
         if (version != null)
             return version;
+        // No environment discovered during lookup.
+        if (LOG.isInfoEnabled())
+            LOG.info("EnterpriseEditionVersion not found in environment and/or classloader, defaulting to EE11");
         // Default if no version discovered during lookup.
         return EnterpriseEditionVersion.EE11;
     }
@@ -138,9 +141,6 @@ public enum EnterpriseEditionVersion
         if (version != null)
             return version;
 
-        // No environment discovered during lookup.
-        if (LOG.isInfoEnabled())
-            LOG.info("EnterpriseEditionVersion not found in environment and/or classloader, defaulting to EE11");
         return null;
     }
 

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/ServletApiVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/ServletApiVersion.java
@@ -13,21 +13,19 @@
 
 package org.eclipse.jetty.ee.common;
 
-import java.lang.module.ModuleDescriptor;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public enum ServletApiVersion
 {
-    v4_0("4.0"),
-    v5_0("5.0"),
-    v6_0("6.0"),
-    v6_1("6.1");
-
-    public static final ServletApiVersion currentVersion = initServletApiVersion();
+    V2_5("2.5"),
+    V3_0("3.0"),
+    V3_1("3.1"),
+    V4_0("4.0"),
+    V5_0("5.0"),
+    V6_0("6.0"),
+    V6_1("6.1"),
+    V6_2("6.2");
 
     private final String version;
     private final int major;
@@ -56,6 +54,61 @@ public enum ServletApiVersion
         return minor;
     }
 
+    public String getWebXmlAttributes()
+    {
+        return switch(this)
+        {
+            case V2_5 -> """
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
+                  version="2.5"
+                """;
+            case V3_0 -> """
+                  xmlns="http://java.sun.com/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
+                  version="3.0"
+                """;
+            case V3_1 -> """
+                  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+                  version="3.1"
+                """;
+            case V4_0 -> """
+                  xmlns="http://xmlns.jcp.org/xml/ns/javaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd"
+                  version="4.0"
+                """;
+            case V5_0 -> """
+                  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
+                  version="5.0"
+                """;
+            case V6_0 -> """
+                  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
+                  version="6.0"
+                """;
+            case V6_1 -> """
+                  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+                  version="6.1"
+                """;
+            case V6_2 -> """
+                  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_2.xsd"
+                  version="6.2"
+                """;
+        };
+    }
+
     public static ServletApiVersion from(String version)
     {
         ServletApiVersion servletApiVersion = Mapping.versions.get(version);
@@ -64,35 +117,25 @@ public enum ServletApiVersion
         return servletApiVersion;
     }
 
-    public static ServletApiVersion initServletApiVersion()
-    {
-        ClassLoader classLoader = ServletApiVersion.class.getClassLoader();
-        try
-        {
-            Class<?> loadedClass = classLoader.loadClass("jakarta.servlet.ServletRequest");
-            String specificationVersion = loadedClass.getPackage().getSpecificationVersion();
-            if (specificationVersion == null)
-            {
-                specificationVersion = classLoader.getDefinedPackage("jakarta.servlet").getSpecificationVersion();
-            }
-            if (specificationVersion == null)
-            {
-                specificationVersion = loadedClass.getModule().getDescriptor().version()
-                    .map(ModuleDescriptor.Version::toString)
-                    .map(version -> version.substring(0, version.lastIndexOf('.')))
-                    .orElse(null);
-            }
-            return ServletApiVersion.from(specificationVersion);
-        }
-        catch (ClassNotFoundException | NoClassDefFoundError e)
-        {
-            throw new IllegalStateException("Cannot detect servlet API version", e);
-        }
-    }
-
+    /**
+     * Get the Servlet API Version.
+     *
+     * <p>
+     *     This version DOES NOT CACHE the result and will lookup the version every call.
+     *     It is strongly recommended that you do not store this value in a static variable, as that
+     *     can lead to improper/invalid caching of the value on OSGi.
+     * </p>
+     * @return the Servlet API version.
+     */
     public static ServletApiVersion getServletApiVersion()
     {
-        return currentVersion;
+        EnterpriseEditionVersion version1 = EnterpriseEditionVersion.getEnterpriseEditionVersion();
+        return switch (version1)
+        {
+            case EE10 -> V6_0;
+            case EE11 -> V6_1;
+            case EE12 -> V6_2;
+        };
     }
 
     private static class Mapping

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
@@ -13,22 +13,15 @@
 
 package org.eclipse.jetty.ee.common;
 
-import java.lang.module.ModuleDescriptor;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public enum WebsocketApiVersion
 {
-    v2_0("2.0"),
-    v2_1("2.1"),
-    v2_2("2.2");
+    V2_0("2.0"),
+    V2_1("2.1"),
+    V2_2("2.2");
 
-    public static final WebsocketApiVersion currentVersion = initWebsocketApiVersion();
-
-    private static Logger LOG = LoggerFactory.getLogger(WebsocketApiVersion.class);
     private final String version;
     private final int major;
     private final int minor;
@@ -64,35 +57,25 @@ public enum WebsocketApiVersion
         return servletApiVersion;
     }
 
-    public static WebsocketApiVersion initWebsocketApiVersion()
-    {
-        ClassLoader classLoader = WebsocketApiVersion.class.getClassLoader();
-        try
-        {
-            Class<?> loadedClass = classLoader.loadClass("jakarta.websocket.Session");
-            String specificationVersion = loadedClass.getPackage().getSpecificationVersion();
-            if (specificationVersion == null)
-            {
-                specificationVersion = classLoader.getDefinedPackage("jakarta.websocket").getSpecificationVersion();
-            }
-            if (specificationVersion == null)
-            {
-                specificationVersion = loadedClass.getModule().getDescriptor().version()
-                    .map(ModuleDescriptor.Version::toString)
-                    .map(version -> version.substring(0, version.lastIndexOf('.')))
-                    .orElse(null);
-            }
-            return WebsocketApiVersion.from(specificationVersion);
-        }
-        catch (ClassNotFoundException | NoClassDefFoundError e)
-        {
-            throw new IllegalStateException("Cannot detect websocket API version", e);
-        }
-    }
-
+    /**
+     * Get the WebSocket API Version.
+     *
+     * <p>
+     *     This version DOES NOT CACHE the result and will lookup the version every call.
+     *     It is strongly recommended that you do not store this value in a static variable, as that
+     *     can lead to improper/invalid caching of the value on OSGi.
+     * </p>
+     * @return the WebSocket API version.
+     */
     public static WebsocketApiVersion getWebsocketApiVersion()
     {
-        return currentVersion;
+        EnterpriseEditionVersion version1 = EnterpriseEditionVersion.getEnterpriseEditionVersion();
+        return switch (version1)
+        {
+            case EE10 -> V2_0;
+            case EE11 -> V2_1;
+            case EE12 -> V2_2;
+        };
     }
 
     private static class Mapping

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
@@ -18,7 +18,6 @@ import java.util.Map;
 
 public enum WebsocketApiVersion
 {
-    V2_0("2.0"),
     V2_1("2.1"),
     V2_2("2.2"),
     V2_3("2.3");

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/WebsocketApiVersion.java
@@ -20,7 +20,8 @@ public enum WebsocketApiVersion
 {
     V2_0("2.0"),
     V2_1("2.1"),
-    V2_2("2.2");
+    V2_2("2.2"),
+    V2_3("2.3");
 
     private final String version;
     private final int major;
@@ -72,9 +73,9 @@ public enum WebsocketApiVersion
         EnterpriseEditionVersion version1 = EnterpriseEditionVersion.getEnterpriseEditionVersion();
         return switch (version1)
         {
-            case EE10 -> V2_0;
-            case EE11 -> V2_1;
-            case EE12 -> V2_2;
+            case EE10 -> V2_1;
+            case EE11 -> V2_2;
+            case EE12 -> V2_3;
         };
     }
 

--- a/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/internal/EnterpriseEditionMetaInfEnvService.java
+++ b/jetty-ee/jetty-ee-common/src/main/java/org/eclipse/jetty/ee/common/internal/EnterpriseEditionMetaInfEnvService.java
@@ -1,0 +1,43 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee.common.internal;
+
+import org.eclipse.jetty.ee.common.EnterpriseEditionVersion;
+
+/**
+ * {@link EnterpriseEditionVersion.Service} that derives the environment from the
+ * {@link EnterpriseEditionVersion#ENVIRONMENT_PROPERTIES} marker resource.
+ *
+ * <p>The marker lives in the per-environment {@link ClassLoader} (eg: the {@code jetty-ee11-servlet}
+ * module), so it is resolved via the {@link Thread#getContextClassLoader() thread context ClassLoader}
+ * which during deployment, configuration and request handling is that per-environment ClassLoader.
+ * The ClassLoader that defined this class cannot be used: under JPMS {@code jetty-ee-common} is a
+ * single shared module whose ClassLoader cannot see the per-environment marker.</p>
+ */
+public class EnterpriseEditionMetaInfEnvService implements EnterpriseEditionVersion.Service
+{
+    @Override
+    public EnterpriseEditionVersion getVersion()
+    {
+        ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+        EnterpriseEditionVersion version = EnterpriseEditionVersion.fromEnvironmentMarker(contextClassLoader);
+        if (version == null)
+        {
+            ClassLoader localClassLoader = getClass().getClassLoader();
+            if (localClassLoader != contextClassLoader)
+                version = EnterpriseEditionVersion.fromEnvironmentMarker(localClassLoader);
+        }
+        return version;
+    }
+}

--- a/jetty-ee/jetty-ee-common/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
+++ b/jetty-ee/jetty-ee-common/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
@@ -1,0 +1,1 @@
+org.eclipse.jetty.ee.common.internal.EnterpriseEditionMetaInfEnvService

--- a/jetty-ee/jetty-ee-demos/jetty-ee-demo-proxy-webapp/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-demos/jetty-ee-demo-proxy-webapp/src/test/resources/jetty-logging.properties
@@ -1,9 +1,10 @@
-org.eclipse.jetty.util.log.class=org.eclipse.jetty.util.log.StdErrLog
 #org.eclipse.jetty.LEVEL=WARN
 #org.eclipse.jetty.client.LEVEL=DEBUG
 #org.eclipse.jetty.http.LEVEL=DEBUG
 #org.eclipse.jetty.proxy.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-fcgi-proxy/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-fcgi-proxy/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.fcgi.proxy.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-glassfish-jstl/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-glassfish-jstl/src/test/resources/jetty-logging.properties
@@ -2,6 +2,8 @@
 # org.eclipse.jetty.LEVEL=INFO
 # org.eclipse.jetty.util.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-jaspi/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-jaspi/src/test/resources/jetty-logging.properties
@@ -1,0 +1,4 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.webapp.LEVEL=DEBUG
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN

--- a/jetty-ee/jetty-ee-maven-plugin/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-maven-plugin/src/test/resources/jetty-logging.properties
@@ -5,6 +5,8 @@
 #org.eclipse.jetty.http.LEVEL=DEBUG
 #org.eclipse.jetty.http.pathmap.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-osgi/jetty-ee-osgi-boot/src/main/java/org/eclipse/jetty/ee/osgi/boot/EEActivator.java
+++ b/jetty-ee/jetty-ee-osgi/jetty-ee-osgi-boot/src/main/java/org/eclipse/jetty/ee/osgi/boot/EEActivator.java
@@ -55,12 +55,13 @@ public class EEActivator extends AbstractEEActivator
 {
     private static final Logger LOG = LoggerFactory.getLogger(EEActivator.class);
 
-    public static final String ENVIRONMENT = EnterpriseEditionVersion.getEnterpriseEditionVersion().name();
-
     @Override
     public String getEnvironment()
     {
-        return ENVIRONMENT;
+        // Resolve lazily: capturing this in a static (or eager) field would run during this
+        // boot bundle's own activation, before SPIFly has registered the
+        // EnterpriseEditionVersion.Service providers, and would freeze the wrong environment.
+        return EnterpriseEditionVersion.getEnterpriseEditionVersion().environmentName();
     }
 
     @Override
@@ -143,7 +144,7 @@ public class EEActivator extends AbstractEEActivator
                             Map<String, String> properties = new HashMap<>();
                             properties.put(OSGiWebappConstants.JETTY_BUNDLE_ROOT, metadata.getPath().toUri().toString());
                             properties.put(OSGiServerConstants.JETTY_HOME, (String)server.getAttribute(OSGiServerConstants.JETTY_HOME));
-                            properties.put("environment", ENVIRONMENT);
+                            properties.put("environment", getEnvironment());
                             xmlConfiguration.getProperties().putAll(properties);
                             xmlConfiguration.configure(contextHandler);
                             return null;
@@ -321,7 +322,7 @@ public class EEActivator extends AbstractEEActivator
                             Map<String, String> properties = new HashMap<>();
                             properties.put(OSGiWebappConstants.JETTY_BUNDLE_ROOT, metadata.getPath().toUri().toString());
                             properties.put(OSGiServerConstants.JETTY_HOME, (String)server.getAttribute(OSGiServerConstants.JETTY_HOME));
-                            properties.put("environment", ENVIRONMENT);
+                            properties.put("environment", getEnvironment());
                             xmlConfiguration.getProperties().putAll(properties);
                             xmlConfiguration.configure(webApp);
                             return null;

--- a/jetty-ee/jetty-ee-osgi/test-jetty-ee-osgi/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-osgi/test-jetty-ee-osgi/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 org.eclipse.jetty.LEVEL=INFO
 #org.eclipse.jetty.ee.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/jndi/Transaction.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/jndi/Transaction.java
@@ -37,7 +37,7 @@ public class Transaction extends org.eclipse.jetty.plus.jndi.Transaction
     public Transaction(UserTransaction userTransaction)
         throws NamingException
     {
-        super(EnterpriseEditionVersion.getEnterpriseEditionVersion().name(), userTransaction);
+        super(EnterpriseEditionVersion.getEnterpriseEditionVersion().environmentName(), userTransaction);
     }
 
 }

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/EnvConfiguration.java
@@ -22,7 +22,6 @@ import javax.naming.NamingException;
 
 import org.eclipse.jetty.ee.common.EnterpriseEditionVersion;
 import org.eclipse.jetty.ee.common.WebAppClassLoader;
-import org.eclipse.jetty.ee.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee.webapp.AbstractConfiguration;
 import org.eclipse.jetty.ee.webapp.FragmentConfiguration;
 import org.eclipse.jetty.ee.webapp.JettyWebXmlConfiguration;
@@ -208,8 +207,8 @@ public class EnvConfiguration extends AbstractConfiguration
             LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
         if (LOG.isDebugEnabled())
-            LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.getEnvironmentName());
-        doBindings(envCtx, ServletContextHandler.getEnvironmentName());
+            LOG.debug("Binding env entries from environment {} scope", context.getEnvironmentName());
+        doBindings(envCtx, context.getEnvironmentName());
         if (LOG.isDebugEnabled())
             LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/EnvConfiguration.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/EnvConfiguration.java
@@ -49,7 +49,6 @@ public class EnvConfiguration extends AbstractConfiguration
     private static final Logger LOG = LoggerFactory.getLogger(EnvConfiguration.class);
 
     private static final String JETTY_ENV_BINDINGS = "org.eclipse.jetty.jndi.EnvConfiguration";
-    private static final String JETTY_EE_ENV_XML_FILENAME = "jetty-%s-env.xml".formatted(EnterpriseEditionVersion.getEnterpriseEditionVersion().name());
     private static final String JETTY_ENV_XML_FILENAME = "jetty-env.xml";
 
     public EnvConfiguration()
@@ -181,6 +180,13 @@ public class EnvConfiguration extends AbstractConfiguration
         }
     }
 
+    public String getJettyEeEnvXmlFilename()
+    {
+        // The use of EnterpriseEditionVersion.getEnterpriseEditionVersion() cannot occur during phases where
+        // the ClassLoader isn't used or isn't available yet (like OSGi boot activation)
+        return "jetty-%s-env.xml".formatted(EnterpriseEditionVersion.getEnterpriseEditionVersion().environmentName());
+    }
+
     /**
      * Bind all EnvEntries that have been declared, so that the processing of the
      * web.xml file can potentially override them.
@@ -202,8 +208,8 @@ public class EnvConfiguration extends AbstractConfiguration
             LOG.debug("Binding env entries from the server scope");
         doBindings(envCtx, context.getServer());
         if (LOG.isDebugEnabled())
-            LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.ENVIRONMENT.getName());
-        doBindings(envCtx, ServletContextHandler.ENVIRONMENT.getName());
+            LOG.debug("Binding env entries from environment {} scope", ServletContextHandler.getEnvironmentName());
+        doBindings(envCtx, ServletContextHandler.getEnvironmentName());
         if (LOG.isDebugEnabled())
             LOG.debug("Binding env entries from the context scope");
         doBindings(envCtx, context);
@@ -249,8 +255,8 @@ public class EnvConfiguration extends AbstractConfiguration
     }
 
     /**
-     * Obtain a WEB-INF/jetty-ee-env.xml, falling back to
-     * looking for WEB-INF/jetty-env.xml.
+     * Obtain a {@code WEB-INF/jetty-ee##-env.xml} (environment specific), falling back to
+     * looking for {@code WEB-INF/jetty-env.xml} (generic).
      *
      * @param webInf the WEB-INF of the context to search
      * @return the file if it exists or null otherwise
@@ -262,8 +268,8 @@ public class EnvConfiguration extends AbstractConfiguration
             if (webInf == null || !webInf.isDirectory())
                 return null;
 
-            //try to find jetty-ee-env.xml
-            Resource xmlResource = webInf.resolve(JETTY_EE_ENV_XML_FILENAME);
+            //try to find jetty-ee##-env.xml (environment specific)
+            Resource xmlResource = webInf.resolve(getJettyEeEnvXmlFilename());
             if (!Resources.missing(xmlResource))
                 return xmlResource;
 

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusConfiguration.java
@@ -18,7 +18,6 @@ import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 
 import org.eclipse.jetty.ee.plus.jndi.Transaction;
-import org.eclipse.jetty.ee.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee.webapp.AbstractConfiguration;
 import org.eclipse.jetty.ee.webapp.FragmentConfiguration;
 import org.eclipse.jetty.ee.webapp.JettyWebXmlConfiguration;
@@ -83,13 +82,13 @@ public class PlusConfiguration extends AbstractConfiguration
     {
         try
         {
-            Transaction.bindTransactionToENC(ServletContextHandler.getEnvironmentName());
+            Transaction.bindTransactionToENC(context.getEnvironmentName());
         }
         catch (NameNotFoundException e)
         {
             try
             {
-                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(ServletContextHandler.getEnvironmentName());
+                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(context.getEnvironmentName());
             }
             catch (NameNotFoundException x)
             {

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusConfiguration.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusConfiguration.java
@@ -83,13 +83,13 @@ public class PlusConfiguration extends AbstractConfiguration
     {
         try
         {
-            Transaction.bindTransactionToENC(ServletContextHandler.ENVIRONMENT.getName());
+            Transaction.bindTransactionToENC(ServletContextHandler.getEnvironmentName());
         }
         catch (NameNotFoundException e)
         {
             try
             {
-                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(ServletContextHandler.ENVIRONMENT.getName());
+                org.eclipse.jetty.plus.jndi.Transaction.bindTransactionToENC(ServletContextHandler.getEnvironmentName());
             }
             catch (NameNotFoundException x)
             {

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessor.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessor.java
@@ -874,7 +874,7 @@ public class PlusDescriptorProcessor extends IterativeDescriptorProcessor
             return;
 
         //try the ee environment next
-        scope = ServletContextHandler.ENVIRONMENT.getName();
+        scope = ServletContextHandler.getEnvironmentName();
         bound = NamingEntryUtil.bindToENC(scope, name, nameInEnvironment);
         if (bound)
             return;

--- a/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessor.java
+++ b/jetty-ee/jetty-ee-plus/src/main/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessor.java
@@ -19,7 +19,6 @@ import javax.naming.Context;
 import javax.naming.InitialContext;
 import javax.naming.NameNotFoundException;
 
-import org.eclipse.jetty.ee.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee.webapp.Descriptor;
 import org.eclipse.jetty.ee.webapp.FragmentDescriptor;
 import org.eclipse.jetty.ee.webapp.IterativeDescriptorProcessor;
@@ -874,7 +873,7 @@ public class PlusDescriptorProcessor extends IterativeDescriptorProcessor
             return;
 
         //try the ee environment next
-        scope = ServletContextHandler.getEnvironmentName();
+        scope = context.getEnvironmentName();
         bound = NamingEntryUtil.bindToENC(scope, name, nameInEnvironment);
         if (bound)
             return;

--- a/jetty-ee/jetty-ee-plus/src/test/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee/jetty-ee-plus/src/test/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessorTest.java
@@ -20,7 +20,6 @@ import javax.naming.InitialContext;
 import javax.naming.Name;
 
 import org.eclipse.jetty.ee.common.WebAppClassLoader;
-import org.eclipse.jetty.ee.servlet.ServletContextHandler;
 import org.eclipse.jetty.ee.webapp.Configuration;
 import org.eclipse.jetty.ee.webapp.Descriptor;
 import org.eclipse.jetty.ee.webapp.FragmentDescriptor;
@@ -160,11 +159,11 @@ public class PlusDescriptorProcessorTest
 
         //Resource 1 declared in environment scope
         eeObject1 = new Object();
-        Resource res1 = new Resource(ServletContextHandler.getEnvironmentName(), "eeObject1", eeObject1);
+        Resource res1 = new Resource(context.getEnvironmentName(), "eeObject1", eeObject1);
 
         //Resource 2 declared in environment scope
         eeObject2 = new Object();
-        Resource res2 = new Resource(ServletContextHandler.getEnvironmentName(), "eeObject2", eeObject2);
+        Resource res2 = new Resource(context.getEnvironmentName(), "eeObject2", eeObject2);
 
         URL webXml = Thread.currentThread().getContextClassLoader().getResource("web.xml");
         webDescriptor = new WebDescriptor(context.getResourceFactory().newResource(webXml));

--- a/jetty-ee/jetty-ee-plus/src/test/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessorTest.java
+++ b/jetty-ee/jetty-ee-plus/src/test/java/org/eclipse/jetty/ee/plus/webapp/PlusDescriptorProcessorTest.java
@@ -160,11 +160,11 @@ public class PlusDescriptorProcessorTest
 
         //Resource 1 declared in environment scope
         eeObject1 = new Object();
-        Resource res1 = new Resource(ServletContextHandler.ENVIRONMENT.getName(), "eeObject1", eeObject1);
+        Resource res1 = new Resource(ServletContextHandler.getEnvironmentName(), "eeObject1", eeObject1);
 
         //Resource 2 declared in environment scope
         eeObject2 = new Object();
-        Resource res2 = new Resource(ServletContextHandler.ENVIRONMENT.getName(), "eeObject2", eeObject2);
+        Resource res2 = new Resource(ServletContextHandler.getEnvironmentName(), "eeObject2", eeObject2);
 
         URL webXml = Thread.currentThread().getContextClassLoader().getResource("web.xml");
         webDescriptor = new WebDescriptor(context.getResourceFactory().newResource(webXml));

--- a/jetty-ee/jetty-ee-plus/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-plus/src/test/resources/jetty-logging.properties
@@ -1,0 +1,4 @@
+#org.eclipse.jetty.LEVEL=DEBUG
+#org.eclipse.jetty.webapp.LEVEL=DEBUG
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN

--- a/jetty-ee/jetty-ee-proxy/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-proxy/src/test/resources/jetty-logging.properties
@@ -4,6 +4,8 @@
 #org.eclipse.jetty.server.LEVEL=DEBUG
 #org.eclipse.jetty.server.handler.ConnectHandler.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-quickstart/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-quickstart/src/test/resources/jetty-logging.properties
@@ -3,6 +3,8 @@ org.eclipse.jetty.LEVEL=INFO
 # org.eclipse.jetty.ee.webapp.LEVEL=DEBUG
 # org.eclipse.jetty.ee.quickstart.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/ServletContextHandler.java
+++ b/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/ServletContextHandler.java
@@ -165,26 +165,6 @@ public class ServletContextHandler extends ContextHandler
         DESTROYED
     }
 
-    public static String getEnvironmentName()
-    {
-        Environment env = getEnvironment();
-        if (env == null)
-            throw new IllegalStateException("No Jetty Environment exists yet for this ServletContext");
-        return env.getName();
-    }
-
-    public static Environment getEnvironment()
-    {
-        // Resolve per call, never cache in a static field: under JPMS this class is shared across
-        // every environment (ee10, ee11, ...), so a static cache would freeze the first environment
-        // resolved and return it for all the others. EnterpriseEditionVersion.getEnterpriseEditionVersion()
-        // is likewise documented as not cacheable.
-        EnterpriseEditionVersion version = EnterpriseEditionVersion.getEnterpriseEditionVersion();
-        if (version == null)
-            return null;
-        return Environment.ensure(version.environmentName(), ServletContextHandler.class);
-    }
-
     public static ServletContextHandler getServletContextHandler(jakarta.servlet.ServletContext servletContext, String purpose)
     {
         if (servletContext instanceof ServletContextApi servletContextApi)
@@ -248,6 +228,8 @@ public class ServletContextHandler extends ContextHandler
     private final Set<EventListener> _durableListeners = new HashSet<>();
 
     protected final DecoratedObjectFactory _objFactory;
+    protected final EnterpriseEditionVersion _enterpriseVersion;
+    protected final Environment _environment;
 //    protected Class<? extends SecurityHandler> _defaultSecurityHandlerClass = org.eclipse.jetty.security.ConstraintSecurityHandler.class;
     protected SessionHandler _sessionHandler;
     protected SecurityHandler _securityHandler;
@@ -294,6 +276,11 @@ public class ServletContextHandler extends ContextHandler
 
     public ServletContextHandler(String contextPath, SessionHandler sessionHandler, SecurityHandler securityHandler, ServletHandler servletHandler, ErrorHandler errorHandler, int options)
     {
+        _enterpriseVersion = EnterpriseEditionVersion.getEnterpriseEditionVersion();
+        if (_enterpriseVersion == null)
+            throw new RuntimeException("Unable to discover EnterpriseEditionVersion");
+        _environment = Environment.ensure(_enterpriseVersion.environmentName(), ServletContextHandler.class);
+
         _servletContext = newServletContextApi();
 
         if (contextPath != null)
@@ -1745,6 +1732,26 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
+     * Get the Environment for this Context.
+     *
+     * @return the environment;
+     */
+    public Environment getEnvironment()
+    {
+        return _environment;
+    }
+
+    /**
+     * Get the Environment Name for this Context.
+     *
+     * @return the environment name;
+     */
+    public String getEnvironmentName()
+    {
+        return _environment.getName();
+    }
+
+    /**
      * The DecoratedObjectFactory for use by IoC containers (weld / spring / etc)
      *
      * @return The DecoratedObjectFactory
@@ -2146,14 +2153,17 @@ public class ServletContextHandler extends ContextHandler
 
     public class ServletContextApi implements jakarta.servlet.ServletContext
     {
-        private static final ServletApiVersion SERVLET_API_VERSION = ServletApiVersion.getServletApiVersion();
-        private int _effectiveMajorVersion = SERVLET_API_VERSION.getMajorVersion();
-        private int _effectiveMinorVersion = SERVLET_API_VERSION.getMinorVersion();
+        private final ServletApiVersion _servletApiVersion;
+        private int _effectiveMajorVersion;
+        private int _effectiveMinorVersion;
         protected boolean _enabled = true; // whether or not the dynamic API is enabled for callers
         protected boolean _extendedListenerTypes = false;
 
         public ServletContextApi()
         {
+            _servletApiVersion = ServletApiVersion.getServletApiVersion();
+            _effectiveMajorVersion = _servletApiVersion.getMajorVersion();
+            _effectiveMinorVersion = _servletApiVersion.getMinorVersion();
         }
 
         @Override
@@ -2165,13 +2175,13 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public int getMajorVersion()
         {
-            return SERVLET_API_VERSION.getMajorVersion();
+            return _servletApiVersion.getMajorVersion();
         }
 
         @Override
         public int getMinorVersion()
         {
-            return SERVLET_API_VERSION.getMinorVersion();
+            return _servletApiVersion.getMinorVersion();
         }
 
         @Override

--- a/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/ServletContextHandler.java
+++ b/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/ServletContextHandler.java
@@ -69,6 +69,7 @@ import jakarta.servlet.http.HttpSessionBindingListener;
 import jakarta.servlet.http.HttpSessionIdListener;
 import jakarta.servlet.http.HttpSessionListener;
 import org.eclipse.jetty.ee.common.EnterpriseEditionVersion;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.servlet.ServletContextResponse.EncodingFrom;
 import org.eclipse.jetty.ee.servlet.ServletContextResponse.OutputType;
 import org.eclipse.jetty.ee.servlet.security.ConstraintAware;
@@ -133,12 +134,7 @@ import static jakarta.servlet.ServletContext.TEMPDIR;
 public class ServletContextHandler extends ContextHandler
 {
     private static final Logger LOG = LoggerFactory.getLogger(ServletContextHandler.class);
-    public static final Environment ENVIRONMENT = Environment.ensure(EnterpriseEditionVersion.getEnterpriseEditionVersion().name(), ServletContextHandler.class);
-    /**
-     * @deprecated Use {@link ServletContextHandler#ENVIRONMENT} instead.
-     */
-    @Deprecated(since = "12.0.9", forRemoval = true)
-    public static final Environment __environment = ENVIRONMENT;
+
     public static final Class<?>[] SERVLET_LISTENER_TYPES =
         {
             ServletContextListener.class,
@@ -167,6 +163,26 @@ public class ServletContextHandler extends ContextHandler
         NOTSET,
         INITIALIZED,
         DESTROYED
+    }
+
+    public static String getEnvironmentName()
+    {
+        Environment env = getEnvironment();
+        if (env == null)
+            throw new IllegalStateException("No Jetty Environment exists yet for this ServletContext");
+        return env.getName();
+    }
+
+    public static Environment getEnvironment()
+    {
+        // Resolve per call, never cache in a static field: under JPMS this class is shared across
+        // every environment (ee10, ee11, ...), so a static cache would freeze the first environment
+        // resolved and return it for all the others. EnterpriseEditionVersion.getEnterpriseEditionVersion()
+        // is likewise documented as not cacheable.
+        EnterpriseEditionVersion version = EnterpriseEditionVersion.getEnterpriseEditionVersion();
+        if (version == null)
+            return null;
+        return Environment.ensure(version.environmentName(), ServletContextHandler.class);
     }
 
     public static ServletContextHandler getServletContextHandler(jakarta.servlet.ServletContext servletContext, String purpose)
@@ -2130,11 +2146,9 @@ public class ServletContextHandler extends ContextHandler
 
     public class ServletContextApi implements jakarta.servlet.ServletContext
     {
-        public static final int SERVLET_MAJOR_VERSION = 6;
-        public static final int SERVLET_MINOR_VERSION = 1;
-
-        private int _effectiveMajorVersion = SERVLET_MAJOR_VERSION;
-        private int _effectiveMinorVersion = SERVLET_MINOR_VERSION;
+        private static final ServletApiVersion SERVLET_API_VERSION = ServletApiVersion.getServletApiVersion();
+        private int _effectiveMajorVersion = SERVLET_API_VERSION.getMajorVersion();
+        private int _effectiveMinorVersion = SERVLET_API_VERSION.getMinorVersion();
         protected boolean _enabled = true; // whether or not the dynamic API is enabled for callers
         protected boolean _extendedListenerTypes = false;
 
@@ -2151,13 +2165,13 @@ public class ServletContextHandler extends ContextHandler
         @Override
         public int getMajorVersion()
         {
-            return SERVLET_MAJOR_VERSION;
+            return SERVLET_API_VERSION.getMajorVersion();
         }
 
         @Override
         public int getMinorVersion()
         {
-            return SERVLET_MINOR_VERSION;
+            return SERVLET_API_VERSION.getMinorVersion();
         }
 
         @Override

--- a/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/SessionHandler.java
+++ b/jetty-ee/jetty-ee-servlet/src/main/java/org/eclipse/jetty/ee/servlet/SessionHandler.java
@@ -573,7 +573,7 @@ public class SessionHandler extends AbstractSessionManager implements Handler.Si
 
     public Session.API newSessionAPIWrapper(ManagedSession session)
     {
-        if (ServletApiVersion.getServletApiVersion().ordinal() >= ServletApiVersion.v6_1.ordinal())
+        if (ServletApiVersion.getServletApiVersion().ordinal() >= ServletApiVersion.V6_1.ordinal())
             return Servlet61SessionApi.wrapSession(session);
         return ServletSessionApi.wrapSession(session);
     }

--- a/jetty-ee/jetty-ee-servlet/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-servlet/src/test/resources/jetty-logging.properties
@@ -7,6 +7,8 @@
 #org.eclipse.jetty.server.DebugListener.LEVEL=DEBUG
 #org.eclipse.jetty.server.internal.HttpChannelState.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-servlets/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-servlets/src/test/resources/jetty-logging.properties
@@ -3,6 +3,7 @@
 #org.eclipse.jetty.ee.servlets.LEVEL=DEBUG
 #org.eclipse.jetty.ee.servlets.QoSFilter.LEVEL=DEBUG
 #org.eclipse.jetty.ee.servlets.DoSFilter.LEVEL=DEBUG
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
 org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN

--- a/jetty-ee/jetty-ee-servlets/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-servlets/src/test/resources/jetty-logging.properties
@@ -3,6 +3,7 @@
 #org.eclipse.jetty.ee.servlets.LEVEL=DEBUG
 #org.eclipse.jetty.ee.servlets.QoSFilter.LEVEL=DEBUG
 #org.eclipse.jetty.ee.servlets.DoSFilter.LEVEL=DEBUG
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-cdi/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-cdi/src/test/resources/jetty-logging.properties
@@ -4,6 +4,8 @@ org.eclipse.jetty.LEVEL=INFO
 #org.eclipse.jetty.ee.cdi.LEVEL=DEBUG
 #org.jboss.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-client-transports/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-client-transports/src/test/resources/jetty-logging.properties
@@ -12,6 +12,8 @@ org.eclipse.jetty.http3.qpack.LEVEL=INFO
 org.eclipse.jetty.quic.quiche.foreign.LEVEL=INFO
 org.eclipse.jetty.quic.quiche.jna.LEVEL=INFO
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/AnnotatedAsyncListenerTest.java
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/AnnotatedAsyncListenerTest.java
@@ -13,11 +13,8 @@
 
 package org.eclipse.jetty.ee.test;
 
-import java.io.BufferedWriter;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 
 import jakarta.annotation.Resource;
 import jakarta.servlet.AsyncContext;
@@ -30,6 +27,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.ee.annotations.AnnotationConfiguration;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.plus.webapp.EnvConfiguration;
 import org.eclipse.jetty.ee.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.ee.servlet.ServletHolder;
@@ -49,6 +47,7 @@ import org.eclipse.jetty.util.thread.QueuedThreadPool;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class AnnotatedAsyncListenerTest
@@ -69,14 +68,14 @@ public class AnnotatedAsyncListenerTest
         Path webInf = webAppDir.resolve("WEB-INF");
         Files.createDirectories(webInf);
 
-        try (BufferedWriter writer = Files.newBufferedWriter(webInf.resolve("web.xml"), StandardCharsets.UTF_8, StandardOpenOption.CREATE))
-        {
-            writer.write("<web-app xmlns=\"http://xmlns.jcp.org/xml/ns/javaee\" " +
-                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
-                "xsi:schemaLocation=\"http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd\" " +
-                "version=\"3.1\">" +
-                "</web-app>");
-        }
+        Files.writeString(webInf.resolve("web.xml"),
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app %s>
+            </web-app>
+            """.formatted(ServletApiVersion.V3_1.getWebXmlAttributes()),
+            UTF_8
+        );
 
         WebAppContext context = new WebAppContext(webAppDir.toString(), "/");
         context.setConfigurations(new Configuration[]

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/DeploymentDefaultContextPathTest.java
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/DeploymentDefaultContextPathTest.java
@@ -25,8 +25,8 @@ import java.util.Map;
 
 import org.eclipse.jetty.deploy.DeploymentScanner;
 import org.eclipse.jetty.deploy.StandardDeployer;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
-import org.eclipse.jetty.ee.webapp.WebDescriptor;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
@@ -174,11 +174,13 @@ public class DeploymentDefaultContextPathTest
             FS.ensureDirExists(webinf);
 
             Path webXml = root.resolve("WEB-INF/web.xml");
-            String webXmlText = WebDescriptor.WEB_APP_ELEMENT + """
+            String webXmlText = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <web-app %s>
                   <display-name>EE Test WebApp</display-name>
                   <default-context-path>%s</default-context-path>
                 </web-app>
-                """.formatted(defaultContextPath);
+                """.formatted(ServletApiVersion.getServletApiVersion().getWebXmlAttributes(), defaultContextPath);
             Files.writeString(webXml, webXmlText, StandardCharsets.UTF_8);
 
             Path indexHtml = root.resolve("index.html");

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/ErrorHandlingViaJspTest.java
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/java/org/eclipse/jetty/ee/test/ErrorHandlingViaJspTest.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.FormRequestContent;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.servlet.ServletChannel;
 import org.eclipse.jetty.ee.test.servlets.AlwaysUnsupportedServlet;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
@@ -44,6 +45,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -97,12 +99,8 @@ public class ErrorHandlingViaJspTest
         Path webxml = webinfDir.resolve("web.xml");
 
         Files.writeString(webxml, """
-            <web-app
-              xmlns="https://jakarta.ee/xml/ns/jakartaee"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd"
-              metadata-complete="false"
-              version="5.0">
+            <web-app %s
+              metadata-complete="false">
               <display-name>Sample WebApp</display-name>
             
               <servlet>
@@ -120,7 +118,7 @@ public class ErrorHandlingViaJspTest
                 <location>/error.jsp</location>
               </error-page>
             </web-app>
-            """.formatted(AlwaysUnsupportedServlet.class.getName()), StandardCharsets.UTF_8);
+            """.formatted(ServletApiVersion.V5_0.getWebXmlAttributes(), AlwaysUnsupportedServlet.class.getName()), UTF_8);
 
         Files.writeString(webappDir.resolve("error.jsp"), """
             <%@ page language="java" contentType="text/html; charset=utf-8"

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-integration/src/test/resources/jetty-logging.properties
@@ -2,6 +2,8 @@
 #org.eclipse.jetty.websocket.LEVEL=DEBUG
 #org.eclipse.jetty.util.ssl.KeyStoreScanner.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-loginservice/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-loginservice/src/test/resources/jetty-logging.properties
@@ -2,6 +2,8 @@
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.server.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-quickstart/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-quickstart/src/test/resources/jetty-logging.properties
@@ -4,6 +4,8 @@ org.eclipse.jetty.LEVEL=INFO
 #org.eclipse.jetty.quickstart.LEVEL=DEBUG
 # org.eclipse.jetty.quickstart.AttributeNormalizer.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-common/src/main/java/org/eclipse/jetty/ee/session/AbstractWebAppObjectInSessionTest.java
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-common/src/main/java/org/eclipse/jetty/ee/session/AbstractWebAppObjectInSessionTest.java
@@ -20,8 +20,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
-import org.eclipse.jetty.ee.webapp.WebDescriptor;
 import org.eclipse.jetty.http.HttpField;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.session.AbstractSessionDataStoreFactory;
@@ -59,9 +59,11 @@ public abstract class AbstractWebAppObjectInSessionTest extends AbstractSessionT
         webInfDir.mkdir();
         // Write web.xml
         File webXml = new File(webInfDir, "web.xml");
-        String xml = WebDescriptor.WEB_APP_ELEMENT +
-                "\n" +
-                "</web-app>";
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <web-app %s>
+                </web-app>
+                """.formatted(ServletApiVersion.getServletApiVersion().getWebXmlAttributes());
         FileWriter w = new FileWriter(webXml);
         w.write(xml);
         w.close();

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-common/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-common/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 # Jetty Logging using jetty-slf4j-impl
 #org.eclipse.jetty.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-file/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-file/src/test/resources/jetty-logging.properties
@@ -2,6 +2,8 @@
 # org.eclipse.jetty.LEVEL=WARN
 log.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-hazelcast/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-hazelcast/src/test/resources/jetty-logging.properties
@@ -4,6 +4,8 @@ org.eclipse.jetty.logging.appender.MESSAGE_ESCAPE=false
 # org.eclipse.jetty.LEVEL=WARN
 log.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-infinispan/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-infinispan/src/test/resources/jetty-logging.properties
@@ -5,6 +5,8 @@ org.eclipse.jetty.server.session.LEVEL=INFO
 org.eclipse.jetty.server.infinispan.session.LEVEL=INFO
 log.LEVEL=INFO
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee/session/jdbc/ReloadedSessionMissingClassTest.java
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-jdbc/src/test/java/org/eclipse/jetty/ee/session/jdbc/ReloadedSessionMissingClassTest.java
@@ -23,9 +23,9 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.HttpClient;
 import org.eclipse.jetty.client.Request;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.session.SessionTestSupport;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
-import org.eclipse.jetty.ee.webapp.WebDescriptor;
 import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.session.AbstractSessionDataStoreFactory;
 import org.eclipse.jetty.session.DefaultSessionCacheFactory;
@@ -74,12 +74,14 @@ public class ReloadedSessionMissingClassTest
         webInfDir.mkdir();
 
         File webXml = new File(webInfDir, "web.xml");
-        String xml = WebDescriptor.WEB_APP_ELEMENT +
-                "\n" +
-                "  <session-config>\n" +
-                "    <session-timeout>1</session-timeout>\n" +
-                "  </session-config>\n" +
-                "</web-app>";
+        String xml = """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app %s>
+              <session-config>
+                <session-timeout>1</session-timeout>
+              </session-config>
+            </web-app>
+            """.formatted(ServletApiVersion.getServletApiVersion().getWebXmlAttributes());
         FileWriter w = new FileWriter(webXml);
         w.write(xml);
         w.close();

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-jdbc/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-jdbc/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 # Jetty Logging using jetty-slf4j-impl
 #org.eclipse.jetty.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-memcached/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-memcached/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 # Jetty Logging using jetty-slf4j-impl
 #org.eclipse.jetty.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-mongodb/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-tests/jetty-ee-test-sessions/jetty-ee-test-sessions-mongodb/src/test/resources/jetty-logging.properties
@@ -1,6 +1,8 @@
 # Setup default logging implementation for during testing
 # Jetty Logging using jetty-slf4j-impl
-#org.eclipse.jetty.server.LEVEL=DEBUGorg.eclipse.jetty.server.Server.LEVEL=WARN
+org.eclipse.jetty.server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/JettyWebXmlConfiguration.java
+++ b/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/JettyWebXmlConfiguration.java
@@ -36,12 +36,20 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
     public static final String PROPERTY_WEB_INF = "web-inf";
     public static final String XML_CONFIGURATION = "org.eclipse.jetty.webapp.JettyWebXmlConfiguration";
     public static final String JETTY_WEB_XML = "jetty-web.xml";
-    public static final String JETTY_EE_WEB_XML = "jetty-%s-web.xml".formatted(EnterpriseEditionVersion.getEnterpriseEditionVersion().name());
 
     public JettyWebXmlConfiguration()
     {
         super(new Builder()
             .addDependencies(WebXmlConfiguration.class, FragmentConfiguration.class, MetaInfConfiguration.class));
+    }
+
+    public String getJettyEeWebXml()
+    {
+        String environmentName = EnterpriseEditionVersion.getEnterpriseEditionVersion().environmentName();
+
+        // The use of EnterpriseEditionVersion.getEnterpriseEditionVersion() cannot occur during phases where
+        // the ClassLoader isn't used or isn't available yet (like OSGi boot activation)
+        return "jetty-%s-web.xml".formatted(environmentName);
     }
 
     /**
@@ -95,7 +103,7 @@ public class JettyWebXmlConfiguration extends AbstractConfiguration
      */
     private Resource resolveJettyWebXml(Resource webInf)
     {
-        String xmlFile = JETTY_EE_WEB_XML;
+        String xmlFile = getJettyEeWebXml();
         try
         {
             if (webInf == null || !webInf.isDirectory())

--- a/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppContext.java
+++ b/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppContext.java
@@ -28,7 +28,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import jakarta.servlet.ServletContext;
@@ -64,7 +63,6 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.DumpableCollection;
-import org.eclipse.jetty.util.component.Environment;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -194,10 +192,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         // is done after this instance is constructed.
         super(contextPath, sessionHandler, securityHandler, servletHandler, errorHandler, options);
 
-        Environment environment = ServletContextHandler.getEnvironment();
-
-        _protectedClasses = new ClassMatcher(WebAppClassLoading.getProtectedClasses(environment));
-        _hiddenClasses = new ClassMatcher(WebAppClassLoading.getHiddenClasses(environment));
+        _protectedClasses = new ClassMatcher(WebAppClassLoading.getProtectedClasses(getEnvironment()));
+        _hiddenClasses = new ClassMatcher(WebAppClassLoading.getHiddenClasses(getEnvironment()));
 
         setErrorHandler(errorHandler != null ? errorHandler : new ErrorPageErrorHandler());
         setProtectedTargets(__dftProtectedTargets);
@@ -503,9 +499,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     protected void doStart() throws Exception
     {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
-        Environment environment = ServletContextHandler.getEnvironment();
-        Objects.requireNonNull(environment, "Unable to get Environment");
-        Thread.currentThread().setContextClassLoader(environment.getClassLoader());
+        Thread.currentThread().setContextClassLoader(getEnvironment().getClassLoader());
         try
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
@@ -896,7 +890,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         name = String.format("%s@%x", name, hashCode());
 
         dumpObjects(out, indent,
-            Dumpable.named("environment", ServletContextHandler.getEnvironmentName()),
+            Dumpable.named("environment", getEnvironmentName()),
             new ClassLoaderDump(getClassLoader()),
             new DumpableCollection("Protected classes " + name, protectedClasses),
             new DumpableCollection("Hidden classes " + name, hiddenClasses),

--- a/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppContext.java
+++ b/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebAppContext.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import jakarta.servlet.ServletContext;
@@ -63,6 +64,7 @@ import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ClassLoaderDump;
 import org.eclipse.jetty.util.component.Dumpable;
 import org.eclipse.jetty.util.component.DumpableCollection;
+import org.eclipse.jetty.util.component.Environment;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.util.resource.Resources;
@@ -102,8 +104,8 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
 
     private static final String[] __dftProtectedTargets = {"/WEB-INF", "/META-INF"};
 
-    private final ClassMatcher _protectedClasses = new ClassMatcher(WebAppClassLoading.getProtectedClasses(ServletContextHandler.ENVIRONMENT));
-    private final ClassMatcher _hiddenClasses = new ClassMatcher(WebAppClassLoading.getHiddenClasses(ServletContextHandler.ENVIRONMENT));
+    private final ClassMatcher _protectedClasses;
+    private final ClassMatcher _hiddenClasses;
 
     private Configurations _configurations;
     private String _defaultsDescriptor = WEB_DEFAULTS_XML;
@@ -191,6 +193,12 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         // always pass parent as null and then set below, so that any resulting setServer call
         // is done after this instance is constructed.
         super(contextPath, sessionHandler, securityHandler, servletHandler, errorHandler, options);
+
+        Environment environment = ServletContextHandler.getEnvironment();
+
+        _protectedClasses = new ClassMatcher(WebAppClassLoading.getProtectedClasses(environment));
+        _hiddenClasses = new ClassMatcher(WebAppClassLoading.getHiddenClasses(environment));
+
         setErrorHandler(errorHandler != null ? errorHandler : new ErrorPageErrorHandler());
         setProtectedTargets(__dftProtectedTargets);
     }
@@ -495,7 +503,9 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
     protected void doStart() throws Exception
     {
         ClassLoader old = Thread.currentThread().getContextClassLoader();
-        Thread.currentThread().setContextClassLoader(ServletContextHandler.ENVIRONMENT.getClassLoader());
+        Environment environment = ServletContextHandler.getEnvironment();
+        Objects.requireNonNull(environment, "Unable to get Environment");
+        Thread.currentThread().setContextClassLoader(environment.getClassLoader());
         try
         {
             _metadata.setAllowDuplicateFragmentNames(isAllowDuplicateFragmentNames());
@@ -886,7 +896,7 @@ public class WebAppContext extends ServletContextHandler implements WebAppClassL
         name = String.format("%s@%x", name, hashCode());
 
         dumpObjects(out, indent,
-            Dumpable.named("environment", ServletContextHandler.ENVIRONMENT.getName()),
+            Dumpable.named("environment", ServletContextHandler.getEnvironmentName()),
             new ClassLoaderDump(getClassLoader()),
             new DumpableCollection("Protected classes " + name, protectedClasses),
             new DumpableCollection("Hidden classes " + name, hiddenClasses),

--- a/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebDescriptor.java
+++ b/jetty-ee/jetty-ee-webapp/src/main/java/org/eclipse/jetty/ee/webapp/WebDescriptor.java
@@ -32,13 +32,6 @@ import org.slf4j.LoggerFactory;
  */
 public class WebDescriptor extends Descriptor
 {
-    public static final String WEB_APP_ELEMENT = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
-                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
-                 version="6.1">
-        """;
     private static final Logger LOG = LoggerFactory.getLogger(WebDescriptor.class);
 
     /**

--- a/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/MetaInfConfigurationTest.java
+++ b/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/MetaInfConfigurationTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.common.WebAppClassLoader;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
@@ -86,12 +87,10 @@ public class MetaInfConfigurationTest
 
         String web25 = """
             <?xml version="1.0" encoding="ISO-8859-1"?>
-            <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-               version="2.5">
+            <web-app %s>
               <display-name>Test 2.5 WebApp</display-name>
             </web-app>
-            """;
+            """.formatted(ServletApiVersion.V2_5.getWebXmlAttributes());
 
         Files.writeString(webxml, web25, StandardCharsets.UTF_8);
         Path libDir = webinf.resolve("lib");
@@ -197,12 +196,10 @@ public class MetaInfConfigurationTest
 
         String web25 = """
             <?xml version="1.0" encoding="ISO-8859-1"?>
-            <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-               xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-               version="2.5">
+            <web-app %s>
               <display-name>Test 2.5 WebApp</display-name>
             </web-app>
-            """;
+            """.formatted(ServletApiVersion.V2_5.getWebXmlAttributes());
 
         Files.writeString(webxml, web25, StandardCharsets.UTF_8);
         Path libDir = webinf.resolve("lib");
@@ -314,13 +311,11 @@ public class MetaInfConfigurationTest
 
         String web30 = """
             <?xml version="1.0" encoding="ISO-8859-1"?>
-            <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd"
-                 metadata-complete="false"
-                 version="3.0">
+            <web-app %s
+                 metadata-complete="false">
               <display-name>Test 3.0 WebApp</display-name>
             </web-app>
-            """;
+            """.formatted(ServletApiVersion.V3_0.getWebXmlAttributes());
 
         Files.writeString(webxml, web30, StandardCharsets.UTF_8);
         Path libDir = webinf.resolve("lib");
@@ -432,13 +427,11 @@ public class MetaInfConfigurationTest
 
         String web31 = """
             <?xml version="1.0" encoding="ISO-8859-1"?>
-            <web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                 xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
-                 metadata-complete="true"
-                 version="3.1">
+            <web-app %s
+                 metadata-complete="true">
               <display-name>Test 3.1 WebApp</display-name>
             </web-app>
-            """;
+            """.formatted(ServletApiVersion.V3_1.getWebXmlAttributes());
 
         Files.writeString(webxml, web31, StandardCharsets.UTF_8);
         Path libDir = webinf.resolve("lib");

--- a/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/StandardDescriptorProcessorTest.java
+++ b/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/StandardDescriptorProcessorTest.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.servlet.DefaultServlet;
 import org.eclipse.jetty.ee.servlet.ServletHolder;
 import org.eclipse.jetty.ee.servlet.ServletMapping;
@@ -208,13 +209,10 @@ public class StandardDescriptorProcessorTest
         FS.ensureDirExists(descriptorXml.getParent());
         Files.writeString(descriptorXml, """
             <?xml version="1.0" encoding="UTF-8"?>
-            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
-              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-              xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd"
-              version="6.0">
+            <web-app %s>
               <name>Test WebApp</name>
             </web-app>
-            """);
+            """.formatted(ServletApiVersion.V6_0.getWebXmlAttributes()));
         wac.setDescriptor(descriptorXml.toUri().toASCIIString());
 
         final Map<String, String> CREATE_JAR_ENV = new HashMap<>();

--- a/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/WebDescriptorTest.java
+++ b/jetty-ee/jetty-ee-webapp/src/test/java/org/eclipse/jetty/ee/webapp/WebDescriptorTest.java
@@ -17,6 +17,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
 import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
 import org.eclipse.jetty.util.resource.ResourceFactory;
@@ -37,14 +38,11 @@ public class WebDescriptorTest
         Path xml = workDir.getEmptyPathDir().resolve("test.xml");
         Files.writeString(xml, """
             <?xml version="1.0" encoding="UTF-8"?>
-            <web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
-                     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                     metadata-complete="false"
-                     xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
-                     version="6.1">
+            <web-app %s
+                     metadata-complete="false">
               <display-name>Empty WebApp Descriptor</display-name>
             </web-app>
-            """, StandardCharsets.UTF_8);
+            """.formatted(ServletApiVersion.V6_1.getWebXmlAttributes()), StandardCharsets.UTF_8);
 
         WebDescriptor webDescriptor = new WebDescriptor(ResourceFactory.root().newResource(xml));
         XmlParser xmlParser = new XmlParser(true);

--- a/jetty-ee/jetty-ee-webapp/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-webapp/src/test/resources/jetty-logging.properties
@@ -6,6 +6,8 @@
 #org.eclipse.jetty.ee.webapp.MetaInfConfiguration.LEVEL=DEBUG
 #org.eclipse.jetty.ee.webapp.WebInfConfiguration.LEVEL=DEBUG
 #org.eclipse.jetty.util.PathWatcher.Noisy.LEVEL=OFF
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.Server.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-client/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-client/src/test/resources/jetty-logging.properties
@@ -8,6 +8,8 @@ org.eclipse.jetty.LEVEL=INFO
 # org.eclipse.jetty.io.LEVEL=DEBUG
 # org.eclipse.jetty.io.ManagedSelector.LEVEL=INFO
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-common/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-common/src/test/resources/jetty-logging.properties
@@ -29,6 +29,8 @@
 ### Disabling intentional error out of RFCSocket
 org.eclipse.jetty.websocket.tests.server.RFCSocket.LEVEL=OFF
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-server/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-server/src/test/resources/jetty-logging.properties
@@ -9,6 +9,8 @@
 # -- LEAVE THIS AT DEBUG LEVEL --
 #org.eclipse.jetty.websocket.jakarta.server.browser.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-tests/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jakarta-tests/src/test/resources/jetty-logging.properties
@@ -14,6 +14,8 @@
 # org.eclipse.jetty.websocket.tests.client.LEVEL=DEBUG
 # org.eclipse.jetty.websocket.tests.server.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee/websocket/tests/JettyWebSocketWebApp.java
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee/websocket/tests/JettyWebSocketWebApp.java
@@ -14,13 +14,13 @@
 package org.eclipse.jetty.ee.websocket.tests;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
-import org.eclipse.jetty.ee.webapp.WebDescriptor;
 import org.eclipse.jetty.ee.websocket.server.config.JettyWebSocketConfiguration;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.IO;
@@ -29,6 +29,7 @@ import org.eclipse.jetty.util.TypeUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -66,13 +67,14 @@ public class JettyWebSocketWebApp extends WebAppContext
 
     public void createWebXml() throws IOException
     {
-        String emptyWebXml = WebDescriptor.WEB_APP_ELEMENT + "</web-app>";
+        String emptyWebXml =
+            """
+            <?xml version="1.0" encoding="UTF-8"?>
+            <web-app %s>
+            </web-app>
+            """.formatted(ServletApiVersion.getServletApiVersion().getWebXmlAttributes());
 
-        Path webXml = webInf.resolve("web.xml");
-        try (FileWriter writer = new FileWriter(webXml.toFile()))
-        {
-            writer.write(emptyWebXml);
-        }
+        Files.writeString(webInf.resolve("web.xml"), emptyWebXml, UTF_8);
     }
 
     public void copyWebXml(Path webXml) throws IOException

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee/websocket/tests/WebAppTester.java
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/java/org/eclipse/jetty/ee/websocket/tests/WebAppTester.java
@@ -14,7 +14,6 @@
 package org.eclipse.jetty.ee.websocket.tests;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -23,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.eclipse.jetty.ee.annotations.AnnotationConfiguration;
+import org.eclipse.jetty.ee.common.ServletApiVersion;
 import org.eclipse.jetty.ee.plus.webapp.EnvConfiguration;
 import org.eclipse.jetty.ee.plus.webapp.PlusConfiguration;
 import org.eclipse.jetty.ee.webapp.Configuration;
@@ -33,7 +33,6 @@ import org.eclipse.jetty.ee.webapp.JndiConfiguration;
 import org.eclipse.jetty.ee.webapp.MetaInfConfiguration;
 import org.eclipse.jetty.ee.webapp.WebAppConfiguration;
 import org.eclipse.jetty.ee.webapp.WebAppContext;
-import org.eclipse.jetty.ee.webapp.WebDescriptor;
 import org.eclipse.jetty.ee.webapp.WebInfConfiguration;
 import org.eclipse.jetty.ee.webapp.WebXmlConfiguration;
 import org.eclipse.jetty.server.Server;
@@ -48,6 +47,7 @@ import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -194,12 +194,13 @@ public class WebAppTester extends ContainerLifeCycle
 
         public void createWebInf() throws IOException
         {
-            String emptyWebXml = WebDescriptor.WEB_APP_ELEMENT + "</web-app>";
-            File webXml = _webInf.resolve("web.xml").toFile();
-            try (FileWriter out = new FileWriter(webXml))
-            {
-                out.write(emptyWebXml);
-            }
+            String emptyWebXml =
+                """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <web-app %s>
+                </web-app>
+                """.formatted(ServletApiVersion.getServletApiVersion().getWebXmlAttributes());
+            Files.writeString(_webInf.resolve("web.xml"), emptyWebXml, UTF_8);
         }
 
         public void copyWebInf(String testResourceName) throws IOException

--- a/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/resources/jetty-logging.properties
+++ b/jetty-ee/jetty-ee-websocket/jetty-ee-websocket-jetty-tests/src/test/resources/jetty-logging.properties
@@ -3,6 +3,8 @@
 # org.eclipse.jetty.websocket.tests.LEVEL=DEBUG
 # org.eclipse.jetty.ee.websocket.LEVEL=DEBUG
 org.eclipse.jetty.server.Server.LEVEL=WARN
+# Squelch the info about not discovering EE## and defaulting to EE## during testing in jetty-ee
+org.eclipse.jetty.ee.common.EnterpriseEditionVersion.LEVEL=WARN
 org.eclipse.jetty.server.AbstractConnector.LEVEL=WARN
 org.eclipse.jetty.server.handler.ContextHandler.LEVEL=WARN
 org.eclipse.jetty.util.ssl.SslContextFactory.LEVEL=WARN

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/src/main/java/org/eclipse/jetty/ee10/osgi/boot/jsp/FragmentActivator.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot-jsp/src/main/java/org/eclipse/jetty/ee10/osgi/boot/jsp/FragmentActivator.java
@@ -1,0 +1,19 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.osgi.boot.jsp;
+
+public class FragmentActivator extends org.eclipse.jetty.ee.osgi.boot.jsp.FragmentActivator
+{
+    // no special implementation here.
+}

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/pom.xml
@@ -72,7 +72,9 @@
           <instructions>
             <Bundle-SymbolicName>org.eclipse.jetty.ee10.osgi.boot;singleton:=true</Bundle-SymbolicName>
             <Bundle-Activator>org.eclipse.jetty.ee.osgi.boot.EEActivator</Bundle-Activator>
-            <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))", org.eclipse.jetty.ee10.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))", org.eclipse.jetty.ee.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
+            <DynamicImport-Package>org.eclipse.jetty.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))",
+              org.eclipse.jetty.ee10.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))",
+              org.eclipse.jetty.ee.*;version="[$(version;===;${parsedVersion.osgiVersion}),$(version;==+;${parsedVersion.osgiVersion}))"</DynamicImport-Package>
             <Import-Package>${osgi.slf4j.import.packages},
               jakarta.mail;version="2.0";resolution:=optional,
               jakarta.mail.event;version="2.0";resolution:=optional,
@@ -96,8 +98,9 @@
               org.xml.sax.helpers,
               org.eclipse.jetty.ee10.annotations;resolution:=optional,
               *</Import-Package>
-            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)"</Require-Capability>
-            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.ee10.webapp.Configuration</Provide-Capability>
+            <Require-Capability>osgi.extender; filter:="(osgi.extender=osgi.serviceloader.registrar)";resolution:=optional</Require-Capability>
+            <Provide-Capability>osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.ee.webapp.Configuration,
+              osgi.serviceloader; osgi.serviceloader=org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service</Provide-Capability>
             <_nouses>true</_nouses>
           </instructions>
         </configuration>

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EnterpriseEdition10Service.java
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/java/org/eclipse/jetty/ee10/osgi/boot/EnterpriseEdition10Service.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.osgi.boot;
+
+import org.eclipse.jetty.ee.common.EnterpriseEditionVersion;
+
+/**
+ * Use EE10 when running this OSGi configuration.
+ */
+public class EnterpriseEdition10Service implements EnterpriseEditionVersion.Service
+{
+    @Override
+    public EnterpriseEditionVersion getVersion()
+    {
+        return EnterpriseEditionVersion.EE10;
+    }
+}

--- a/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
+++ b/jetty-ee10/jetty-ee10-osgi/jetty-ee10-osgi-boot/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
@@ -1,0 +1,1 @@
+org.eclipse.jetty.ee10.osgi.boot.EnterpriseEdition10Service

--- a/jetty-ee10/jetty-ee10-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
@@ -1,0 +1,1 @@
+environment=ee10

--- a/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/java/org/eclipse/jetty/ee11/osgi/boot/EnterpriseEdition11Service.java
+++ b/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/java/org/eclipse/jetty/ee11/osgi/boot/EnterpriseEdition11Service.java
@@ -1,0 +1,28 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.osgi.boot;
+
+import org.eclipse.jetty.ee.common.EnterpriseEditionVersion;
+
+/**
+ * Use EE11 when running this OSGi configuration.
+ */
+public class EnterpriseEdition11Service implements EnterpriseEditionVersion.Service
+{
+    @Override
+    public EnterpriseEditionVersion getVersion()
+    {
+        return EnterpriseEditionVersion.EE11;
+    }
+}

--- a/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
+++ b/jetty-ee11/jetty-ee11-osgi/jetty-ee11-osgi-boot/src/main/resources/META-INF/services/org.eclipse.jetty.ee.common.EnterpriseEditionVersion$Service
@@ -1,0 +1,1 @@
+org.eclipse.jetty.ee11.osgi.boot.EnterpriseEdition11Service

--- a/jetty-ee11/jetty-ee11-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
@@ -1,0 +1,1 @@
+environment=ee11

--- a/jetty-ee12/jetty-ee12-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
+++ b/jetty-ee12/jetty-ee12-servlet/src/main/resources/META-INF/org.eclipse.jetty/env.properties
@@ -1,0 +1,1 @@
+environment=ee12


### PR DESCRIPTION
This is a subset of the changes from PR #15225 (that PR was getting too big)

Uppercase for all version enums.

Introduced new discovery mechanism in `EnterpriseEditionVersion` based on `ServiceLoader`.
* Testing for Standard Classloader behavior.
* Testing for JPMS behavior.
* Testing for OSGi behavior.

Eliminated eager static initialization of `Environment` as it causes problems with various runtime environments (eg: OSGi and it's boot activator)

`WebSocketApiVersion` is now based on results of `EnterpriseEditionVersion`

`ServletApiVersion` is now based on results of `EnterpriseEditionVersion`
  * Introduced `.getWebXmlAttributes()` method to get the `<web-app>` attributes for a specific Servlet API version, used these in test cases.