### PR TITLE
Fixes #15432 - Brotli compression truncates responses larger than the encoder buffer

### DIFF
--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/main/java/org/eclipse/jetty/compression/brotli/internal/BrotliEncoderSink.java
@@ -30,19 +30,23 @@ public class BrotliEncoderSink extends EncoderSink
     enum State
     {
         /**
-         * Taking the input and encoding.
+         * Consuming input content, pushing it to the encoder each time the input buffer fills.
          */
         PROCESSING,
         /**
-         * Done taking input, flushing what's left in encoder.
+         * Draining the output of a {@link EncoderJNI.Operation#PROCESS} operation, one buffer at a time.
          */
-        FLUSHING,
+        PROCESS_OUTPUT,
         /**
-         * Done flushing, performing finish operation.
+         * Draining the output of the final {@link EncoderJNI.Operation#FLUSH} operation.
          */
-        FINISHING,
+        FLUSH_OUTPUT,
         /**
-         * Finish operation completed.
+         * Draining the output of the final {@link EncoderJNI.Operation#FINISH} operation.
+         */
+        FINISH_OUTPUT,
+        /**
+         * All output has been produced.
          */
         FINISHED
     }
@@ -69,7 +73,10 @@ public class BrotliEncoderSink extends EncoderSink
     @Override
     protected WriteRecord encode(boolean last, ByteBuffer content)
     {
-        if (encoder.isFinished())
+        // Guard on our own terminal state: a single operation is drained across several invocations, so
+        // the encoder can report finished while we are still being re-invoked to emit its output. Only a
+        // write once we have reached FINISHED is illegal.
+        if (state.get() == State.FINISHED)
             throw new IllegalStateException("Already released");
 
         while (true)
@@ -78,46 +85,57 @@ public class BrotliEncoderSink extends EncoderSink
             {
                 case PROCESSING ->
                 {
-                    try
+                    if (BufferUtil.hasContent(content))
                     {
-                        while (BufferUtil.hasContent(content))
+                        if (inputBuffer.hasRemaining())
                         {
-                            // only encode if inputBuffer is full.
-                            if (!inputBuffer.hasRemaining())
-                            {
-                                ByteBuffer output = encode(EncoderJNI.Operation.PROCESS);
-                                if (output != null)
-                                    return new WriteRecord(false, output, Callback.NOOP);
-                            }
-
-                            // the only place the input buffer gets set.
+                            // Fill the input buffer; do not flip it, that's not what Brotli4j expects/wants.
                             BufferUtil.put(content, inputBuffer);
-                            // do not flip input buffer, that's not what Brotli4j expects/wants.
                         }
-                        // content is fully consumed.
+                        else
+                        {
+                            // Input buffer full: hand it to the encoder, then drain the produced output.
+                            encoder.push(EncoderJNI.Operation.PROCESS, inputBuffer.limit());
+                            state.set(State.PROCESS_OUTPUT);
+                        }
+                    }
+                    else
+                    {
+                        // Content fully consumed. A non-last write simply waits for more content.
                         if (!last)
                             return null;
-                    }
-                    finally
-                    {
-                        if (last)
-                            state.compareAndSet(State.PROCESSING, State.FLUSHING);
+                        // Final write: flush whatever is still buffered, then finish.
+                        inputBuffer.limit(inputBuffer.position());
+                        encoder.push(EncoderJNI.Operation.FLUSH, inputBuffer.limit());
+                        state.set(State.FLUSH_OUTPUT);
                     }
                 }
-                case FLUSHING ->
+                case PROCESS_OUTPUT ->
                 {
-                    inputBuffer.limit(inputBuffer.position());
-                    ByteBuffer output = encode(EncoderJNI.Operation.FLUSH);
-                    state.compareAndSet(State.FLUSHING, State.FINISHING);
+                    ByteBuffer output = drain(EncoderJNI.Operation.PROCESS);
                     if (output != null)
                         return new WriteRecord(false, output, Callback.NOOP);
+                    // Output drained: reuse the input buffer for the next content.
+                    inputBuffer.clear();
+                    state.set(State.PROCESSING);
                 }
-                case FINISHING ->
+                case FLUSH_OUTPUT ->
                 {
-                    inputBuffer.limit(inputBuffer.position());
-                    ByteBuffer output = encode(EncoderJNI.Operation.FINISH);
-                    state.compareAndSet(State.FINISHING, State.FINISHED);
-                    return new WriteRecord(true, output != null ? output : BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+                    ByteBuffer output = drain(EncoderJNI.Operation.FLUSH);
+                    if (output != null)
+                        return new WriteRecord(false, output, Callback.NOOP);
+                    // Flush drained: finish the stream (no further input).
+                    encoder.push(EncoderJNI.Operation.FINISH, 0);
+                    state.set(State.FINISH_OUTPUT);
+                }
+                case FINISH_OUTPUT ->
+                {
+                    ByteBuffer output = drain(EncoderJNI.Operation.FINISH);
+                    if (output != null)
+                        return new WriteRecord(false, output, Callback.NOOP);
+                    // Finish drained: signal completion with a final empty last write.
+                    state.set(State.FINISHED);
+                    return new WriteRecord(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
                 }
                 case FINISHED ->
                 {
@@ -127,37 +145,37 @@ public class BrotliEncoderSink extends EncoderSink
         }
     }
 
-    protected ByteBuffer encode(EncoderJNI.Operation op)
+    /**
+     * Returns the next output buffer produced by the given operation, or {@code null} once the operation
+     * has been fully drained.
+     *
+     * <p>The operation's input must already have been submitted with
+     * {@link EncoderJNI.Wrapper#push(EncoderJNI.Operation, int)}; this method only pulls output and, if the
+     * encoder still holds unprocessed input, drives it with a zero-length push. A single operation
+     * (notably the final {@code FLUSH}/{@code FINISH} of a large response) can produce several output
+     * buffers, so this returns one buffer at a time and is invoked once per {@link EncoderSink} write.
+     * Returning them individually is what prevents earlier buffers from being dropped and the response
+     * from being truncated.</p>
+     */
+    private ByteBuffer drain(EncoderJNI.Operation op)
     {
         try
         {
-            boolean inputPushed = false;
-            ByteBuffer output = null;
             while (true)
             {
                 if (!encoder.isSuccess())
-                {
                     throw new IOException("Brotli Encoder failure");
-                }
-                // process previous output before new input
-                else if (encoder.hasMoreOutput())
-                {
-                    output = encoder.pull();
-                }
-                else if (encoder.hasRemainingInput())
+
+                if (encoder.hasMoreOutput())
+                    return encoder.pull();
+
+                if (encoder.hasRemainingInput())
                 {
                     encoder.push(op, 0);
+                    continue;
                 }
-                else if (!inputPushed)
-                {
-                    encoder.push(op, inputBuffer.limit());
-                    inputPushed = true;
-                }
-                else
-                {
-                    inputBuffer.clear();
-                    return output;
-                }
+
+                return null;
             }
         }
         catch (IOException e)

--- a/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
+++ b/jetty-core/jetty-compression/jetty-compression-brotli/src/test/java/org/eclipse/jetty/compression/brotli/BrotliEncoderSinkTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -85,5 +86,41 @@ public class BrotliEncoderSinkTest extends AbstractBrotliTest
             ExecutionException thrown = assertThrows(ExecutionException.class, callback2::get);
             assertInstanceOf(IllegalStateException.class, thrown.getCause());
         }
+    }
+
+    /**
+     * Regression test for large-response truncation: a single Brotli operation can emit more than one
+     * output buffer, and every one of them must be written downstream. Incompressible (random) data and
+     * a large encoder buffer force a single {@code PROCESS}/{@code FINISH} to produce multiple
+     * {@code pull()} results; if any but the last were dropped the round-trip would not match.
+     */
+    @Test
+    public void testLargeContentIsNotTruncated() throws Exception
+    {
+        startBrotli();
+
+        int dataSize = 4 * 1024 * 1024;
+        byte[] original = new byte[dataSize];
+        new java.util.Random(42).nextBytes(original);
+
+        BrotliEncoderConfig config = new BrotliEncoderConfig();
+        config.setBufferSize(1024 * 1024);
+        config.setCompressionLevel(5);
+
+        byte[] compressed;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream())
+        {
+            Content.Sink fileSink = Content.Sink.from(baos);
+            Content.Sink encoderSink = brotli.newEncoderSink(fileSink, config);
+
+            Callback.Completable callback = new Callback.Completable();
+            encoderSink.write(true, ByteBuffer.wrap(original), callback);
+            callback.get();
+            compressed = baos.toByteArray();
+        }
+
+        byte[] decompressed = decompress(compressed);
+        assertEquals(original.length, decompressed.length, "decompressed length (a shorter value means the response was truncated)");
+        assertArrayEquals(original, decompressed);
     }
 }


