### PR TITLE
Upgrade mortbay apache-jsp and apache-el

### DIFF
--- a/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -52,7 +52,6 @@
       <artifactId>jetty-test-helper</artifactId>
       <scope>test</scope>
     </dependency>
-
   </dependencies>
 
   <build>

--- a/jetty-ee10/jetty-ee10-apache-jsp/src/main/config/modules/ee10-apache-jsp.mod
+++ b/jetty-ee10/jetty-ee10-apache-jsp/src/main/config/modules/ee10-apache-jsp.mod
@@ -20,7 +20,7 @@ ee10.jsp.impl.version?=@jsp.impl.version@
 lib/ee10-apache-jsp/jakarta.el.jakarta.el-api-${ee10.jakarta.el.api.version}.jar
 lib/ee10-apache-jsp/jakarta.servlet.jsp.jakarta.servlet.jsp-api-${ee10.jakarta.servlet.jsp.api.version}.jar
 lib/ee10-apache-jsp/org.eclipse.jdt.ecj-${eclipse.jdt.ecj.version}.jar
-lib/ee10-apache-jsp/org.mortbay.jasper.apache-el-${ee10.jsp.impl.version}.jar
-lib/ee10-apache-jsp/org.mortbay.jasper.apache-jsp-${ee10.jsp.impl.version}.jar
+lib/ee10-apache-jsp/org.mortbay.jasper.mortbay-apache-el-${ee10.jsp.impl.version}.jar
+lib/ee10-apache-jsp/org.mortbay.jasper.mortbay-apache-jsp-${ee10.jsp.impl.version}.jar
 lib/jetty-ee10-apache-jsp-${jetty.version}.jar
 

--- a/jetty-ee10/jetty-ee10-home/pom.xml
+++ b/jetty-ee10/jetty-ee10-home/pom.xml
@@ -319,7 +319,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>jakarta.servlet.jsp,jakarta.el,org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>jakarta.servlet.jsp-api,jakarta.el-api,apache-el,apache-jsp,ecj</includeArtifactIds>
+              <includeArtifactIds>jakarta.servlet.jsp-api,jakarta.el-api,mortbay-apache-el,mortbay-apache-jsp,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee10-apache-jsp</outputDirectory>
             </configuration>
@@ -333,7 +333,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>jakarta.servlet.jsp,jakart.el,org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>jakart.servlet.jsp-api,jakarta.el-api,apache-el,apache-jsp,ecj</includeArtifactIds>
+              <includeArtifactIds>jakart.servlet.jsp-api,jakarta.el-api,mortbay-apache-el,mortbay-apache-jsp,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee10-apache-jsp</outputDirectory>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/pom.xml
@@ -75,11 +75,11 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-el</artifactId>
+      <artifactId>mortbay-apache-el</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.tinybundles</groupId>

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/java/org/eclipse/jetty/ee10/osgi/test/TestOSGiUtil.java
@@ -247,8 +247,8 @@ public class TestOSGiUtil
         //jetty jsp bundles
         res.add(systemProperty("jakarta.el.ExpressionFactory").value("org.apache.el.ExpressionFactoryImpl"));
         res.add(mavenBundle().groupId("jakarta.servlet.jsp").artifactId("jakarta.servlet.jsp-api").versionAsInProject());
-        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-el").versionAsInProject().start());
-        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-jsp").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("mortbay-apache-el").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("mortbay-apache-jsp").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty.ee10").artifactId("jetty-ee10-apache-jsp").versionAsInProject().start());
         res.add(mavenBundle().groupId("jakarta.servlet.jsp.jstl").artifactId("jakarta.servlet.jsp.jstl-api").versionAsInProject());
         res.add(mavenBundle().groupId("org.glassfish.web").artifactId("jakarta.servlet.jsp.jstl").versionAsInProject().start());

