### PR TITLE
Fixes #15421 - Handle excess writes against content-length

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -198,13 +198,14 @@ public class HttpOutput extends ServletOutputStream
 
     private boolean isAllContentWritten(long written)
     {
-        if (_applicationContentLength >= 0)
-        {
-            if (written > _applicationContentLength)
-                throw new IllegalStateException("too much content written");
-            return written == _applicationContentLength;
-        }
-        return false;
+        return _applicationContentLength >= 0 && written >= _applicationContentLength;
+    }
+
+    private long remainingContentLength()
+    {
+        if (_applicationContentLength < 0)
+            return Long.MAX_VALUE;
+        return Math.max(0L, _applicationContentLength - _written);
     }
 
     /**
@@ -811,6 +812,14 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+            }
+
             long written = _written + len;
             int space = maximizeAggregateSpace();
 
@@ -941,6 +950,7 @@ public class HttpOutput extends ServletOutputStream
     {
         // This write always bypasses aggregate buffer
         int len = BufferUtil.length(buffer);
+        ByteBuffer content = buffer;
         boolean flush;
         boolean last;
 
@@ -949,6 +959,17 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+                content = buffer.slice();
+                content.limit(len);
+                buffer.position(buffer.position() + len);
+            }
+
             long written = _written + len;
 
             // Is this the last write due to content-length?
@@ -989,7 +1010,7 @@ public class HttpOutput extends ServletOutputStream
 
         if (async)
         {
-            new AsyncWrite(buffer, last).iterate();
+            new AsyncWrite(content, last).iterate();
         }
         else
         {
@@ -1006,7 +1027,7 @@ public class HttpOutput extends ServletOutputStream
 
                 // write any remaining content in the buffer directly
                 if (len > 0)
-                    channelWrite(buffer, last);
+                    channelWrite(content, last);
                 else if (last && !complete)
                     channelWrite(BufferUtil.EMPTY_BUFFER, true);
 
@@ -1031,6 +1052,9 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            if (remainingContentLength() == 0)
+                throw new EofException("Closed");
+
             long written = _written + 1;
             int space = maximizeAggregateSpace();
 

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ExcessContentWrittenTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ExcessContentWrittenTest.java
@@ -1,0 +1,194 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests writing more content than declared by {@link HttpServletResponse#setContentLength(int)}.
+ * @see <a href="https://github.com/jetty/jetty.project/issues/15421">Issue #15421</a>
+ */
+public class ExcessContentWrittenTest
+{
+    private Server _server;
+    private LocalConnector _connector;
+
+    public void start(HttpServlet servlet) throws Exception
+    {
+        _server = new Server();
+        _connector = new LocalConnector(_server);
+        _server.addConnector(_connector);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(servlet, "/*");
+        _server.setHandler(context);
+        _server.start();
+    }
+
+    @AfterEach
+    public void stop()
+    {
+        LifeCycle.stop(_server);
+    }
+
+    private HttpTester.Response getResponse() throws Exception
+    {
+        HttpTester.Request request = new HttpTester.Request();
+        request.setMethod("GET");
+        request.setURI("/");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+        request.setHeader("Connection", "close");
+        return HttpTester.parseResponse(_connector.getResponse(request.generate()));
+    }
+
+    @Test
+    public void testWriteMoreThanContentLength() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        AtomicBoolean closedOnExtraWrite = new AtomicBoolean();
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(100);
+                    byte[] content = new byte[200];
+                    Arrays.fill(content, 0, 100, (byte)'a');
+                    Arrays.fill(content, 100, 200, (byte)'b');
+                    OutputStream out = response.getOutputStream();
+                    out.write(content);
+                    try
+                    {
+                        out.write(new byte[1]);
+                    }
+                    catch (IOException ignored)
+                    {
+                        closedOnExtraWrite.set(true);
+                    }
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("100"));
+        assertThat(response.getContentBytes().length, is(100));
+        assertThat(response.getContent(), is("a".repeat(100)));
+        assertTrue(closedOnExtraWrite.get());
+    }
+
+    @Test
+    public void testWritePartialThenExcess() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        AtomicBoolean closedOnExtraWrite = new AtomicBoolean();
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(100);
+                    OutputStream out = response.getOutputStream();
+                    out.write(new byte[60]);
+                    out.write(new byte[80]); // only 40 of these should be written
+                    try
+                    {
+                        out.write(new byte[10]);
+                    }
+                    catch (IOException ignored)
+                    {
+                        closedOnExtraWrite.set(true);
+                    }
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("100"));
+        assertThat(response.getContentBytes().length, is(100));
+        assertTrue(closedOnExtraWrite.get());
+    }
+
+    @Test
+    public void testWriteMoreThanContentLengthWithByteBuffer() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(50);
+                    ByteBuffer buffer = ByteBuffer.allocate(100);
+                    for (int i = 0; i < 100; i++)
+                        buffer.put((byte)('A' + (i % 26)));
+                    buffer.flip();
+                    ((HttpOutput)response.getOutputStream()).write(buffer);
+                    assertThat(buffer.position(), is(50));
+                    assertThat(buffer.limit(), is(100));
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentBytes().length, is(50));
+        assertThat(response.getContent(), is("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWX"));
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -198,13 +198,14 @@ public class HttpOutput extends ServletOutputStream
 
     private boolean isAllContentWritten(long written)
     {
-        if (_applicationContentLength >= 0)
-        {
-            if (written > _applicationContentLength)
-                throw new IllegalStateException("too much content written");
-            return written == _applicationContentLength;
-        }
-        return false;
+        return _applicationContentLength >= 0 && written >= _applicationContentLength;
+    }
+
+    private long remainingContentLength()
+    {
+        if (_applicationContentLength < 0)
+            return Long.MAX_VALUE;
+        return Math.max(0L, _applicationContentLength - _written);
     }
 
     /**
@@ -824,6 +825,14 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+            }
+
             long written = _written + len;
             int space = maximizeAggregateSpace();
 
@@ -954,6 +963,7 @@ public class HttpOutput extends ServletOutputStream
     {
         // This write always bypasses aggregate buffer
         int len = BufferUtil.length(buffer);
+        ByteBuffer content = buffer;
         boolean flush;
         boolean last;
 
@@ -962,6 +972,17 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+                content = buffer.slice();
+                content.limit(len);
+                buffer.position(buffer.position() + len);
+            }
+
             long written = _written + len;
 
             // Is this the last write due to content-length?
@@ -1002,7 +1023,7 @@ public class HttpOutput extends ServletOutputStream
 
         if (async)
         {
-            new AsyncWrite(buffer, last).iterate();
+            new AsyncWrite(content, last).iterate();
         }
         else
         {
@@ -1019,7 +1040,7 @@ public class HttpOutput extends ServletOutputStream
 
                 // write any remaining content in the buffer directly
                 if (len > 0)
-                    channelWrite(buffer, last);
+                    channelWrite(content, last);
                 else if (last && !complete)
                     channelWrite(BufferUtil.EMPTY_BUFFER, true);
 
@@ -1044,6 +1065,9 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
+            if (remainingContentLength() == 0)
+                throw new EofException("Closed");
+
             long written = _written + 1;
             int space = maximizeAggregateSpace();
 

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ExcessContentWrittenTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ExcessContentWrittenTest.java
@@ -1,0 +1,194 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests writing more content than declared by {@link HttpServletResponse#setContentLength(int)}.
+ * @see <a href="https://github.com/jetty/jetty.project/issues/15421">Issue #15421</a>
+ */
+public class ExcessContentWrittenTest
+{
+    private Server _server;
+    private LocalConnector _connector;
+
+    public void start(HttpServlet servlet) throws Exception
+    {
+        _server = new Server();
+        _connector = new LocalConnector(_server);
+        _server.addConnector(_connector);
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/");
+        context.addServlet(servlet, "/*");
+        _server.setHandler(context);
+        _server.start();
+    }
+
+    @AfterEach
+    public void stop()
+    {
+        LifeCycle.stop(_server);
+    }
+
+    private HttpTester.Response getResponse() throws Exception
+    {
+        HttpTester.Request request = new HttpTester.Request();
+        request.setMethod("GET");
+        request.setURI("/");
+        request.setVersion(HttpVersion.HTTP_1_1);
+        request.setHeader("Host", "test");
+        request.setHeader("Connection", "close");
+        return HttpTester.parseResponse(_connector.getResponse(request.generate()));
+    }
+
+    @Test
+    public void testWriteMoreThanContentLength() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        AtomicBoolean closedOnExtraWrite = new AtomicBoolean();
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(100);
+                    byte[] content = new byte[200];
+                    Arrays.fill(content, 0, 100, (byte)'a');
+                    Arrays.fill(content, 100, 200, (byte)'b');
+                    OutputStream out = response.getOutputStream();
+                    out.write(content);
+                    try
+                    {
+                        out.write(new byte[1]);
+                    }
+                    catch (IOException ignored)
+                    {
+                        closedOnExtraWrite.set(true);
+                    }
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("100"));
+        assertThat(response.getContentBytes().length, is(100));
+        assertThat(response.getContent(), is("a".repeat(100)));
+        assertTrue(closedOnExtraWrite.get());
+    }
+
+    @Test
+    public void testWritePartialThenExcess() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        AtomicBoolean closedOnExtraWrite = new AtomicBoolean();
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(100);
+                    OutputStream out = response.getOutputStream();
+                    out.write(new byte[60]);
+                    out.write(new byte[80]); // only 40 of these should be written
+                    try
+                    {
+                        out.write(new byte[10]);
+                    }
+                    catch (IOException ignored)
+                    {
+                        closedOnExtraWrite.set(true);
+                    }
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.get(HttpHeader.CONTENT_LENGTH), is("100"));
+        assertThat(response.getContentBytes().length, is(100));
+        assertTrue(closedOnExtraWrite.get());
+    }
+
+    @Test
+    public void testWriteMoreThanContentLengthWithByteBuffer() throws Exception
+    {
+        CountDownLatch complete = new CountDownLatch(1);
+        start(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                try
+                {
+                    response.setContentLength(50);
+                    ByteBuffer buffer = ByteBuffer.allocate(100);
+                    for (int i = 0; i < 100; i++)
+                        buffer.put((byte)('A' + (i % 26)));
+                    buffer.flip();
+                    response.getOutputStream().write(buffer);
+                    assertThat(buffer.position(), is(50));
+                    assertThat(buffer.limit(), is(100));
+                }
+                finally
+                {
+                    complete.countDown();
+                }
+            }
+        });
+
+        HttpTester.Response response = getResponse();
+        assertTrue(complete.await(5, TimeUnit.SECONDS));
+        assertThat(response.getStatus(), is(200));
+        assertThat(response.getContentBytes().length, is(50));
+        assertThat(response.getContent(), is("ABCDEFGHIJKLMNOPQRSTUVWXYZABCDEFGHIJKLMNOPQRSTUVWX"));
+    }
+}