### PR DESCRIPTION
Proposed fix for issue #15432

## Summary
`CompressionHandler` with Brotli enabled truncates responses larger than one
encoder input buffer. The client receives a **valid, fully decodable** Brotli
stream that contains only a prefix of the payload - decompression succeeds but
the body is incomplete, which makes the corruption silent. gzip and zstd through
the same handler are unaffected. Reproduces on `jetty-12.1.x` (current) with
brotli4j 1.23.0.

## Root cause
`BrotliEncoderSink` drained the encoder with a loop that stored each
`EncoderJNI.pull()` into a single local and returned one `ByteBuffer`:

```java
else if (encoder.hasMoreOutput())
    output = encoder.pull();   // overwrites; only the last buffer survives
...
return output;
```

`pull()` returns at most one output-buffer-sized chunk, and a single operation - typically the final FLUSH/FINISH after a large body - can produce several. Every buffer except the last was dropped. The stream still ended with a valid end-of-stream metablock, so it decoded cleanly but short, cut at an encoder-buffer boundary.

**Fix**
Return each pulled buffer individually and let EncoderSink re-invoke encode() until the operation is fully drained, so no output is dropped. This mirrors how ZstandardEncoderSink already works.

Track the per-operation phase in the existing State (PROCESS_OUTPUT / FLUSH_OUTPUT / FINISH_OUTPUT) rather than an extra field; each operation's push now happens on the state transition and drain() only pulls output.

Guard terminal writes on the sink's own FINISHED state instead of encoder.isFinished(), which becomes true while output is still being drained.

**Testing**
New BrotliEncoderSinkTest.testLargeContentIsNotTruncated: compresses an incompressible payload larger than the encoder buffer and asserts a byte-for-byte round-trip.