### PR TITLE
Fixes #15385, #15391 - HTTP/3 & Quiche dependencies.

### DIFF
--- a/documentation/jetty/modules/programming-guide/pages/client/http3.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/client/http3.adoc
@@ -19,11 +19,60 @@ The high-level HTTP library supports cookies, authentication, redirection, conne
 
 The low-level HTTP/3 client library has been designed for those applications that need low-level access to HTTP/3 features such as _sessions_, _streams_ and _frames_, and this is quite a rare use case.
 
-Support for the QUIC protocol underlying HTTP/3 is provided by default via Jetty classes that wrap the link:https://github.com/cloudflare/quiche[Quiche] native library.
+See also the correspondent xref:server/http3.adoc[HTTP/3 server library].
+
+[[intro]]
+== Introducing HTTP3Client
+
+The Maven artifact coordinates for the HTTP/3 client library are the following:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.http3</groupId>
+  <artifactId>jetty-http3-client</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+The HTTP/3 protocol is layered on top of the underlying QUIC protocol.
+
+The QUIC protocol implementation underlying HTTP/3 is provided by Jetty classes that wrap the link:https://github.com/cloudflare/quiche[Quiche] native library, so you need also the following artifact:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-client</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+Furthermore, the binding to the Quiche native library has two implementations: one based on link:https://github.com/java-native-access/jna[JNA] that works with Java 17 or later, and one based on JDK's https://openjdk.org/jeps/454[Foreign Function & Memory (FFM)] APIs that works with Java 22 or later.
+
+You must choose the binding you want to use (depending on the Java version you are using), with either of the following artifacts:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-jna</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-foreign</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
 
 [NOTE]
 ====
-Since Java 22, the JVM emits a warning message when Java code tries to access native code.
+Since Java 22, the JVM emits a warning message when Java code tries to access code in native libraries.
 For example with Java 25:
 
 ----
