### PR TITLE
test: cover http connection shutdown close

### DIFF
--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpConnectionTest.java
@@ -27,6 +27,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -1819,5 +1820,89 @@ public class HttpConnectionTest
             .distinct()
             .toList();
         assertThat(backingBuffers.size(), is(1));
+    }
+
+    @Test
+    public void testShutdownConnectorSendsConnectionClose() throws Exception
+    {
+        AtomicReference<Boolean> persistentOnWriteComplete = new AtomicReference<>();
+        CountDownLatch writeComplete = new CountDownLatch(1);
+        _server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                HttpConnection connection = (HttpConnection)request.getConnectionMetaData().getConnection();
+
+                _connector.shutdown();
+                response.setStatus(HttpStatus.OK_200);
+                response.write(true, BufferUtil.toBuffer("OK"), Callback.from(() ->
+                {
+                    persistentOnWriteComplete.set(connection.isPersistent());
+                    writeComplete.countDown();
+                    callback.succeeded();
+                }, callback::failed));
+                return true;
+            }
+        });
+        _server.start();
+
+        String rawResponse = _connector.getResponse("""
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.get(HttpHeader.CONNECTION), is("close"));
+        assertThat(response.getContent(), is("OK"));
+        assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
+        assertThat(persistentOnWriteComplete.get(), is(false));
+    }
+
+    @Test
+    public void testConnectionAttributesCanBeUpdatedAndRemoved() throws Exception
+    {
+        AtomicReference<Set<String>> namesAfterRemove = new AtomicReference<>();
+        AtomicReference<long[]> messageCounts = new AtomicReference<>();
+        CountDownLatch writeComplete = new CountDownLatch(1);
+        _server.setHandler(new Handler.Abstract.NonBlocking()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                HttpConnection connection = (HttpConnection)request.getConnectionMetaData().getConnection();
+
+                assertThat(connection.setAttribute("test.attribute", "initial"), Matchers.nullValue());
+                assertThat(connection.getAttribute("test.attribute"), is("initial"));
+                assertThat(connection.setAttribute("test.attribute", "updated"), is("initial"));
+                assertThat(connection.removeAttribute("test.attribute"), is("updated"));
+                namesAfterRemove.set(connection.getAttributeNameSet());
+
+                response.write(true, BufferUtil.toBuffer("OK"), Callback.from(() ->
+                {
+                    messageCounts.set(new long[] {connection.getMessagesIn(), connection.getMessagesOut()});
+                    writeComplete.countDown();
+                    callback.succeeded();
+                }, callback::failed));
+                return true;
+            }
+        });
+        _server.start();
+
+        String rawResponse = _connector.getResponse("""
+            GET / HTTP/1.1\r
+            Host: localhost\r
+            \r
+            """);
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+
+        assertThat(response.getStatus(), is(HttpStatus.OK_200));
+        assertThat(response.getContent(), is("OK"));
+        assertTrue(writeComplete.await(5, TimeUnit.SECONDS));
+        assertThat(messageCounts.get()[0], is(1L));
+        assertThat(messageCounts.get()[1], is(1L));
+        assertThat(namesAfterRemove.get(), not(Matchers.hasItem("test.attribute")));
     }
 }


### PR DESCRIPTION
Hi,

I added focused regression coverage for two small HttpConnection paths: the shutdown response path that should send `Connection: close`, and the connection attribute path for updating, removing, and checking request/response message counts. These keep the behavior covered directly without adding much test setup.

Impact on coverage:

* Covers the relevant HttpConnection logic, including the [request/response message accounting path](https://github.com/eclipse/jetty.project/blob/jetty-12.1.x/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java#L265-L273) and the [send callback reset path](https://github.com/eclipse/jetty.project/blob/jetty-12.1.x/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpConnection.java#L815-L830).
* Line coverage for HttpConnection increases by about 2%.

I hope you find these tests useful. 😄 Please let me know if you have any questions or concerns.

Thanks,
Amir