### PR TITLE
Fixes #15453 - HttpServletResponse: setHeader("Content-Length", N) should be treated like setContentLengthLong(N).

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ResourceServlet.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee10.servlet;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -563,18 +562,9 @@ public class ResourceServlet extends HttpServlet
                 // otherwise we can use the core response directly.
                 boolean writingOrStreaming = servletContextResponse.isWritingOrStreaming();
                 boolean useServletResponse = !(httpServletResponse instanceof ServletApiResponse) || writingOrStreaming;
-                Response r = useServletResponse
+                Response coreResponse = useServletResponse
                     ? new ServletCoreResponse(coreRequest, httpServletResponse, included)
                     : servletChannel.getResponse();
-                // Ignore last writes done via the Core API as the ServletChannel will perform the last write upon completion.
-                Response coreResponse = new Response.Wrapper(coreRequest, r)
-                {
-                    @Override
-                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
-                    {
-                        super.write(false, byteBuffer, callback);
-                    }
-                };
 
                 // If the core response is already committed then do nothing more
                 if (coreResponse.isCommitted())

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletApiResponse.java
@@ -359,9 +359,9 @@ public class ServletApiResponse implements HttpServletResponse
         if (isCommitted())
             return;
 
+        getServletChannel().getHttpOutput().setApplicationContentLength(len);
         if (len >= 0)
         {
-            getServletChannel().getHttpOutput().setApplicationContentLength(len);
             if (len > 0)
                 getResponse().getHeaders().put(HttpHeader.CONTENT_LENGTH, len);
             else

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -492,6 +492,11 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
 
             return switch (field.getHeader())
             {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(field.getLongValue());
+                    yield super.onAddField(field);
+                }
                 case CONTENT_TYPE -> setContentType(field);
                 default -> super.onAddField(field);
             };
@@ -503,25 +508,36 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (isCommitted())
                 return false;
 
-            if (field.getHeader() == HttpHeader.CONTENT_TYPE)
-            {
-                _contentType = null;
-                _mimeType = null;
-                if (!isWriting())
-                {
-                    _characterEncoding = switch (_encodingFrom)
-                    {
-                        case SET_CHARACTER_ENCODING, SET_LOCALE -> _characterEncoding;
-                        default ->
-                        {
-                            _encodingFrom = EncodingFrom.NOT_SET;
-                            yield null;
-                        }
-                    };
-                }
-            }
+            if (field.getHeader() == null)
+                return super.onRemoveField(field);
 
-            return true;
+            return switch (field.getHeader())
+            {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(-1);
+                    yield super.onRemoveField(field);
+                }
+                case CONTENT_TYPE ->
+                {
+                    _contentType = null;
+                    _mimeType = null;
+                    if (!isWriting())
+                    {
+                        _characterEncoding = switch (_encodingFrom)
+                        {
+                            case SET_CHARACTER_ENCODING, SET_LOCALE -> _characterEncoding;
+                            default ->
+                            {
+                                _encodingFrom = EncodingFrom.NOT_SET;
+                                yield null;
+                            }
+                        };
+                    }
+                    yield super.onRemoveField(field);
+                }
+                default -> super.onRemoveField(field);
+            };
         }
 
         @Override
@@ -535,7 +551,16 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (newField.getHeader() == null)
                 return newField;
 
-            return newField.getHeader() == HttpHeader.CONTENT_TYPE ?  setContentType(newField) : newField;
+            return switch (oldField.getHeader())
+            {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(oldField.getLongValue());
+                    yield super.onReplaceField(oldField, newField);
+                }
+                case CONTENT_TYPE -> setContentType(newField);
+                default -> super.onReplaceField(oldField, newField);
+            };
         }
 
         private HttpField setContentType(HttpField field)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -551,11 +551,11 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (newField.getHeader() == null)
                 return newField;
 