@@ -41,22 +90,6 @@ To grant Jetty access to the Quiche native library, use `--enable-native-access=
 This grants only to the Jetty JPMS module `org.eclipse.jetty.quic.quiche.foreign` in the module-path access to any native library.
 ====
 
-See also the correspondent xref:server/http3.adoc[HTTP/3 server library].
-
-[[intro]]
-== Introducing HTTP3Client
-
-The Maven artifact coordinates for the HTTP/3 client library are the following:
-
-[,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>org.eclipse.jetty.http3</groupId>
-  <artifactId>jetty-http3-client</artifactId>
-  <version>{jetty-version}</version>
-</dependency>
-----
-
 The main class is named `org.eclipse.jetty.http3.client.HTTP3Client`, and must be created, configured and started before use:
 
 [,java,indent=0]
@@ -73,18 +106,16 @@ include::code:example$src/main/java/org/eclipse/jetty/docs/programming/client/ht
 
 `HTTP3Client` allows client applications to connect to an HTTP/3 server.
 
-The HTTP/3 protocol is layered on top of the underlying QUIC protocol.
-
 When a client wants to establish a connection with a server, the QUIC protocol establishes the connection with the server, represented by a QUIC _session_.
 
 A QUIC _session_ typically has a long life -- once the connection is established, it remains active until it is not used anymore (and therefore it is closed by the idle timeout mechanism), until a fatal error occurs (for example, a network failure), or if one of the peers decides unilaterally to close the connection.
 
-There is a 1-to-1 relationship between a QUIC _session_ and an HTTP/3 _session_, defined by class `org.eclipse.jetty.http3.api.Session`.
+There is a 1-to-1 relationship between a QUIC _session_ and an HTTP/3 _session_, defined by class `org.eclipse.jetty.http3.api.Session.Client`.
 
 The QUIC protocol is multiplexed, that is it allows multiple, independent, QUIC _streams_ to exchange data to and from the server, over a single connection.
 Therefore, a single QUIC _session_ manages multiple concurrent QUIC _streams_.
 
-There is a 1-to-1 relationship between a QUIC _stream_ and an HTTP/3 _stream_, defined by class `org.eclipse.jetty.http3.api.Stream`.
+There is a 1-to-1 relationship between a QUIC _stream_ and an HTTP/3 _stream_, defined by class `org.eclipse.jetty.http3.api.Stream.Client`.
 
 Each HTTP/3 request/response cycle is carried by an HTTP/3 _stream_, and has typically a very short life compared to the _session_: a _stream_ only exists for the duration of the request/response cycle and then disappears.
 

--- a/documentation/jetty/modules/programming-guide/pages/server/http3.adoc
+++ b/documentation/jetty/modules/programming-guide/pages/server/http3.adoc
@@ -17,7 +17,56 @@ In the vast majority of cases, server applications should use the generic, high-
 
 The low-level HTTP/3 server library has been designed for those applications that need low-level access to HTTP/3 features such as _sessions_, _streams_ and _frames_, and this is quite a rare use case.
 
-Support for the QUIC protocol underlying HTTP/3 is provided by default via Jetty classes that wrap the link:https://github.com/cloudflare/quiche[Quiche] native library.
+See also the correspondent xref:client/http3.adoc[HTTP/3 client library].
+
+[[intro]]
+== Introduction
+
+The Maven artifact coordinates for the HTTP/3 server library are the following:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.http3</groupId>
+  <artifactId>jetty-http3-server</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+The HTTP/3 protocol is layered on top of the underlying QUIC protocol.
+
+The QUIC protocol implementation underlying HTTP/3 is provided by Jetty classes that wrap the link:https://github.com/cloudflare/quiche[Quiche] native library, so you need also the following artifact:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-server</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+Furthermore, the binding to the Quiche native library has two implementations: one based on link:https://github.com/java-native-access/jna[JNA] that works with Java 17 or later, and one based on JDK's https://openjdk.org/jeps/454[Foreign Function & Memory (FFM)] APIs that works with Java 22 or later.
+
+You must choose the binding you want to use (depending on the Java version you are using), with either of the following artifacts:
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-jna</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
+
+[,xml,subs=attributes+]
+----
+<dependency>
+  <groupId>org.eclipse.jetty.quic</groupId>
+  <artifactId>jetty-quic-quiche-foreign</artifactId>
+  <version>{jetty-version}</version>
+</dependency>
+----
 
 [NOTE]
 ====
@@ -39,34 +88,16 @@ To grant Jetty access to the Quiche native library, use `--enable-native-access=
 This grants only to the Jetty JPMS module `org.eclipse.jetty.quic.quiche.foreign` in the module-path access to any native library.
 ====
 
-See also the correspondent xref:client/http3.adoc[HTTP/3 client library].
-
-[[intro]]
-== Introduction
-
-The Maven artifact coordinates for the HTTP/3 server library are the following:
-
-[,xml,subs=attributes+]
-----
-<dependency>
-  <groupId>org.eclipse.jetty.http3</groupId>
-  <artifactId>jetty-http3-server</artifactId>
-  <version>{jetty-version}</version>
-</dependency>
-----
-
-The HTTP/3 protocol is layered on top of the underlying QUIC protocol.
-
 When a client wants to establish a connection with a server, the QUIC protocol establishes the connection with the server, represented by a QUIC _session_.
 
 A QUIC _session_ typically has a long life -- once the connection is established, it remains active until it is not used anymore (and therefore it is closed by the idle timeout mechanism), until a fatal error occurs (for example, a network failure), or if one of the peers decides unilaterally to close the connection.
 
-There is a 1-to-1 relationship between a QUIC _session_ and an HTTP/3 _session_, defined by class `org.eclipse.jetty.http3.api.Session`.
+There is a 1-to-1 relationship between a QUIC _session_ and an HTTP/3 _session_, defined by class `org.eclipse.jetty.http3.api.Session.Server`.
 
 The QUIC protocol is multiplexed, that is it allows multiple, independent, QUIC _streams_ to exchange data to and from the server, over a single connection.
 Therefore, a single QUIC _session_ manages multiple concurrent QUIC _streams_.
 
