### PR TITLE
Fix for 15420 (add support for HttpClient.maxDestinations)

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -502,7 +502,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     }
 
     /**
-     * Returns the destination, creating it if absent, the destination for the given request
+     * Returns the destination, creating it if absent, for the given request
      *
      * @param request the request
      * @return the destination for the request
@@ -533,7 +533,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     }
 
     /**
-     * Returns the destination, creating it if absent, the destination with the given origin.
+     * Returns the destination, creating it if absent, with the given origin.
      *
      * @param origin the origin that identifies the destination
      * @return the destination for the given origin
@@ -963,7 +963,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
      * <p>
      * When the max is reached and a new destination is added, IllegalStateException is thrown.
      *
-     * @param maxDestinations the max number of destubatuibs that this HttpClient manages
+     * @param maxDestinations the max number of destinations that this HttpClient manages
      */
     public void setMaxDestinations(int maxDestinations)
     {

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpClient.java
@@ -129,6 +129,7 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     private boolean followRedirects = true;
     private int maxConnectionsPerDestination = 64;
     private int maxRequestsQueuedPerDestination = 1024;
+    private int maxDestinations = -1;
     private int requestBufferSize = 4096;
     private int maxRequestHeadersSize = 8192;
     private int responseBufferSize = 16384;
@@ -500,6 +501,13 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         return new HttpRequest(this, conversation, uri);
     }
 
