### PR TITLE
Fix #15368 - HTTP/2 client aborts a fully-received response during graceful shutdown

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -369,10 +369,14 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             activeChannels.clear();
         }
         Throwable failure = failureSupplier.get();
-        for (HttpChannel channel : channels)
+        for (HttpChannelOverHTTP2 channel : channels)
         {
             HttpExchange exchange = channel.getHttpExchange();
-            if (exchange != null)
+            // Do not abort an exchange whose response has already been fully received (the last DATA
+            // frame, end-of-stream, has arrived) but not yet consumed by the application. Closing the
+            // connection (e.g. a GOAWAY at the end of a server graceful shutdown) must not discard a
+            // response that the client already holds.
+            if (exchange != null && !channel.isLastDataReceived())
                 exchange.getRequest().abort(failure);
         }
         return false;

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -164,29 +164,16 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
     @Test
     public void testConnectionCloseDoesNotAbortExchangeWithCompletedResponse() throws Exception
     {
-        // White-box reproduction of jetty#15368. The race is: the response has been fully received
-        // by the client transport (isResponseComplete() == true), but the exchange has not yet
-        // terminated (the application has not consumed the body), so the channel is still "active".
-        // If the connection is closed in this window (e.g. a GOAWAY at the end of a server graceful
-        // shutdown), the connection must NOT abort the exchange, otherwise the already-received
-        // response is discarded with a ClosedChannelException.
-        //
-        // To hit this window deterministically, we capture the HttpConnectionOverHTTP2 instance, let
-        // a small response be fully received (but not consumed), then invoke connection.close()
-        // directly and assert the response body can still be read.
         byte[] payload = new byte[1024];
         Arrays.fill(payload, (byte)'x');
 
         HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(new HttpConfiguration());
-        h2c.setInitialSessionRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
-        h2c.setInitialStreamRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
         prepareServer(h2c);
         server.setHandler(new Handler.Abstract()
         {
             @Override
             public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
             {
-                response.setStatus(HttpStatus.OK_200);
                 response.write(true, ByteBuffer.wrap(payload), callback);
                 return true;
             }
@@ -222,7 +209,7 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
 
         // The already-received response must still be deliverable.
         byte[] body = IO.readBytes(listener.getInputStream());
-        assertEquals(payload.length, body.length);
+        assertArrayEquals(payload, body);
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 
+import org.eclipse.jetty.client.AbstractConnectionPool;
 import org.eclipse.jetty.client.AsyncRequestContent;
 import org.eclipse.jetty.client.CompletableResponseListener;
 import org.eclipse.jetty.client.Connection;
@@ -210,6 +211,86 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
         // The already-received response must still be deliverable.
         byte[] body = IO.readBytes(listener.getInputStream());
         assertArrayEquals(payload, body);
+
+        // Disposal still happens: sparing the abort must not leak the connection. Once the completed
+        // response has been consumed, the connection is released back to (and swept from) the pool.
+        await().atMost(5, TimeUnit.SECONDS).until(() ->
+        {
+            List<Destination> destinations = httpClient.getDestinations();
+            if (destinations.isEmpty())
+                return true;
+            AbstractConnectionPool pool = (AbstractConnectionPool)destinations.get(0).getConnectionPool();
+            String dump = pool.dump();
+            return dump.lines().noneMatch(l -> l.matches(".*multiplex=[1-9]([0-9]+)?.*")) &&
+                dump.contains(",leaked=0,");
+        });
+    }
+
+    @Test
+    public void testConnectionFailureDoesNotAbortExchangeWithCompletedResponse() throws Exception
+    {
+        // Companion to the close() test above, exercising the other caller of
+        // ensureClosedOrAbortActiveChannels: HttpConnectionOverHTTP2.onFailure(), which aborts and then
+        // destroys the connection WITHOUT a trailing session.close(). A response fully received but not
+        // yet consumed must still be delivered, and the connection must still be disposed (no leak).
+        byte[] payload = new byte[1024];
+        Arrays.fill(payload, (byte)'x');
+
+        HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(new HttpConfiguration());
+        prepareServer(h2c);
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                response.write(true, ByteBuffer.wrap(payload), callback);
+                return true;
+            }
+        });
+        server.start();
+
+        AtomicReference<HttpConnectionOverHTTP2> connectionRef = new AtomicReference<>();
+        prepareClient();
+        httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)
+        {
+            @Override
+            protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
+            {
+                HttpConnectionOverHTTP2 c = new HttpConnectionOverHTTP2(destination, session, connection);
+                connectionRef.set(c);
+                return c;
+            }
+        });
+        httpClient.start();
+
+        InputStreamResponseListener listener = new InputStreamResponseListener();
+        httpClient.newRequest("localhost", connector.getLocalPort()).send(listener);
+
+        Response response = listener.get(5, TimeUnit.SECONDS);
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Fail the session while the completed-but-unconsumed exchange is still active. This drives
+        // HttpConnectionOverHTTP2.onFailure() (via the session's failure notification) — the hard path
+        // that failStreams(stream -> true), then destroys the connection with no session.close().
+        HttpConnectionOverHTTP2 connection = connectionRef.get();
+        assertNotNull(connection);
+        ((HTTP2Session)connection.getSession()).onConnectionFailure(ErrorCode.INTERNAL_ERROR.code, "test_failure");
+
+        // The already-received response must still be deliverable, not discarded.
+        byte[] body = IO.readBytes(listener.getInputStream());
+        assertArrayEquals(payload, body);
+
+        // And the connection must still be disposed (no leak) even without session.close().
+        await().atMost(5, TimeUnit.SECONDS).until(() ->
+        {
+            List<Destination> destinations = httpClient.getDestinations();
+            if (destinations.isEmpty())
+                return true;
+            AbstractConnectionPool pool = (AbstractConnectionPool)destinations.get(0).getConnectionPool();
+            String dump = pool.dump();
+            return dump.lines().noneMatch(l -> l.matches(".*multiplex=[1-9]([0-9]+)?.*")) &&
+                dump.contains(",leaked=0,");
+        });
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/HttpClientTransportOverHTTP2Test.java
@@ -23,6 +23,7 @@ import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -91,6 +92,7 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -157,6 +159,70 @@ public class HttpClientTransportOverHTTP2Test extends AbstractTest
             assertEquals(httpClient.getMaxResponseHeadersSize(), http2Client.getMaxResponseHeadersSize());
         }
         assertTrue(http2Client.isStopped());