-There is a 1-to-1 relationship between a QUIC _stream_ and an HTTP/3 _stream_, defined by class `org.eclipse.jetty.http3.api.Stream`.
+There is a 1-to-1 relationship between a QUIC _stream_ and an HTTP/3 _stream_, defined by class `org.eclipse.jetty.http3.api.Stream.Server`.
 
 Each HTTP/3 request/response cycle is carried by an HTTP/3 _stream_, and has typically a very short life compared to the _session_: a _stream_ only exists for the duration of the request/response cycle and then disappears.
 

--- a/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
+++ b/jetty-core/jetty-http3/jetty-http3-tests/pom.xml
@@ -79,10 +79,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/pom.xml
@@ -87,4 +87,5 @@
       </build>
     </profile>
   </profiles>
+
 </project>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-client/pom.xml
@@ -22,11 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty.quic</groupId>
-      <artifactId>jetty-quic-quiche-jna</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
+      <artifactId>jetty-quic-quiche-common</artifactId>
     </dependency>
 
     <dependency>
@@ -53,23 +49,32 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
-      <!--
-      This profile makes sure the Foreign binding is used for tests when running on JDK 22+.
-      Older JDKs will revert to the JNA binding.
-      -->
       <dependencies>
         <dependency>
           <groupId>org.eclipse.jetty.quic</groupId>
           <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
         </dependency>
       </dependencies>
       <build>
         <plugins>
-          <!-- Make sure to use the Foreign binding by allowing native access to the foreign module. -->
           <plugin>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>

--- a/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
+++ b/jetty-core/jetty-quic/jetty-quic-quiche/jetty-quic-quiche-common/src/main/java/org/eclipse/jetty/quic/quiche/Quiche.java
@@ -41,32 +41,39 @@ public abstract class Quiche
 
     static
     {
-        // This code is safe even if trying to load a QuicheBinding instance throws an error,
-        // as in that case a warning would be logged and the binding ignored.
-        List<QuicheBinding> bindings = TypeUtil.serviceStream(ServiceLoader.load(QuicheBinding.class))
-            .sorted(Comparator.comparingInt(QuicheBinding::priority))
-            .collect(Collectors.toList());
+        try
+        {
+            // Don't fail if a binding cannot be loaded, try the next.
+            List<QuicheBinding> bindings = TypeUtil.serviceStream(ServiceLoader.load(QuicheBinding.class))
+                .sorted(Comparator.comparingInt(QuicheBinding::priority))
+                .collect(Collectors.toList());
 
-        if (LOG.isDebugEnabled())
-            LOG.debug("found quiche binding implementations: {}", bindings);
+            if (LOG.isDebugEnabled())
+                LOG.debug("found quiche binding implementations: {}", bindings);
 
-        List<Throwable> failures = new ArrayList<>();
-        QUICHE_BINDING = bindings.stream()
-            .filter(quicheBinding ->
-            {
-                Throwable failure = quicheBinding.initialize();
-                failures.add(failure);
-                return failure == null;
-            })
-            .min(Comparator.comparingInt(QuicheBinding::priority))
-            .orElseThrow(() ->
-            {
-                IllegalStateException ise = new IllegalStateException("no quiche binding implementation found");
-                failures.forEach(ise::addSuppressed);
-                return ise;
-            });
-        if (LOG.isDebugEnabled())
-            LOG.debug("using quiche binding implementation: {}", QUICHE_BINDING.getClass().getName());
+            List<Throwable> failures = new ArrayList<>();
+            QUICHE_BINDING = bindings.stream()
+                .filter(quicheBinding ->
+                {
+                    Throwable failure = quicheBinding.initialize();
+                    failures.add(failure);
+                    return failure == null;
+                })
+                .min(Comparator.comparingInt(QuicheBinding::priority))
+                .orElseThrow(() ->
+                {
+                    IllegalStateException ise = new IllegalStateException("no quiche binding implementation found");
+                    failures.forEach(ise::addSuppressed);
+                    return ise;
+                });
+            if (LOG.isDebugEnabled())
+                LOG.debug("using quiche binding implementation: {}", QUICHE_BINDING.getClass().getName());
+        }
+        catch (Throwable x)
+        {
+            LOG.warn("could not resolve quiche binding", x);
+            throw x;
+        }
     }
 
     public static InetSocketAddress toInetSocketAddress(SocketAddress address, boolean client)