+    /**
+     * Returns the destination, creating it if absent, the destination for the given request
+     *
+     * @param request the request
+     * @return the destination for the request
+     * @throws IllegalStateException if maxDestinations is exceeded
+     */
     public Destination resolveDestination(Request request)
     {
         HttpClientTransport transport = getHttpClientTransport();
@@ -525,10 +533,11 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     }
 
     /**
-     * <p>Returns, creating it if absent, the destination with the given origin.</p>
+     * Returns the destination, creating it if absent, the destination with the given origin.
      *
      * @param origin the origin that identifies the destination
      * @return the destination for the given origin
+     * @throws IllegalStateException if maxDestinations is exceeded
      */
     public Destination resolveDestination(Origin origin)
     {
@@ -536,6 +545,9 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
         {
             if (v == null || v.stale())
             {
+                if (maxDestinations > 0 && destinations.size() == maxDestinations)
+                    throw new IllegalStateException("Max destinations exceeded");
+
                 HttpDestination newDestination = (HttpDestination)getHttpClientTransport().newDestination(k);
                 // Start the destination before it's published to other threads.
                 addManaged(newDestination);
@@ -935,6 +947,27 @@ public class HttpClient extends ContainerLifeCycle implements AutoCloseable
     public void setMaxConnectionsPerDestination(int maxConnectionsPerDestination)
     {
         this.maxConnectionsPerDestination = maxConnectionsPerDestination;
+    }
+
+    /**
+     * @return the max number of destinations that this HttpClient manages
+     */
+    @ManagedAttribute("The max number of destinations for this client")
+    public int getMaxDestinations()
+    {
+        return maxDestinations;
+    }
+
+    /**
+     * Sets the max number of destinations for this client.
+     * <p>
+     * When the max is reached and a new destination is added, IllegalStateException is thrown.
+     *
+     * @param maxDestinations the max number of destubatuibs that this HttpClient manages
+     */
+    public void setMaxDestinations(int maxDestinations)
+    {
+        this.maxDestinations = maxDestinations;
     }
 
     /**

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -253,7 +253,7 @@ public class HttpProxy extends ProxyConfiguration.Proxy
                 connect.attribute(Connection.class.getName(), new ProxyConnection(proxyDestination, connection, promise));
                 connection.send(connect, new TunnelListener(connect));
             }
-            catch (Exception e)
+            catch (Throwable e)
             {
                 HttpConversation conversation = ((HttpRequest)connect).getConversation();
                 EndPoint endPoint = (EndPoint)conversation.getAttribute(EndPoint.class.getName());

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -247,9 +247,18 @@ public class HttpProxy extends ProxyConfiguration.Proxy
                 // since this request is to "connect" to the server.
                 .timeout(connectTimeout, TimeUnit.MILLISECONDS);
 
-            Destination proxyDestination = httpClient.resolveDestination(destination.getProxy().getOrigin());
-            connect.attribute(Connection.class.getName(), new ProxyConnection(proxyDestination, connection, promise));
-            connection.send(connect, new TunnelListener(connect));
+            try
+            {
+                Destination proxyDestination = httpClient.resolveDestination(destination.getProxy().getOrigin());
+                connect.attribute(Connection.class.getName(), new ProxyConnection(proxyDestination, connection, promise));
+                connection.send(connect, new TunnelListener(connect));
+            }
+            catch (Exception e)
+            {
+                HttpConversation conversation = ((HttpRequest)connect).getConversation();
+                EndPoint endPoint = (EndPoint)conversation.getAttribute(EndPoint.class.getName());
+                tunnelFailed(endPoint, e);
+            }
         }
 
         private void tunnelSucceeded(EndPoint endPoint)

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/ProtocolHttpUpgrader.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/internal/ProtocolHttpUpgrader.java
@@ -63,35 +63,42 @@ public class ProtocolHttpUpgrader implements HttpUpgrader
     @Override
     public void upgrade(Response response, EndPoint endPoint, Callback callback)
     {
-        if (response.getHeaders().contains(HttpHeader.UPGRADE, protocol))
+        try
         {
-            HttpClient httpClient = destination.getHttpClient();
-            HttpClientTransport transport = httpClient.getHttpClientTransport();
-            if (transport instanceof HttpClientTransportDynamic dynamicTransport)
+            if (response.getHeaders().contains(HttpHeader.UPGRADE, protocol))
             {
-                Origin origin = destination.getOrigin();
-                Origin newOrigin = new Origin(origin.getScheme(), origin.getAddress(), origin.getTag(), new Origin.Protocol(List.of(protocol), false), origin.getTransport());
-                Destination newDestination = httpClient.resolveDestination(newOrigin);
+                HttpClient httpClient = destination.getHttpClient();
+                HttpClientTransport transport = httpClient.getHttpClientTransport();
+                if (transport instanceof HttpClientTransportDynamic dynamicTransport)
+                {
+                    Origin origin = destination.getOrigin();
+                    Origin newOrigin = new Origin(origin.getScheme(), origin.getAddress(), origin.getTag(), new Origin.Protocol(List.of(protocol), false), origin.getTransport());
+                    Destination newDestination = httpClient.resolveDestination(newOrigin);
 
-                // Multiple threads may access the map, especially with DEBUG logging enabled.
-                Map<String, Object> context = new ConcurrentHashMap<>();
-                context.put(Destination.CONTEXT_KEY, newDestination);
-                context.put(HttpResponse.class.getName(), response);
-                context.put(Connection.PROMISE_CONTEXT_KEY, Promise.from(y -> callback.succeeded(), callback::failed));
+                    // Multiple threads may access the map, especially with DEBUG logging enabled.
+                    Map<String, Object> context = new ConcurrentHashMap<>();
+                    context.put(Destination.CONTEXT_KEY, newDestination);
+                    context.put(HttpResponse.class.getName(), response);
+                    context.put(Connection.PROMISE_CONTEXT_KEY, Promise.from(y -> callback.succeeded(), callback::failed));
 
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Upgrading {} on {}", response.getRequest(), endPoint);
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("Upgrading {} on {}", response.getRequest(), endPoint);
 
-                dynamicTransport.upgrade(endPoint, context);
+                    dynamicTransport.upgrade(endPoint, context);
+                }
+                else
+                {
+                    throw new HttpResponseException(HttpClientTransportDynamic.class.getName() + " required to upgrade to: " + protocol, response);
+                }
             }
             else
             {
-                callback.failed(new HttpResponseException(HttpClientTransportDynamic.class.getName() + " required to upgrade to: " + protocol, response));
+                throw new HttpResponseException("Not an upgrade to: " + protocol, response);
             }
         }
-        else
+        catch (Throwable t)
         {
-            callback.failed(new HttpResponseException("Not an upgrade to: " + protocol, response));
+            callback.failed(t);
         }
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientTest.java
@@ -81,6 +81,7 @@ import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.SocketAddressResolver;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -432,6 +433,59 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         assertNotNull(response);
         assertEquals(200, response.getStatus());
         assertEquals(5, progress.get());
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMaxDestinations(Scenario scenario) throws Exception
+    {
+        start(scenario, new EmptyServerHandler());
+
+        client.setMaxDestinations(1);
+
+        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+            .scheme(scenario.getScheme())
+            .send();
+        assertEquals(HttpStatus.OK_200, response.getStatus());
+
+        assertThrows(ExecutionException.class, () ->
+        {
+            client.newRequest("127.0.0.1", connector.getLocalPort())
+                .scheme(scenario.getScheme())
+                .send();
+        });
+    }
+
+    @ParameterizedTest
+    @ArgumentsSource(ScenarioProvider.class)
+    public void testMaxDestinationsOnRedirect(Scenario scenario) throws Exception
+    {
+        start(scenario, new Handler.Abstract()
+            {
+                @Override
+                public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback) throws Exception
+                {
+                    if (org.eclipse.jetty.server.Request.getPathInContext(request).equals("/redirected"))
+                    {
+                        callback.succeeded();
+                    }
+                    else
+                    {
+                        org.eclipse.jetty.server.Response.sendRedirect(request, response, callback, "%s://127.0.0.1:%s/redirected".formatted(request.getHttpURI().getScheme(), request.getHttpURI().getPort()));
+                    }
+                    return true;
+                }
+            }
+        );
+
+        client.setMaxDestinations(1);
+
+        assertThrows(ExecutionException.class, () ->
+        {
+            client.newRequest("localhost", connector.getLocalPort())
+                .scheme(scenario.getScheme())
+                .send();
+        });
     }
 
     @ParameterizedTest
@@ -2020,7 +2074,7 @@ public class HttpClientTest extends AbstractHttpClientServerTest
         }
         catch (IOException e)
         {
-            Assumptions.assumeTrue(false, 
+            Assumptions.assumeTrue(false,
                 "Cannot bind to " + bindAddress + " address on this system");
         }
 


### PR DESCRIPTION
Adds support for HttpClient.maxDestinations. When HttpClient tries to create more destinations than are allowed an IllegalStateException is thrown.