--- a/jetty-ee10/pom.xml
+++ b/jetty-ee10/pom.xml
@@ -61,7 +61,7 @@
     <jakarta.xml.ws.api.version>4.0.3</jakarta.xml.ws.api.version>
     <jersey.version>3.1.12</jersey.version>
 
-    <jsp.impl.version>10.1.43</jsp.impl.version>
+    <jsp.impl.version>10.1.56</jsp.impl.version>
     <mail.impl.version>2.0.2</mail.impl.version>
 
     <sonar.skip>true</sonar.skip>
@@ -395,13 +395,13 @@
       </dependency>
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-el</artifactId>
+        <artifactId>mortbay-apache-el</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
       <!-- Jakarta EE10 Dependencies -->
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-jsp</artifactId>
+        <artifactId>mortbay-apache-jsp</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
     </dependencies>

--- a/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
+++ b/jetty-ee8/jetty-ee8-apache-jsp/pom.xml
@@ -27,7 +27,7 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
       <exclusions>
         <exclusion>
           <groupId>org.eclipse.jetty.toolchain</groupId>

--- a/jetty-ee8/jetty-ee8-apache-jsp/src/main/config/modules/ee8-apache-jsp.mod
+++ b/jetty-ee8/jetty-ee8-apache-jsp/src/main/config/modules/ee8-apache-jsp.mod
@@ -16,6 +16,6 @@ ee8.jsp.impl.version?=@jsp.impl.version@
 
 [lib]
 lib/ee8-apache-jsp/org.eclipse.jdt.ecj-${eclipse.jdt.ecj.version}.jar
-lib/ee8-apache-jsp/org.mortbay.jasper.apache-el-${ee8.jsp.impl.version}.jar
-lib/ee8-apache-jsp/org.mortbay.jasper.apache-jsp-${ee8.jsp.impl.version}.jar
+lib/ee8-apache-jsp/org.mortbay.jasper.mortbay-apache-el-${ee8.jsp.impl.version}.jar
+lib/ee8-apache-jsp/org.mortbay.jasper.mortbay-apache-jsp-${ee8.jsp.impl.version}.jar
 lib/jetty-ee8-apache-jsp-${jetty.version}.jar

--- a/jetty-ee8/jetty-ee8-home/pom.xml
+++ b/jetty-ee8/jetty-ee8-home/pom.xml
@@ -314,7 +314,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-jsp,apache-el,ecj</includeArtifactIds>
+              <includeArtifactIds>mortbay-apache-jsp,mortbay-apache-el,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee8-apache-jsp</outputDirectory>
             </configuration>
@@ -328,7 +328,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-jsp,apache-el,ecj</includeArtifactIds>
+              <includeArtifactIds>mortbay-apache-jsp,mortbay-apache-el,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee8-apache-jsp</outputDirectory>

--- a/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
+++ b/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/pom.xml
@@ -17,7 +17,7 @@
     <!-- too many duplicates with osgi jars... -->
     <duplicate-finder.skip>true</duplicate-finder.skip>
     <ee9.module>jetty-ee9-osgi/test-jetty-ee9-osgi</ee9.module>
-    <el.artifactId>apache-el</el.artifactId>
+    <el.artifactId>mortbay-apache-el</el.artifactId>
     <el.groupId>org.mortbay.jasper</el.groupId>
     <enterprise.artifactId>jakarta.enterprise.cdi-api</enterprise.artifactId>
     <enterprise.groupId>jakarta.enterprise</enterprise.groupId>
@@ -90,11 +90,11 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-el</artifactId>
+      <artifactId>mortbay-apache-el</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.tinybundles</groupId>

--- a/jetty-ee8/pom.xml
+++ b/jetty-ee8/pom.xml
@@ -50,7 +50,7 @@
     <javax.mail.glassfish.version>1.4.1.v201005082020</javax.mail.glassfish.version>
     <javax.servlet.jsp.jstl.impl.version>1.2.5</javax.servlet.jsp.jstl.impl.version>
     <jetty.servlet.api.version>4.0.9</jetty.servlet.api.version>