-            return switch (oldField.getHeader())
+            return switch (newField.getHeader())
             {
                 case CONTENT_LENGTH ->
                 {
-                    getHttpOutput().setApplicationContentLength(oldField.getLongValue());
+                    getHttpOutput().setApplicationContentLength(newField.getLongValue());
                     yield super.onReplaceField(oldField, newField);
                 }
                 case CONTENT_TYPE -> setContentType(newField);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/Http2Test.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-client-transports/src/test/java/org/eclipse/jetty/ee10/test/client/transport/Http2Test.java
@@ -1,0 +1,146 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.test.client.transport;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.FuturePromise;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class Http2Test
+{
+    private Server server;
+    private ServerConnector connector;
+    private HTTP2Client client;
+
+    private void start(HttpServlet httpServlet) throws Exception
+    {
+        QueuedThreadPool serverThreads = new QueuedThreadPool();
+        serverThreads.setName("server");
+        server = new Server(serverThreads);
+        connector = new ServerConnector(server, 1, 1, new HTTP2CServerConnectionFactory(new HttpConfiguration()));
+        server.addConnector(connector);
+        ServletContextHandler servletContextHandler = new ServletContextHandler("/");
+        servletContextHandler.addServlet(new ServletHolder(httpServlet), "/*");
+        server.setHandler(servletContextHandler);
+        server.start();
+
+        QueuedThreadPool clientThreads = new QueuedThreadPool();
+        clientThreads.setName("client");
+        client = new HTTP2Client();
+        client.setExecutor(clientThreads);
+        client.start();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, textBlock = """
+        contentLengthMode, flushMode
+        int              , false
+        int              , true
+        long             , false
+        long             , true
+        string           , false
+        string           , true
+        """)
+    public void testServletContentLengthDoesSendEmptyLastDataFrame(String contentLengthMode, boolean flushMode) throws Exception
+    {
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                int length = 64;
+                switch (contentLengthMode)
+                {
+                    case "int" -> response.setContentLength(length);
+                    case "long" -> response.setContentLengthLong(length);
+                    case "string" -> response.setHeader("Content-Length", String.valueOf(length));
+                }
+                response.getOutputStream().write(new byte[length]);
+                if (flushMode)
+                    response.flushBuffer();
+            }
+        });
+
+        InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
+        FuturePromise<Session> sessionPromise = new FuturePromise<>();
+        client.connect(address, new Session.Listener() {}, sessionPromise);
+        Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+        MetaData.Request metaData = new MetaData.Request("GET", HttpURI.from("/"), HttpVersion.HTTP_2, HttpFields.EMPTY);
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        Queue<Stream.Data> datas = new ConcurrentLinkedQueue<>();
+        session.newStream(frame, new Stream.Listener()
+        {
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    datas.offer(data);
+                    if (data.frame().isEndStream())
+                        break;
+                }
+            }
+        }).get(5, TimeUnit.SECONDS);
+
+        await().atMost(5, TimeUnit.SECONDS).until(() -> datas.stream().anyMatch(d -> d.frame().isEndStream()));
+
+        // There should only be 1 DATA frame with data and last=true,
+        // not a DATA frame with data, and then an empty, last DATA frame.
+        assertThat(datas.toString(), datas.size(), equalTo(1));
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ResourceServlet.java
@@ -15,7 +15,6 @@ package org.eclipse.jetty.ee11.servlet;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.nio.file.InvalidPathException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -575,18 +574,9 @@ public class ResourceServlet extends HttpServlet
                 // otherwise we can use the core response directly.
                 boolean writingOrStreaming = servletContextResponse.isWritingOrStreaming();
                 boolean useServletResponse = !(httpServletResponse instanceof ServletApiResponse) || writingOrStreaming;
-                Response r = useServletResponse
+                Response coreResponse = useServletResponse
                     ? new ServletCoreResponse(coreRequest, httpServletResponse, included)
                     : servletChannel.getResponse();
