### PR TITLE
Cleanup javadoc for recently deprecated Context newResource methods.

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/resource/ResourceFactory.java
@@ -160,7 +160,17 @@ public interface ResourceFactory
     }
 
     /**
-     * Construct a resource from a uri.
+     * Construct a resource from a URI.
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
      *
      * @param uri A URI.
      * @return A Resource object.
@@ -169,6 +179,16 @@ public interface ResourceFactory
 
     /**
      * <p>Construct a Resource from a string reference into classloaders.</p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
      *
      * @param resource Resource as string representation
      * @return The new Resource
@@ -201,6 +221,16 @@ public interface ResourceFactory
      * <p>
      *     If a provided resource name starts with a {@code /} (example: {@code /org/example/ClassName.class})
      *     then the non-slash version is also tried against the same ClassLoader (example: {@code org/example/ClassName.class}).
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
      * </p>
      *
      * @param resource the resource name to find in a classloader
@@ -276,6 +306,16 @@ public interface ResourceFactory
      * Convenience method for {@code newClassLoaderResource(resource, true)}
      * </p>
      *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
      * @param resource string representation of resource to find in a classloader
      * @return The new Resource
      * @throws IllegalArgumentException if string is blank
@@ -291,6 +331,16 @@ public interface ResourceFactory
      *
      * <p>
      * Convenience method {@code .newClassLoaderResource(resource, false)}
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
      * </p>
      *
      * @param resource the relative name of the resource
@@ -311,10 +361,14 @@ public interface ResourceFactory
      * </p>
      *
      * <p>
-     *     A Memory Resource is created from a the contents of
-     *     {@link URL#openStream()} and kept in memory from
-     *     that point forward.  Never accessing the URL
-     *     again to refresh it's contents.
+     *     Each call will create a new Memory Resource from the contents of
+     *     {@link URL#openStream()} and kept in memory for the duration
+     *     of this ResourceFactory implementation.  Never accessing the URL
+     *     again to refresh its contents.
+     * </p>
+     *
+     * <p>
+     *     The created Memory Resource does not support child resources.
      * </p>
      *
      * @param url the URL to load into memory
@@ -332,6 +386,16 @@ public interface ResourceFactory
 
     /**
      * Construct a resource from a string.
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
      *
      * @param resource A URL or filename.
      * @return A Resource object, or null if the string points to a location
@@ -388,6 +452,16 @@ public interface ResourceFactory
     /**
      * Construct a Resource from provided path.
      *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
      * @param path the path
      * @return the Resource for the provided path, or null if the path
      *  does not exist
@@ -404,6 +478,16 @@ public interface ResourceFactory
     /**
      * Construct a possible combined {@code Resource} from a list of URIs.
      *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
      * @param uris the URIs
      * @return the Resource for the provided URIs, or null if all
      *  the provided URIs do not exist
@@ -419,6 +503,16 @@ public interface ResourceFactory
 
     /**
      * Construct a {@link Resource} from a provided URL.
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
      *
      * @param url the URL
      * @return the Resource for the provided URL, or null if the
@@ -443,6 +537,16 @@ public interface ResourceFactory
     /**
      * Construct a {@link Resource} from a {@code file:} based URI that is mountable (eg: a jar file).
      *
+     * <p>
+     *     Each call will allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
      * @param uri the URI
      * @return the Resource, mounted as a {@link java.nio.file.FileSystem}, or null if
      *   the uri points to a location that does not exist.
@@ -460,6 +564,16 @@ public interface ResourceFactory
      *
      * <p>
      *     The supported types: {@link Path}, {@link String}, {@link URI}, {@link URL}, and {@link Resource}
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create root (or base) resources.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
      * </p>
      *
      * @param obj if the object to convert
@@ -487,11 +601,28 @@ public interface ResourceFactory
 
     /**
      * Split a string of references, that may be split with '{@code ,}', or '{@code ;}', or '{@code |}' into a List of {@link Resource}.
+     *
      * <p>
-     *     Each part of the input string could be path references (unix or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
+     *     Each part of the input string could be path references (UNIX or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
      * </p>
+     *
+     * <p>
+     *     Convenience method for {@code split(string, ",;|", false)}
+     * </p>
+     *
      * <p>
      *     If the result of processing the input segment is a java archive, it will not automatically be mounted, the caller must perform the mount if necessary
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create a List of root (or base) resources.
+     *     Consider using {@link #combine(Resource...)} to make them into a single {@link Resource}.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
      * </p>
      *
      * @param str the input string of references
@@ -502,11 +633,71 @@ public interface ResourceFactory
         return split(str, ",;|", false);
     }
 
+    /**
+     * Split a string of references, that may be split with '{@code ,}', or '{@code ;}', or '{@code |}' into a List of {@link Resource}.
+     *
+     * <p>
+     *     Each part of the input string could be path references (UNIX or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
+     * </p>
+     *
+     * <p>
+     *     Convenience method for {@code split(string, ",;|", unwrap)}
+     * </p>
+     *
+     * <p>
+     *     If the result of processing the input segment is a java archive, it will not automatically be mounted, the caller must perform the mount if necessary
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create a List of root (or base) resources.
+     *     Consider using {@link #combine(Resource...)} to make them into a single {@link Resource}.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
+     * @param str the input string of references
+     * @param unwrap if true {@code jar:file} references will be unwrapped back to just the container
+     * @return list of resources
+     */
     default List<Resource> split(String str, boolean unwrap)
     {
         return split(str, ",;|", unwrap);
     }
 
