### PR TITLE
Fixes #15456 - Fragments in redirects not supported by default in standalone Jetty installation.

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/UriCompliance.java
@@ -285,7 +285,7 @@ public final class UriCompliance implements ComplianceViolation.Mode
     public static final UriCompliance UNSAFE = new UriCompliance("UNSAFE", allOf(Violation.class));
 
     private static final AtomicInteger __custom = new AtomicInteger();
-    private static final List<UriCompliance> KNOWN_MODES = List.of(DEFAULT, JETTY_11, LEGACY, RFC3986, UNAMBIGUOUS, UNSAFE);
+    private static final List<UriCompliance> KNOWN_MODES = List.of(DEFAULT, DEFAULT_REDIRECT, JETTY_11, LEGACY, RFC3986, UNAMBIGUOUS, UNSAFE);
 
     public static boolean isAmbiguous(Set<Violation> violations)
     {

--- a/jetty-core/jetty-server/src/main/config/etc/jetty-http-config.xml
+++ b/jetty-core/jetty-server/src/main/config/etc/jetty-http-config.xml
@@ -35,7 +35,7 @@
   </Set>
   <Set name="redirectUriCompliance">
     <Call class="org.eclipse.jetty.http.UriCompliance" name="from">
-      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT" /></Arg>
+      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT_REDIRECT" /></Arg>
     </Call>
   </Set>
   <Set name="requestCookieCompliance">

--- a/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-config.xml
+++ b/jetty-ee10/jetty-ee10-osgi/test-jetty-ee10-osgi/src/test/config/etc/jetty-http-config.xml
@@ -34,7 +34,7 @@
   </Set>
   <Set name="redirectUriCompliance">
     <Call class="org.eclipse.jetty.http.UriCompliance" name="from">
-      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT" /></Arg>
+      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT_REDIRECT" /></Arg>
     </Call>
   </Set>
   <Set name="requestCookieCompliance">

--- a/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-config.xml
+++ b/jetty-ee11/jetty-ee11-osgi/test-jetty-ee11-osgi/src/test/config/etc/jetty-http-config.xml
@@ -34,7 +34,7 @@
   </Set>
   <Set name="redirectUriCompliance">
     <Call class="org.eclipse.jetty.http.UriCompliance" name="from">
-      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT" /></Arg>
+      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT_REDIRECT" /></Arg>
     </Call>
   </Set>
   <Set name="requestCookieCompliance">

--- a/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/src/test/config/etc/jetty-http-config.xml
+++ b/jetty-ee8/jetty-ee8-osgi/test-jetty-ee8-osgi/src/test/config/etc/jetty-http-config.xml
@@ -34,7 +34,7 @@
   </Set>
   <Set name="redirectUriCompliance">
     <Call class="org.eclipse.jetty.http.UriCompliance" name="from">
-      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT" /></Arg>
+      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT_REDIRECT" /></Arg>
     </Call>
   </Set>
   <Set name="requestCookieCompliance">

--- a/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-config.xml
+++ b/jetty-ee9/jetty-ee9-osgi/test-jetty-ee9-osgi/src/test/config/etc/jetty-http-config.xml
@@ -34,7 +34,7 @@
   </Set>
   <Set name="redirectUriCompliance">
     <Call class="org.eclipse.jetty.http.UriCompliance" name="from">
-      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT" /></Arg>
+      <Arg><Property name="jetty.httpConfig.redirectUriCompliance" default="DEFAULT_REDIRECT" /></Arg>
     </Call>
   </Set>
   <Set name="requestCookieCompliance">


### PR DESCRIPTION
Fixed `jetty-http-config.xml` to reference the proper default string for property `jetty.httpConfig.redirectUriCompliance`.