--- a/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
+++ b/jetty-ee9/jetty-ee9-nested/src/main/java/org/eclipse/jetty/ee9/nested/HttpOutput.java
@@ -810,6 +810,14 @@ public class HttpOutput extends ServletOutputStream implements Runnable
             throw new EofException(_onError);
     }
 
+    private long remainingContentLength()
+    {
+        long contentLength = _channel.getResponse().getContentLength();
+        if (contentLength < 0)
+            return Long.MAX_VALUE;
+        return Math.max(0L, contentLength - _written);
+    }
+
     @Override
     public void write(byte[] b, int off, int len) throws IOException
     {
@@ -825,6 +833,14 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+            }
+
             long written = _written + len;
             int space = maximizeAggregateSpace();
             last = _channel.getResponse().isAllContentWritten(written);
@@ -952,6 +968,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
     {
         // This write always bypasses aggregate buffer
         int len = BufferUtil.length(buffer);
+        ByteBuffer content = buffer;
         boolean flush;
         boolean last;
 
@@ -960,6 +977,17 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             checkWritable();
+            long remaining = remainingContentLength();
+            if (len > remaining)
+            {
+                if (remaining == 0)
+                    throw new EofException("Closed");
+                len = (int)remaining;
+                content = buffer.slice();
+                content.limit(len);
+                buffer.position(buffer.position() + len);
+            }
+
             long written = _written + len;
             last = _channel.getResponse().isAllContentWritten(written);
             flush = last || len > 0 || (_aggregate != null && _aggregate.hasRemaining());
@@ -997,7 +1025,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
         if (async)
         {
-            new AsyncWrite(buffer, last).iterate();
+            new AsyncWrite(content, last).iterate();
         }
         else
         {
@@ -1014,7 +1042,7 @@ public class HttpOutput extends ServletOutputStream implements Runnable
 
                 // write any remaining content in the buffer directly
                 if (len > 0)
-                    channelWrite(buffer, last);
+                    channelWrite(content, last);
                 else if (last && !complete)
                     channelWrite(BufferUtil.EMPTY_BUFFER, true);
 
@@ -1039,6 +1067,9 @@ public class HttpOutput extends ServletOutputStream implements Runnable
         try (AutoLock l = _channelState.lock())
         {
             checkWritable();
+            if (remainingContentLength() == 0)
+                throw new EofException("Closed");
+
             long written = _written + 1;
             int space = maximizeAggregateSpace();
             last = _channel.getResponse().isAllContentWritten(written);


### PR DESCRIPTION
## Closes #15421

When a servlet writes more bytes than declared with `setContentLength()` / `setContentLengthLong()`, Jetty used to throw `IllegalStateException("too much content written")` and return a 500.

Servlet Spec §5.7 says the response is closed once the content-length amount has been written. Writing more than that should close the stream after the declared length, not abort with 500.

### Changes
- In `HttpOutput` (ee9 / ee10 / ee11), limit each write to the remaining application content-length.
- When the content-length is reached, mark the write as last so the stream is closed.
- Further writes then fail with `EofException` / `IOException`.
- Core still rejects excess writes with `written N > M content-length` (unchanged).

### Tests
Regression tests in ee10 and ee11 that fail without the fix:
- single write larger than content-length → 200 with truncated body
- partial write then excess → closes at content-length
- `ByteBuffer` write path (position advanced, limit preserved)

Verified:
- regressions fail without the fix (3/3)
- pass with the fix
- existing `HttpOutputTest` still green