### PR TITLE
Fixes #13970 - ForwardedRequestCustomizer must not use     the request port when the Forwarded host has no port

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/ForwardedRequestCustomizer.java
@@ -533,7 +533,11 @@ public class ForwardedRequestCustomizer implements HttpConfiguration.Customizer
 
             if (port == MutableHostPort.UNSET) // is unset by headers
             {
-                port = builder.getPort();
+                // The headers replaced the authority without specifying a port,
+                // so the port is implied by the scheme. Do not fall back to the
+                // port of the incoming request, as it refers to the local
+                // connector, not to the authority seen by the client.
+                port = MutableHostPort.IMPLIED;
             }
 
             // Don't change port if port == IMPLIED.

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/ForwardedRequestCustomizerTest.java
@@ -377,6 +377,32 @@ public class ForwardedRequestCustomizerTest
                     .requestURL("https://myhost/")
             ),
 
+            // Forwarded host without port, with a Host header that has a port.
+            // The port is implied by the (forwarded) scheme, and must not be
+            // taken from the Host header of the incoming request.
+            Arguments.of(new TestRequest("RFC7239: Forwarded host without port (https)")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: localhost:8080",
+                        "Forwarded: host=example.com;proto=https"
+                    ),
+                new Expectations()
+                    .scheme("https").serverName("example.com").serverPort(443)
+                    .secure(true)
+                    .requestURL("https://example.com/")
+            ),
+            Arguments.of(new TestRequest("RFC7239: Forwarded host without port (http)")
+                    .headers(
+                        "GET / HTTP/1.1",
+                        "Host: localhost:8080",
+                        "Forwarded: host=example.com;proto=http"
+                    ),
+                new Expectations()
+                    .scheme("http").serverName("example.com").serverPort(80)
+                    .secure(false)
+                    .requestURL("http://example.com/")
+            ),
+
             // =================================================================
             // ProxyPass usages
             Arguments.of(new TestRequest("ProxyPass (example.com:80 to localhost:8080)")
@@ -1136,6 +1162,22 @@ public class ForwardedRequestCustomizerTest
                 new Expectations()
                     .scheme("https").serverName("new.example.net").serverPort(7443)
                     .requestURL("https://new.example.net:7443/test/forwarded.jsp")
+                    .remoteAddr("192.168.2.6").remotePort(0)
+            ),
+            // RFC7239 Tests with https, port in Host, no port in Forwarded host.
+            // The port is implied by the forwarded proto, and must not be taken
+            // from the Host header (or connector) of the incoming request.
+            Arguments.of(new TestRequest("RFC7239 with port in Host and no port in Forwarded host on https and h2")
+                    .headers(
+                        "GET /test/forwarded.jsp HTTP/1.1",
+                        "Host: web.example.net:9443",
+                        "Forwarded: for=192.168.2.6;host=new.example.net;proto=https;proto-version=h2"
+                        // Client: https://new.example.net/test/forwarded.jsp
+                        // Proxy Requests: https://web.example.net:9443/test/forwarded.jsp
+                    ),
+                new Expectations()
+                    .scheme("https").serverName("new.example.net").serverPort(443)
+                    .requestURL("https://new.example.net/test/forwarded.jsp")
                     .remoteAddr("192.168.2.6").remotePort(0)
             )
         );


### PR DESCRIPTION
Fixes #13970

## Problem

When a `Forwarded` (RFC 7239) header specifies a host without a port (e.g. `Forwarded: host=example.com;proto=https`), `ForwardedRequestCustomizer` falls back to the port of the incoming request (`builder.getPort()`), i.e. the local connector port. Behind a reverse proxy this leaks the backend port into the request authority, so the request URL is reconstructed as `https://example.com:8084/` instead of `https://example.com/`, breaking redirects and any URL generated from the request.

The `X-Forwarded-Host` path does not have this problem: `MutableHostPort.setHostPort(HostPort, Source)` maps a missing port to `IMPLIED`. But the RFC 7239 `host=` parameter goes through `setHostPort(String, int, Source)`, which stores `HostPort.getPort()`'s `-1` (`URIUtil.UNDEFINED_PORT`) as-is, leaving the port `UNSET` and triggering the local-port fallback in `customize()`.

## Fix

When the headers set the authority but no port, resolve the port to `MutableHostPort.IMPLIED` instead of the incoming request's port. Every path that can reach this fallback (RFC 7239 `host=`/`by=`, forced host) has set the host from the headers, so the implied port of the (possibly also forwarded) scheme is the correct client-facing value. This also matches how other implementations (e.g. Vert.x `ForwardedParser`) resolve a missing forwarded port, and makes the `Forwarded` header consistent with the existing `X-Forwarded-Host` behavior (see the existing "ProxyPass (example.com:80 to localhost:8080)" test case).

Note that the pre-existing "RFC7239 mixed with X-Forwarded-* headers" test expects `Forwarded: ...;host=example.com` to override an earlier `X-Forwarded-Port: 3333` with an implied port, so the port must be resolved at the `customize()` fallback rather than by switching the RFC 7239 parsing to the `setHostPort(HostPort, Source)` overload (which would let the lower-priority explicit port win).

## Tests

- Added `cases()` entries reproducing the issue: `Host: localhost:8080` + `Forwarded: host=example.com;proto=https|http` must yield `https://example.com/` / `http://example.com/` with the scheme-default server port.
- Added a `nonStandardPortCases()` entry: `Host: web.example.net:9443` + `Forwarded: for=...;host=new.example.net;proto=https` must yield `https://new.example.net/` (port 443), not `https://new.example.net:9443/`.
- All existing `ForwardedRequestCustomizerTest` cases pass unchanged.