-    <jsp.impl.version>9.0.107</jsp.impl.version>
+    <jsp.impl.version>9.0.119</jsp.impl.version>
     <modify-sources-plugin.version>1.0.14</modify-sources-plugin.version>
     <sonar.skip>true</sonar.skip>
     <weld.version>3.1.9.Final</weld.version>
@@ -271,12 +271,12 @@
       </dependency>
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-el</artifactId>
+        <artifactId>mortbay-apache-el</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-jsp</artifactId>
+        <artifactId>mortbay-apache-jsp</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
     </dependencies>

--- a/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
+++ b/jetty-ee9/jetty-ee9-apache-jsp/pom.xml
@@ -26,7 +26,7 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/jetty-ee9/jetty-ee9-apache-jsp/src/main/config/modules/ee9-apache-jsp.mod
+++ b/jetty-ee9/jetty-ee9-apache-jsp/src/main/config/modules/ee9-apache-jsp.mod
@@ -16,6 +16,6 @@ ee9.jsp.impl.version?=@jsp.impl.version@
 
 [lib]
 lib/ee9-apache-jsp/org.eclipse.jdt.ecj-${eclipse.jdt.ecj.version}.jar
-lib/ee9-apache-jsp/org.mortbay.jasper.apache-el-${ee9.jsp.impl.version}.jar
-lib/ee9-apache-jsp/org.mortbay.jasper.apache-jsp-${ee9.jsp.impl.version}.jar
+lib/ee9-apache-jsp/org.mortbay.jasper.mortbay-apache-el-${ee9.jsp.impl.version}.jar
+lib/ee9-apache-jsp/org.mortbay.jasper.mortbay-apache-jsp-${ee9.jsp.impl.version}.jar
 lib/jetty-ee9-apache-jsp-${jetty.version}.jar

--- a/jetty-ee9/jetty-ee9-home/pom.xml
+++ b/jetty-ee9/jetty-ee9-home/pom.xml
@@ -321,7 +321,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-jsp,apache-el,ecj</includeArtifactIds>
+              <includeArtifactIds>mortbay-apache-jsp,mortbay-apache-el,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <outputDirectory>${assembly-directory}/lib/ee9-apache-jsp</outputDirectory>
             </configuration>
@@ -335,7 +335,7 @@
             <configuration>
               <prependGroupId>true</prependGroupId>
               <includeGroupIds>org.mortbay.jasper,org.eclipse.jdt</includeGroupIds>
-              <includeArtifactIds>apache-jsp,apache-el,ecj</includeArtifactIds>
+              <includeArtifactIds>mortbay-apache-jsp,mortbay-apache-el,ecj</includeArtifactIds>
               <includeTypes>jar</includeTypes>
               <classifier>sources</classifier>
               <outputDirectory>${source-assembly-directory}/lib/ee9-apache-jsp</outputDirectory>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/pom.xml
@@ -72,11 +72,11 @@
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-el</artifactId>
+      <artifactId>mortbay-apache-el</artifactId>
     </dependency>
     <dependency>
       <groupId>org.mortbay.jasper</groupId>
-      <artifactId>apache-jsp</artifactId>
+      <artifactId>mortbay-apache-jsp</artifactId>
     </dependency>
     <dependency>
       <groupId>org.ops4j.pax.tinybundles</groupId>

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/java/org/eclipse/jetty/ee9/osgi/test/TestOSGiUtil.java
@@ -285,8 +285,8 @@ public class TestOSGiUtil
             }
         }
 
-        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-el").versionAsInProject().start());
-        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("apache-jsp").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("mortbay-apache-el").versionAsInProject().start());
+        res.add(mavenBundle().groupId("org.mortbay.jasper").artifactId("mortbay-apache-jsp").versionAsInProject().start());
         res.add(mavenBundle().groupId("org.eclipse.jetty.ee9").artifactId("jetty-ee9-apache-jsp").versionAsInProject().start());
         String jstlGroupId = System.getProperty("jstl.groupId", "jakarta.servlet.jsp.jstl");
         String jstlArtifactId = System.getProperty("jstl.artifactId", "jakarta.servlet.jsp.jstl-api");