-                // Ignore last writes done via the Core API as the ServletChannel will perform the last write upon completion.
-                Response coreResponse = new Response.Wrapper(coreRequest, r)
-                {
-                    @Override
-                    public void write(boolean last, ByteBuffer byteBuffer, Callback callback)
-                    {
-                        super.write(false, byteBuffer, callback);
-                    }
-                };
 
                 // If the core response is already committed then do nothing more
                 if (coreResponse.isCommitted())

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletApiResponse.java
@@ -395,9 +395,9 @@ public class ServletApiResponse implements HttpServletResponse
         if (isCommitted())
             return;
 
+        getServletChannel().getHttpOutput().setApplicationContentLength(len);
         if (len >= 0)
         {
-            getServletChannel().getHttpOutput().setApplicationContentLength(len);
             if (len > 0)
                 getResponse().getHeaders().put(HttpHeader.CONTENT_LENGTH, len);
             else

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -498,6 +498,11 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
 
             return switch (field.getHeader())
             {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(field.getLongValue());
+                    yield super.onAddField(field);
+                }
                 case CONTENT_TYPE -> setContentType(field);
                 default -> super.onAddField(field);
             };
@@ -509,25 +514,36 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (isCommitted())
                 return false;
 
-            if (field.getHeader() == HttpHeader.CONTENT_TYPE)
-            {
-                _contentType = null;
-                _mimeType = null;
-                if (!isWriting())
-                {
-                    _characterEncoding = switch (_encodingFrom)
-                    {
-                        case SET_CHARACTER_ENCODING, SET_LOCALE -> _characterEncoding;
-                        default ->
-                        {
-                            _encodingFrom = EncodingFrom.NOT_SET;
-                            yield null;
-                        }
-                    };
-                }
-            }
+            if (field.getHeader() == null)
+                return super.onRemoveField(field);
 
-            return true;
+            return switch (field.getHeader())
+            {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(-1);
+                    yield super.onRemoveField(field);
+                }
+                case CONTENT_TYPE ->
+                {
+                    _contentType = null;
+                    _mimeType = null;
+                    if (!isWriting())
+                    {
+                        _characterEncoding = switch (_encodingFrom)
+                        {
+                            case SET_CHARACTER_ENCODING, SET_LOCALE -> _characterEncoding;
+                            default ->
+                            {
+                                _encodingFrom = EncodingFrom.NOT_SET;
+                                yield null;
+                            }
+                        };
+                    }
+                    yield super.onRemoveField(field);
+                }
+                default -> super.onRemoveField(field);
+            };
         }
 
         @Override
@@ -541,7 +557,16 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (newField.getHeader() == null)
                 return newField;
 
-            return newField.getHeader() == HttpHeader.CONTENT_TYPE ?  setContentType(newField) : newField;
+            return switch (oldField.getHeader())
+            {
+                case CONTENT_LENGTH ->
+                {
+                    getHttpOutput().setApplicationContentLength(oldField.getLongValue());
+                    yield super.onReplaceField(oldField, newField);
+                }
+                case CONTENT_TYPE -> setContentType(newField);
+                default -> super.onReplaceField(oldField, newField);
+            };
         }
 
         private HttpField setContentType(HttpField field)

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -557,11 +557,11 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (newField.getHeader() == null)
                 return newField;
 
