### PR TITLE
Issue #15096 CrossOriginHandler not returning valid headers when all headers are allowed

### DIFF
--- a/VERSION.txt
+++ b/VERSION.txt
@@ -1,4 +1,5 @@
 jetty-12.1.12-SNAPSHOT
+ + 15096 CrossOriginHandler not returning valid headers when all headers are allowed
 
 12.1.11 - 02 July 2026
  + 15156 Injecting authentication headers using request filters?

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/CrossOriginHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/CrossOriginHandler.java
@@ -76,6 +76,7 @@ public class CrossOriginHandler extends Handler.Wrapper
     private final Set<Pattern> allowedOriginPatterns = new LinkedHashSet<>();
     private boolean anyTimingOriginAllowed;
     private final Set<Pattern> allowedTimingOriginPatterns = new LinkedHashSet<>();
+    private boolean anyHeadersAllowed;
     private PreEncodedHttpField accessControlAllowMethodsField;
     private PreEncodedHttpField accessControlAllowHeadersField;
     private PreEncodedHttpField accessControlExposeHeadersField;
@@ -122,7 +123,8 @@ public class CrossOriginHandler extends Handler.Wrapper
      * Browsers are responsible to check whether the headers of the cross-origin
      * request are allowed, and if they are not produce an error.</p>
      * <p>The headers can be either the character {@code *} to indicate any
-     * header, or actual header names.</p>
+     * header (in which case the requested headers are reflected in the preflight
+     * response), or actual header names.</p>
      *
      * @param headers the set of allowed headers in a cross-origin request
      */
@@ -314,8 +316,10 @@ public class CrossOriginHandler extends Handler.Wrapper
     {
         resolveAllowedOrigins();
         resolveAllowedTimingOrigins();
+        resolveAllowedHeaders();
         accessControlAllowMethodsField = new PreEncodedHttpField(HttpHeader.ACCESS_CONTROL_ALLOW_METHODS, String.join(",", getAllowedMethods()));
-        accessControlAllowHeadersField = new PreEncodedHttpField(HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS, String.join(",", getAllowedHeaders()));
+        if (!anyHeadersAllowed)
+            accessControlAllowHeadersField = new PreEncodedHttpField(HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS, String.join(",", getAllowedHeaders()));
         accessControlExposeHeadersField = new PreEncodedHttpField(HttpHeader.ACCESS_CONTROL_EXPOSE_HEADERS, String.join(",", getExposedHeaders()));
         accessControlMaxAge = new PreEncodedHttpField(HttpHeader.ACCESS_CONTROL_MAX_AGE, getPreflightMaxAge().toSeconds());
 
@@ -349,7 +353,7 @@ public class CrossOriginHandler extends Handler.Wrapper
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("preflight cross-origin request {}", request);
-                handlePreflightResponse(origins, response);
+                handlePreflightResponse(request, origins, response);
                 if (!isDeliverPreflightRequests())
                 {
                     if (LOG.isDebugEnabled())
@@ -457,7 +461,7 @@ public class CrossOriginHandler extends Handler.Wrapper
         return request.getHeaders().contains(HttpHeader.SEC_WEBSOCKET_VERSION);
     }
 
-    private void handlePreflightResponse(String origins, Response response)
+    private void handlePreflightResponse(Request request, String origins, Response response)
     {
         HttpFields.Mutable headers = response.getHeaders();
         headers.put(HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN, origins);
@@ -466,9 +470,18 @@ public class CrossOriginHandler extends Handler.Wrapper
         Set<String> allowedMethods = getAllowedMethods();
         if (!allowedMethods.isEmpty())
             headers.put(accessControlAllowMethodsField);
-        Set<String> allowedHeaders = getAllowedHeaders();
-        if (!allowedHeaders.isEmpty())
-            headers.put(accessControlAllowHeadersField);
+        if (anyHeadersAllowed)
+        {
+            String requestedHeaders = request.getHeaders().get(HttpHeader.ACCESS_CONTROL_REQUEST_HEADERS);
+            if (requestedHeaders != null && !requestedHeaders.isBlank())
+                headers.put(HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS, requestedHeaders);
+        }
+        else
+        {
+            Set<String> allowedHeaders = getAllowedHeaders();
+            if (!allowedHeaders.isEmpty())
+                headers.put(accessControlAllowHeadersField);
+        }
         long seconds = getPreflightMaxAge().toSeconds();
         if (seconds > 0)
             headers.put(accessControlMaxAge);
@@ -518,6 +531,18 @@ public class CrossOriginHandler extends Handler.Wrapper
             }
 
             allowedTimingOriginPatterns.add(Pattern.compile(allowedTimingOrigin, Pattern.CASE_INSENSITIVE));
+        }
+    }
+
+    private void resolveAllowedHeaders()
+    {
+        for (String allowedHeader : getAllowedHeaders())
+        {
+            if ("*".equals(allowedHeader.trim()))
+            {
+                anyHeadersAllowed = true;
+                return;
+            }
         }
     }
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/CrossOriginHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/CrossOriginHandlerTest.java
@@ -393,7 +393,7 @@ public class CrossOriginHandlerTest
             OPTIONS / HTTP/1.1\r
             Host: localhost\r
             Connection: close\r
-            Access-Control-Request-Headers: X-Foo-Bar\r
+            Access-Control-Request-Headers: X-Foo-Bar, X-Baz\r
             Access-Control-Request-Method: GET\r
             Origin: http://localhost\r
             \r
@@ -403,8 +403,8 @@ public class CrossOriginHandlerTest
         assertThat(response.getStatus(), is(HttpStatus.OK_200));
         assertFalse(response.contains(ApplicationHandler.APPLICATION_HEADER));
         assertTrue(response.contains(HttpHeader.ACCESS_CONTROL_ALLOW_ORIGIN));
-        assertTrue(response.contains(HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS));
-        assertTrue(response.contains(HttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        assertThat(response.get(HttpHeader.ACCESS_CONTROL_ALLOW_CREDENTIALS), is("true"));
+        assertThat(response.get(HttpHeader.ACCESS_CONTROL_ALLOW_HEADERS), is("X-Foo-Bar, X-Baz"));
     }
 
     @Test


### PR DESCRIPTION
Fixes #15096

If you set `allowedHeaders=*` on `CrossOriginHandler` with credentials enabled, preflight responses come back with `Access-Control-Allow-Headers: *`. That is not valid for credentialed CORS requests, so browsers fail the preflight. The old `CrossOriginFilter` already reflected `Access-Control-Request-Headers` in this case.

This makes `CrossOriginHandler` do the same: when allowed headers are `*`, echo the requested headers on the preflight response. Explicit header lists are unchanged.

Updated `testPreflightWithWildcardCustomHeaders` to check the reflected value instead of only that the header is present.