+    }
+
+    @Test
+    public void testConnectionCloseDoesNotAbortExchangeWithCompletedResponse() throws Exception
+    {
+        // White-box reproduction of jetty#15368. The race is: the response has been fully received
+        // by the client transport (isResponseComplete() == true), but the exchange has not yet
+        // terminated (the application has not consumed the body), so the channel is still "active".
+        // If the connection is closed in this window (e.g. a GOAWAY at the end of a server graceful
+        // shutdown), the connection must NOT abort the exchange, otherwise the already-received
+        // response is discarded with a ClosedChannelException.
+        //
+        // To hit this window deterministically, we capture the HttpConnectionOverHTTP2 instance, let
+        // a small response be fully received (but not consumed), then invoke connection.close()
+        // directly and assert the response body can still be read.
+        byte[] payload = new byte[1024];
+        Arrays.fill(payload, (byte)'x');
+
+        HTTP2CServerConnectionFactory h2c = new HTTP2CServerConnectionFactory(new HttpConfiguration());
+        h2c.setInitialSessionRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
+        h2c.setInitialStreamRecvWindow(FlowControlStrategy.DEFAULT_WINDOW_SIZE);
+        prepareServer(h2c);
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                response.setStatus(HttpStatus.OK_200);
+                response.write(true, ByteBuffer.wrap(payload), callback);
+                return true;
+            }
+        });
+        server.start();
+
+        AtomicReference<HttpConnectionOverHTTP2> connectionRef = new AtomicReference<>();
+        prepareClient();
+        httpClient = new HttpClient(new HttpClientTransportOverHTTP2(http2Client)
+        {
+            @Override
+            protected Connection newConnection(Destination destination, Session session, HTTP2Connection connection)
+            {
+                HttpConnectionOverHTTP2 c = new HttpConnectionOverHTTP2(destination, session, connection);
+                connectionRef.set(c);
+                return c;
+            }
+        });
+        httpClient.start();
+
+        InputStreamResponseListener listener = new InputStreamResponseListener();
+        httpClient.newRequest("localhost", connector.getLocalPort()).send(listener);
+
+        // The response (headers + all data + end-of-stream) is received here, but we do not consume
+        // the body yet, so the exchange stays active on its channel.
+        Response response = listener.get(5, TimeUnit.SECONDS);
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        // Close the connection while the completed-but-unconsumed exchange is still active.
+        HttpConnectionOverHTTP2 connection = connectionRef.get();
+        assertNotNull(connection);
+        connection.close();
+
+        // The already-received response must still be deliverable.
+        byte[] body = IO.readBytes(listener.getInputStream());
+        assertEquals(payload.length, body.length);
     }
 
     @Test


### PR DESCRIPTION
Fixes #15368.

`HttpConnectionOverHTTP2.ensureClosedOrAbortActiveChannels()` aborts every active channel unconditionally when the connection is closed. When the connection closes at the end of a server graceful shutdown (GOAWAY), a channel whose response has been **fully received but not yet consumed** by the application is still active, so it gets aborted and the already-received response is discarded with a `ClosedChannelException`.

**Fix:** skip aborting a channel whose last DATA frame has already been received (`HttpChannelOverHTTP2.isLastDataReceived()`) — that response is complete and must be delivered to the application. Requests still in flight are aborted as before, so the original intent of the abort-on-close change is preserved.

Gating on `HttpExchange.isResponseComplete()` does not work here, because HTTP/2 content is consumed lazily and the exchange is not marked COMPLETED until the application reads the body; `isLastDataReceived()` reflects that the response bytes have arrived off the wire.

**Test:** `HttpClientTransportOverHTTP2Test.testConnectionCloseDoesNotAbortExchangeWithCompletedResponse` — a white-box test that captures the `HttpConnectionOverHTTP2`, lets a response be fully received but not consumed, then calls `connection.close()` directly (no socket-timing dependence). It fails with `ClosedChannelException` at `ensureClosedOrAbortActiveChannels` without the fix and passes with it. `GoAwayTest` and the rest of `HttpClientTransportOverHTTP2Test` still pass.

This was reproduced independently from the Apache Solr side (`TestGracefulJettyShutdown`, ~60% failure on 12.1.10), as discussed in #15368.