--- a/jetty-ee9/pom.xml
+++ b/jetty-ee9/pom.xml
@@ -70,7 +70,7 @@
     <!-- FIXME we need a separate property for this one -->
     <jetty.servlet.api.version>5.0.2</jetty.servlet.api.version>
 
-    <jsp.impl.version>10.0.27</jsp.impl.version>
+    <jsp.impl.version>10.0.27.2</jsp.impl.version>
 
     <sonar.skip>true</sonar.skip>
     <weld.version>4.0.3.Final</weld.version>
@@ -450,13 +450,13 @@
       </dependency>
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-el</artifactId>
+        <artifactId>mortbay-apache-el</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
       <!-- Jakarta EE 9 Dependencies -->
       <dependency>
         <groupId>org.mortbay.jasper</groupId>
-        <artifactId>apache-jsp</artifactId>
+        <artifactId>mortbay-apache-jsp</artifactId>
         <version>${jsp.impl.version}</version>
       </dependency>
     </dependencies>
@@ -651,7 +651,7 @@
                         <!-- for ee9, we need to stay on 10.0.x of mortbay apache-jsp impl
                              ee10 starts with version 10.1.x -->
                         <groupId>org.mortbay.jasper</groupId>
-                        <artifactId>apache-jsp</artifactId>
+                        <artifactId>mortbay-apache-jsp</artifactId>
                         <ignoreVersions>
                           <ignoreVersion>
                             <type>regex</type>
@@ -663,7 +663,7 @@
                         <!-- for ee9, we need to stay on 10.0.x of mortbay apache-el impl
                              ee10 starts with version 10.1.x -->
                         <groupId>org.mortbay.jasper</groupId>
-                        <artifactId>apache-el</artifactId>
+                        <artifactId>mortbay-apache-el</artifactId>
                         <ignoreVersions>
                           <ignoreVersion>
                             <type>regex</type>
@@ -934,7 +934,7 @@
                         <!-- for ee9, we need to stay on 10.0.x of mortbay apache-jsp impl
                              ee10 starts with version 10.1.x -->
                         <groupId>org.mortbay.jasper</groupId>
-                        <artifactId>apache-jsp</artifactId>
+                        <artifactId>mortbay-apache-jsp</artifactId>
                         <ignoreVersions>
                           <ignoreVersion>
                             <type>regex</type>
@@ -946,7 +946,7 @@
                         <!-- for ee9, we need to stay on 10.0.x of mortbay apache-el impl
                              ee10 starts with version 10.1.x -->
                         <groupId>org.mortbay.jasper</groupId>
-                        <artifactId>apache-el</artifactId>
+                        <artifactId>mortbay-apache-el</artifactId>
                         <ignoreVersions>
                           <ignoreVersion>
                             <type>regex</type>

--- a/jetty-home/pom.xml
+++ b/jetty-home/pom.xml
@@ -575,7 +575,7 @@
                     <exclude>jakarta.authentication:jakarta.authentication-api</exclude>
                     <exclude>jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api</exclude>
                     <exclude>org.glassfish.web:jakarta.servlet.jsp.jstl</exclude>
-                    <exclude>org.mortbay.jasper:apache-jsp</exclude>
+                    <exclude>org.mortbay.jasper:mortbay-apache-jsp</exclude>
                     <exclude>jakarta.transaction:jakarta.transaction-api</exclude>
                     <exclude>jakarta.interceptor:jakarta.interceptor-api</exclude>
                     <exclude>jakarta.enterprise:jakarta.enterprise.cdi-api</exclude>


### PR DESCRIPTION
Upgrading Mortbay Apache-JSP and Apache-EL dependencies for branch `jetty-12.0.x`