-            return switch (oldField.getHeader())
+            return switch (newField.getHeader())
             {
                 case CONTENT_LENGTH ->
                 {
-                    getHttpOutput().setApplicationContentLength(oldField.getLongValue());
+                    getHttpOutput().setApplicationContentLength(newField.getLongValue());
                     yield super.onReplaceField(oldField, newField);
                 }
                 case CONTENT_TYPE -> setContentType(newField);

--- a/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/Http2Test.java
+++ b/jetty-ee11/jetty-ee11-tests/jetty-ee11-test-client-transports/src/test/java/org/eclipse/jetty/ee11/test/client/transport/Http2Test.java
@@ -1,0 +1,146 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.test.client.transport;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.ee11.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee11.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpFields;
+import org.eclipse.jetty.http.HttpURI;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.api.Session;
+import org.eclipse.jetty.http2.api.Stream;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.http2.server.HTTP2CServerConnectionFactory;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.util.FuturePromise;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.eclipse.jetty.util.thread.QueuedThreadPool;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class Http2Test
+{
+    private Server server;
+    private ServerConnector connector;
+    private HTTP2Client client;
+
+    private void start(HttpServlet httpServlet) throws Exception
+    {
+        QueuedThreadPool serverThreads = new QueuedThreadPool();
+        serverThreads.setName("server");
+        server = new Server(serverThreads);
+        connector = new ServerConnector(server, 1, 1, new HTTP2CServerConnectionFactory(new HttpConfiguration()));
+        server.addConnector(connector);
+        ServletContextHandler servletContextHandler = new ServletContextHandler("/");
+        servletContextHandler.addServlet(new ServletHolder(httpServlet), "/*");
+        server.setHandler(servletContextHandler);
+        server.start();
+
+        QueuedThreadPool clientThreads = new QueuedThreadPool();
+        clientThreads.setName("client");
+        client = new HTTP2Client();
+        client.setExecutor(clientThreads);
+        client.start();
+    }
+
+    @AfterEach
+    public void tearDown()
+    {
+        LifeCycle.stop(client);
+        LifeCycle.stop(server);
+    }
+
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, textBlock = """
+        contentLengthMode, flushMode
+        int              , false
+        int              , true
+        long             , false
+        long             , true
+        string           , false
+        string           , true
+        """)
+    public void testServletContentLengthDoesSendEmptyLastDataFrame(String contentLengthMode, boolean flushMode) throws Exception
+    {
+        start(new HttpServlet()
+        {
+            @Override
+            protected void service(HttpServletRequest request, HttpServletResponse response) throws IOException
+            {
+                int length = 64;
+                switch (contentLengthMode)
+                {
+                    case "int" -> response.setContentLength(length);
+                    case "long" -> response.setContentLengthLong(length);
+                    case "string" -> response.setHeader("Content-Length", String.valueOf(length));
+                }
+                response.getOutputStream().write(new byte[length]);
+                if (flushMode)
+                    response.flushBuffer();
+            }
+        });
+
+        InetSocketAddress address = new InetSocketAddress("localhost", connector.getLocalPort());
+        FuturePromise<Session> sessionPromise = new FuturePromise<>();
+        client.connect(address, new Session.Listener() {}, sessionPromise);
+        Session session = sessionPromise.get(5, TimeUnit.SECONDS);
+
+        MetaData.Request metaData = new MetaData.Request("GET", HttpURI.from("/"), HttpVersion.HTTP_2, HttpFields.EMPTY);
+        HeadersFrame frame = new HeadersFrame(metaData, null, true);
+        Queue<Stream.Data> datas = new ConcurrentLinkedQueue<>();
+        session.newStream(frame, new Stream.Listener()
+        {
+            @Override
+            public void onDataAvailable(Stream stream)
+            {
+                while (true)
+                {
+                    Stream.Data data = stream.readData();
+                    if (data == null)
+                    {
+                        stream.demand();
+                        return;
+                    }
+                    datas.offer(data);
+                    if (data.frame().isEndStream())
+                        break;
+                }
+            }
+        }).get(5, TimeUnit.SECONDS);
+
+        await().atMost(5, TimeUnit.SECONDS).until(() -> datas.stream().anyMatch(d -> d.frame().isEndStream()));
+
+        // There should only be 1 DATA frame with data and last=true,
+        // not a DATA frame with data, and then an empty, last DATA frame.
+        assertThat(datas.toString(), datas.size(), equalTo(1));
+    }
+}


### PR DESCRIPTION
Now intercepting the setting of the `Content-Length` header and forwarding to `HttpOutput`. 
In this way, `HttpOutput.write(...)` methods can compute whether it is the last write. 
This, in turn, optimizes the HTTP/2 framing, by avoiding the empty last DATA frame.