--- a/jetty-core/jetty-quic/jetty-quic-tests/pom.xml
+++ b/jetty-core/jetty-quic/jetty-quic-tests/pom.xml
@@ -62,4 +62,45 @@
     </dependency>
   </dependencies>
 
+  <profiles>
+    <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>enable-foreign</id>
+      <activation>
+        <jdk>[22,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}
+                ${jetty.surefire.argLine}
+                --enable-native-access=org.eclipse.jetty.quic.quiche.foreign</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-client-transports/pom.xml
@@ -106,10 +106,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-core/jetty-tests/jetty-test-rfc/pom.xml
+++ b/jetty-core/jetty-tests/jetty-test-rfc/pom.xml
@@ -111,10 +111,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/pom.xml
@@ -111,10 +111,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/pom.xml
@@ -228,4 +228,46 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>enable-foreign</id>
+      <activation>
+        <jdk>[22,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}
+                ${jetty.surefire.argLine}
+                --enable-native-access=org.eclipse.jetty.quic.quiche.foreign</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/pom.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/pom.xml
@@ -111,10 +111,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/pom.xml
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-integration/pom.xml
@@ -228,4 +228,46 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>enable-foreign</id>
+      <activation>
+        <jdk>[22,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}
+                ${jetty.surefire.argLine}
+                --enable-native-access=org.eclipse.jetty.quic.quiche.foreign</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-client-transports/pom.xml
@@ -111,10 +111,30 @@
 
   <profiles>
     <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
       <id>enable-foreign</id>
       <activation>
         <jdk>[22,)</jdk>
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
       <build>
         <plugins>
           <plugin>

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/pom.xml
@@ -265,4 +265,46 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>enable-foreign</id>
+      <activation>
+        <jdk>[22,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}
+                ${jetty.surefire.argLine}
+                --enable-native-access=org.eclipse.jetty.quic.quiche.foreign</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+
 </project>

--- a/tests/test-distribution/test-distribution-common/pom.xml
+++ b/tests/test-distribution/test-distribution-common/pom.xml
@@ -356,7 +356,6 @@
 
   <build>
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
@@ -458,8 +457,48 @@
           </systemPropertyVariables>
         </configuration>
       </plugin>
-
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>enable-jna</id>
+      <activation>
+        <jdk>[17,22)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-jna</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>enable-foreign</id>
+      <activation>
+        <jdk>[22,)</jdk>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.eclipse.jetty.quic</groupId>
+          <artifactId>jetty-quic-quiche-foreign</artifactId>
+          <scope>test</scope>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <argLine>@{argLine}
+                ${jetty.surefire.argLine}
+                --enable-native-access=org.eclipse.jetty.quic.quiche.foreign</argLine>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
 </project>


### PR DESCRIPTION
* Updated `jetty-quic-quiche-client` dependencies to avoid hardcoding the dependency on `jetty-quic-quiche-jna`.
* Updated `jetty-quic-quiche-client` profiles for Java 17 using JNA and Java 22 using FFM for testing.
* Updated HTTP/3 documentation to reference Quiche dependencies and Quiche bindings (JNA vs FFM).