+    /**
+     * Split a string of references, that may be split with '{@code ,}', or '{@code ;}', or '{@code |}' into a List of {@link Resource}.
+     *
+     * <p>
+     *     Each part of the input string could be path references (UNIX or windows style), string URI references, or even glob references (eg: {@code /path/to/libs/*}).
+     * </p>
+     *
+     * <p>
+     *     Convenience method for {@code split(string, delim, false)}
+     * </p>
+     *
+     * <p>
+     *     If the result of processing the input segment is a java archive, it will not automatically be mounted, the caller must perform the mount if necessary
+     * </p>
+     *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create a List of root (or base) resources.
+     *     Consider using {@link #combine(Resource...)} to make them into a single {@link Resource}.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
+     * @param str the input string of references
+     * @param delim if true {@code jar:file} references will be unwrapped back to just the container
+     * @return list of resources
+     */
     default List<Resource> split(String str, String delim)
     {
         return split(str, delim, false);
@@ -514,19 +705,32 @@ public interface ResourceFactory
 
     /**
      * Split a string of references by provided delims into a List of {@link Resource}.
+     *
      * <p>
      *     Each part of the input string could be path references (unix or windows style),
      *     string URI references, or even glob references (eg: {@code /path/to/libs/*}).
      *     Note: that if you use the {@code :} character in your delims, then URI references will be impossible.
      * </p>
+     *
      * <p>
      *     If the result of processing the input segment is a java archive it will not be automatically mounted,
      *     the caller must mount if necessary
      * </p>
      *
+     * <p>
+     *     Each call may allocate a new JVM resource, whose lifecycle
+     *     is tied to this ResourceFactory implementation.
+     * </p>
+     *
+     * <p>
+     *     This method is used to create a List of root (or base) resources.
+     *     Consider using {@link #combine(Resource...)} to make them into a single {@link Resource}.
+     *     Child resources of these resources, should be created using {@link Resource#resolve(String)}
+     * </p>
+     *
      * @param str the input string of references
      * @param delims the list of delimiters
-     * @param unwrap if true jar:file references will be unwrapped back to just the container
+     * @param unwrap if true {@code jar:file} references will be unwrapped back to just the container
      * @return list of resources
      */
     default List<Resource> split(String str, String delims, boolean unwrap)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  *   <dd>
  *     The root directory to look for static resources. Defaults to the context's baseResource. Relative URI
  *     are {@link Resource#resolve(String) resolved} against the context's {@link ServletContextHandler#getBaseResource()}
- *     base resource, all other values are resolved using {@link ServletContextHandler#newResource(String)}.
+ *     base resource.
  *   </dd>
  *   <dt>cacheControl</dt>
  *   <dd>

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -798,9 +798,11 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -809,13 +811,15 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
-     * Convert URL to Resource wrapper for {@link ResourceFactory#newResource(URL)} enables extensions to provide alternate resource implementations.
+     * Convert URI to Resource wrapper for {@link ResourceFactory#newResource(URI)} enables extensions to provide alternate resource implementations.
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -824,13 +828,15 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
-     * Convert a URL or path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
+     * Convert a String URL or Path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextHandler.java
@@ -798,11 +798,7 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URL)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -815,11 +811,7 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URI)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -832,11 +824,7 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(String)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -79,7 +79,7 @@ import org.slf4j.LoggerFactory;
  *   <dd>
  *     The root directory to look for static resources. Defaults to the context's baseResource. Relative URI
  *     are {@link Resource#resolve(String) resolved} against the context's {@link ServletContextHandler#getBaseResource()}
- *     base resource, all other values are resolved using {@link ServletContextHandler#newResource(String)}.
+ *     base resource.
  *   </dd>
  *   <dt>cacheControl</dt>
  *   <dd>

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -796,9 +796,11 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -807,13 +809,15 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
-     * Convert URL to Resource wrapper for {@link ResourceFactory#newResource(URI)} enables extensions to provide alternate resource implementations.
+     * Convert URI to Resource wrapper for {@link ResourceFactory#newResource(URI)} enables extensions to provide alternate resource implementations.
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -822,13 +826,15 @@ public class ServletContextHandler extends ContextHandler
     }
 
     /**
-     * Convert a URL or path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
+     * Convert a String URL or Path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextHandler.java
@@ -796,11 +796,7 @@ public class ServletContextHandler extends ContextHandler
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URL)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -813,11 +809,7 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
-     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URI)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri)
@@ -830,11 +822,7 @@ public class ServletContextHandler extends ContextHandler
      *
      * @param urlOrPath The URL or path to convert
      * @return The Resource for the URL/path
-     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(String)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String urlOrPath)

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1602,11 +1602,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URL)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -1620,11 +1616,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(URI)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri) throws IOException
@@ -1638,11 +1630,7 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param uriOrPath The URL or path to convert
      * @return The Resource for the URL/path
      * @throws IOException The Resource could not be created.
-     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
-     *             configuration and initialization phases of the webapp, and avoided during
-     *             started phase of a webapp.<br/>
-     *             The use of this method during context started phase can result in
-     *             excessive memory consumption depending on the types of resources your webapp is using.
+     * @deprecated do not use this method, use {@link ResourceFactory#newResource(String)}.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String uriOrPath) throws IOException

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/ContextHandler.java
@@ -1602,9 +1602,11 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
      * @param url the url to convert to a Resource
      * @return the Resource for that url
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URL)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URL)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URL url) throws IOException
@@ -1613,14 +1615,16 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     }
 
     /**
-     * Convert URL to Resource wrapper for {@link ResourceFactory#newResource(URL)} enables extensions to provide alternate resource implementations.
+     * Convert URI to Resource wrapper for {@link ResourceFactory#newResource(URI)} enables extensions to provide alternate resource implementations.
      *
      * @param uri the URI to convert to a Resource
      * @return the Resource for that URI
      * @throws IOException if unable to create a Resource from the URL
-     * @deprecated use {@code ResourceFactory.of(component).newResource(URI)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(URI)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(URI uri) throws IOException
@@ -1629,14 +1633,16 @@ public class ContextHandler extends ScopedHandler implements Attributes, Supplie
     }
 
     /**
-     * Convert a URL or path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
+     * Convert a String URL or Path to a Resource. The default implementation is a wrapper for {@link ResourceFactory#newResource(String)}.
      *
      * @param uriOrPath The URL or path to convert
      * @return The Resource for the URL/path
      * @throws IOException The Resource could not be created.
-     * @deprecated use {@code ResourceFactory.of(component).newResource(String)} properly
-     *             at webapp initialization time only.  The use of this method during
-     *             context started phase can result in excessive memory consumption.
+     * @deprecated The use of {@link ResourceFactory#newResource(String)} should be reserved for
+     *             configuration and initialization phases of the webapp, and avoided during
+     *             started phase of a webapp.<br/>
+     *             The use of this method during context started phase can result in
+     *             excessive memory consumption depending on the types of resources your webapp is using.
      */
     @Deprecated(since = "12.1.11", forRemoval = true)
     public Resource newResource(String uriOrPath) throws IOException


### PR DESCRIPTION
Improvement of the deprecation comments around the various (Servlet)ContextHandler.newResource() methods.

Note: nothing in our own code uses these methods.

Closes #15228