### PR TITLE
Jetty 12.1 http1 cleanups

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -374,33 +374,25 @@ public class HttpParser
 
     protected void checkViolation(Violation violation) throws HttpException.RuntimeException
     {
-        if (!checkAndReportViolation(violation, violation.getDescription()))
+        boolean allowed = violation.isAllowedBy(_complianceMode);
+        reportComplianceViolation(violation, violation.getDescription());
+
+        if (!allowed)
             throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
 
-    protected boolean checkAndReportViolation(Violation violation, String reason)
-    {
-        boolean allowed = _complianceMode.allows(violation);
-        reportComplianceViolation(violation, reason, allowed);
-        return allowed;
-    }
-
-    @Deprecated
     protected void reportComplianceViolation(Violation violation)
     {
-        checkAndReportViolation(violation, violation.getDescription());
+        reportComplianceViolation(violation, violation.getDescription());
     }
 
-    @Deprecated
     protected void reportComplianceViolation(Violation violation, String reason)
     {
-        checkAndReportViolation(violation, reason);
-    }
-
-    protected void reportComplianceViolation(Violation violation, String reason, boolean allowed)
-    {
         if (_requestParser)
+        {
+            boolean allowed = _complianceMode.allows(violation);
             _requestHandler.onViolation(new ComplianceViolation.Event(_complianceMode, violation, reason, allowed));
+        }
     }
 
     protected String caseInsensitiveHeader(String orig, String normative)
@@ -408,7 +400,7 @@ public class HttpParser
         if (CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode))
             return normative;
         if (!orig.equals(normative))
-            reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, orig, false);
+            reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, orig);
         return orig;
     }
 
@@ -799,7 +791,8 @@ public class HttpParser
                             }
                             else
                             {
-                                if (checkAndReportViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString))
+                                reportComplianceViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString);
+                                if (_complianceMode.allows(Violation.CASE_INSENSITIVE_METHOD))
                                 {
                                     method = HttpMethod.INSENSITIVE_CACHE.get(_methodString);
                                     if (method != null)
@@ -967,9 +960,9 @@ public class HttpParser
                             break;
 
                         case EOL:
-                        {
                             // HTTP/0.9
-                            if (checkAndReportViolation(Violation.HTTP_0_9, HTTP_0_9.getDescription()))
+                            reportComplianceViolation(HTTP_0_9, HTTP_0_9.getDescription());
+                            if (Violation.HTTP_0_9.isAllowedBy(_complianceMode))
                             {
                                 _requestHandler.startRequest(_methodString, _uri.toCompleteString(), HttpVersion.HTTP_0_9);
                                 setState(State.CONTENT);
@@ -982,7 +975,6 @@ public class HttpParser
                                 throw new HttpException.RuntimeException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "HTTP/0.9 not supported");
                             }
                             break;
-                        }
 
                         case ALPHA:
                         case DIGIT:
@@ -1473,7 +1465,7 @@ public class HttpParser
                                             String en = BufferUtil.toString(buffer, buffer.position() - 1, n.length(), StandardCharsets.US_ASCII);
                                             if (!n.equals(en))
                                             {
-                                                reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, en, true);
+                                                reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, en);
                                                 n = en;
                                                 cachedField = newHttpField(cachedField.getHeader(), n, v);
                                             }
@@ -1553,10 +1545,11 @@ public class HttpParser
                     {
                         case SPACE:
                         case HTAB:
-                            //Ignore trailing whitespaces?
-                            if (checkAndReportViolation(WHITESPACE_AFTER_FIELD_NAME, _headerString))
+                            //Ignore trailing whitespaces ?
+                            if (WHITESPACE_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
                             {
                                 _headerString = takeString();
+                                reportComplianceViolation(WHITESPACE_AFTER_FIELD_NAME, "Space after " + _headerString);
                                 _header = HttpHeader.CACHE.get(_headerString);
                                 _length = -1;
                                 setState(FieldState.WS_AFTER_NAME);
@@ -1578,7 +1571,8 @@ public class HttpParser
                             _valueString = "";
                             _length = -1;
 
-                            if (checkAndReportViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
+                            reportComplianceViolation(NO_COLON_AFTER_FIELD_NAME, "Field " + _headerString);
+                            if (NO_COLON_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
                             {
                                 setState(FieldState.FIELD);
                                 break;
@@ -1609,8 +1603,9 @@ public class HttpParser
                             break;
 
                         case EOL:
-                            if (checkAndReportViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
+                            if (NO_COLON_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
                             {
+                                reportComplianceViolation(NO_COLON_AFTER_FIELD_NAME, "Field " + _headerString);
                                 setState(FieldState.FIELD);
                                 break;
                             }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -2529,8 +2529,12 @@ public class HttpParser
             }
             else if (!_cache.put(field))
             {
-                _cache.clear();
-                _cache.put(field);
+                // clear the cache only if the field is small and still cannot fit in the cache.
+                if ((field.getName().length() + field.getValue().length()) < _cache.size() / 4)
+                {
+                    _cache.clear();
+                    _cache.put(field);
+                }
             }
         }
 
@@ -2546,7 +2550,7 @@ public class HttpParser
                 _cache = Index.buildMutableVisibleAsciiAlphabet(_caseSensitive, _size);
                 for (HttpField f : _cacheableFields)
                 {
-                    if (!_cache.put(f))
+                    if (!_cache.put(f) && (f.getName().length() + f.getValue().length()) < _size / 4)
                         break;
                 }
                 _cacheableFields.clear();

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -374,21 +374,27 @@ public class HttpParser
 
     protected void checkViolation(Violation violation) throws HttpException.RuntimeException
     {
-        boolean allowed = violation.isAllowedBy(_complianceMode);
-        reportComplianceViolation(violation, violation.getDescription(), allowed);
-        if (!allowed)
+        if (!checkViolation(violation, violation.getDescription()))
             throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
 
-    protected void reportComplianceViolation(Violation violation)
+    protected boolean checkViolation(Violation violation, String reason)
     {
-        reportComplianceViolation(violation, violation.getDescription());
+        boolean allowed = _complianceMode.allows(violation);
+        reportComplianceViolation(violation, reason, allowed);
+        return allowed;
     }
 
+    @Deprecated
+    protected void reportComplianceViolation(Violation violation)
+    {
+        checkViolation(violation, violation.getDescription());
+    }
+
+    @Deprecated
     protected void reportComplianceViolation(Violation violation, String reason)
     {
-        if (_requestParser)
-            reportComplianceViolation(violation, reason, _complianceMode.allows(violation));
+        checkViolation(violation, reason);
     }
 
     protected void reportComplianceViolation(Violation violation, String reason, boolean allowed)
@@ -402,7 +408,7 @@ public class HttpParser
         if (CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode))
             return normative;
         if (!orig.equals(normative))
-            reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, orig);
+            reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, orig, false);
         return orig;
     }
 
@@ -793,8 +799,7 @@ public class HttpParser
                             }
                             else
                             {
-                                reportComplianceViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString);
-                                if (_complianceMode.allows(Violation.CASE_INSENSITIVE_METHOD))
+                                if (checkViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString))
                                 {
                                     method = HttpMethod.INSENSITIVE_CACHE.get(_methodString);
                                     if (method != null)
@@ -962,9 +967,9 @@ public class HttpParser
                             break;
 
                         case EOL:
+                        {
                             // HTTP/0.9
-                            reportComplianceViolation(HTTP_0_9, HTTP_0_9.getDescription());
-                            if (Violation.HTTP_0_9.isAllowedBy(_complianceMode))
+                            if (checkViolation(Violation.HTTP_0_9, HTTP_0_9.getDescription()))
                             {
                                 _requestHandler.startRequest(_methodString, _uri.toCompleteString(), HttpVersion.HTTP_0_9);
                                 setState(State.CONTENT);
@@ -977,6 +982,7 @@ public class HttpParser
                                 throw new HttpException.RuntimeException(HttpStatus.HTTP_VERSION_NOT_SUPPORTED_505, "HTTP/0.9 not supported");
                             }
                             break;
+                        }
 
                         case ALPHA:
                         case DIGIT:
@@ -1546,11 +1552,10 @@ public class HttpParser
                     {
                         case SPACE:
                         case HTAB:
-                            //Ignore trailing whitespaces ?
-                            if (WHITESPACE_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
+                            //Ignore trailing whitespaces?
+                            if (checkViolation(WHITESPACE_AFTER_FIELD_NAME, _headerString))
                             {
                                 _headerString = takeString();
-                                reportComplianceViolation(WHITESPACE_AFTER_FIELD_NAME, "Space after " + _headerString);
                                 _header = HttpHeader.CACHE.get(_headerString);
                                 _length = -1;
                                 setState(FieldState.WS_AFTER_NAME);
@@ -1572,8 +1577,7 @@ public class HttpParser
                             _valueString = "";
                             _length = -1;
 
-                            reportComplianceViolation(NO_COLON_AFTER_FIELD_NAME, "Field " + _headerString);
-                            if (NO_COLON_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
+                            if (checkViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
                             {
                                 setState(FieldState.FIELD);
                                 break;
@@ -1604,9 +1608,8 @@ public class HttpParser
                             break;
 
                         case EOL:
-                            if (NO_COLON_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
+                            if (checkViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
                             {
-                                reportComplianceViolation(NO_COLON_AFTER_FIELD_NAME, "Field " + _headerString);
                                 setState(FieldState.FIELD);
                                 break;
                             }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1464,7 +1464,8 @@ public class HttpParser
                                     String n = cachedField.getName();
                                     String v = cachedField.getValue();
 
-                                    if (!Objects.equals(v, UNMATCHED_VALUE))
+                                    boolean unmatchedValue = Objects.equals(v, UNMATCHED_VALUE);
+                                    if (!unmatchedValue)
                                     {
                                         if (CASE_SENSITIVE_FIELD_NAME.isAllowedBy(_complianceMode))
                                         {
@@ -1496,7 +1497,7 @@ public class HttpParser
                                     int delta = n.length() + 1;
                                     int posAfterName = position + delta;
 
-                                    if (Objects.equals(v, UNMATCHED_VALUE) || (posAfterName + v.length()) >= buffer.limit())
+                                    if (unmatchedValue || (posAfterName + v.length()) >= buffer.limit())
                                     {
                                         // Header only
                                         setState(FieldState.VALUE);

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1291,7 +1291,7 @@ public class HttpParser
                     _fieldCache.add(_field);
                 }
             }
-            if (LOG.isDebugEnabled())
+            if (debugEnabled)
                 LOG.debug("parsedHeader({}) header={}, headerString=[{}], valueString=[{}]", _field, _header, _headerString, _valueString);
             _handler.parsedHeader(_field != null ? _field : newHttpField(_header, _headerString, _valueString));
         }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -16,7 +16,6 @@ package org.eclipse.jetty.http;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -246,10 +245,6 @@ public class HttpParser
         EXT_VALUE_CLOSE_QUOTE,
     }
 
-    private static final EnumSet<State> __idleStates = EnumSet.of(State.START, State.END, State.CLOSE, State.CLOSED);
-    private static final EnumSet<State> __completeStates = EnumSet.of(State.END, State.CLOSE, State.CLOSED);
-    private static final EnumSet<State> __terminatedStates = EnumSet.of(State.CLOSE, State.CLOSED);
-
     private final boolean debugEnabled = LOG.isDebugEnabled(); // Cache debug to help branch prediction
     private final HttpHandler _handler;
     private final RequestHandler _requestHandler;
@@ -380,8 +375,7 @@ public class HttpParser
     protected void checkViolation(Violation violation) throws HttpException.RuntimeException
     {
         boolean allowed = violation.isAllowedBy(_complianceMode);
-        reportComplianceViolation(violation, violation.getDescription());
-
+        reportComplianceViolation(violation, violation.getDescription(), allowed);
         if (!allowed)
             throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
@@ -394,10 +388,13 @@ public class HttpParser
     protected void reportComplianceViolation(Violation violation, String reason)
     {
         if (_requestParser)
-        {
-            boolean allowed = _complianceMode.allows(violation);
+            reportComplianceViolation(violation, reason, _complianceMode.allows(violation));
+    }
+
+    protected void reportComplianceViolation(Violation violation, String reason, boolean allowed)
+    {
+        if (_requestParser)
             _requestHandler.onViolation(new ComplianceViolation.Event(_complianceMode, violation, reason, allowed));
-        }
     }
 
     protected String caseInsensitiveHeader(String orig, String normative)
@@ -481,17 +478,18 @@ public class HttpParser
 
     public boolean isIdle()
     {
-        return __idleStates.contains(_state);
+        int ordinal = _state.ordinal();
+        return ordinal == State.START.ordinal() || ordinal >= State.END.ordinal();
     }
 
     public boolean isComplete()
     {
-        return __completeStates.contains(_state);
+        return _state.ordinal() >= State.END.ordinal();
     }
 
     public boolean isTerminated()
     {
-        return __terminatedStates.contains(_state);
+        return _state.ordinal() >= State.CLOSE.ordinal();
     }
 
     public boolean isState(State state)
@@ -1468,7 +1466,7 @@ public class HttpParser
                                             String en = BufferUtil.toString(buffer, buffer.position() - 1, n.length(), StandardCharsets.US_ASCII);
                                             if (!n.equals(en))
                                             {
-                                                reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, en);
+                                                reportComplianceViolation(CASE_SENSITIVE_FIELD_NAME, en, true);
                                                 n = en;
                                                 cachedField = newHttpField(cachedField.getHeader(), n, v);
                                             }

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -374,11 +374,11 @@ public class HttpParser
 
     protected void checkViolation(Violation violation) throws HttpException.RuntimeException
     {
-        if (!checkViolation(violation, violation.getDescription()))
+        if (!checkAndReportViolation(violation, violation.getDescription()))
             throw new HttpException.RuntimeException(HttpStatus.BAD_REQUEST_400, violation.getDescription());
     }
 
-    protected boolean checkViolation(Violation violation, String reason)
+    protected boolean checkAndReportViolation(Violation violation, String reason)
     {
         boolean allowed = _complianceMode.allows(violation);
         reportComplianceViolation(violation, reason, allowed);
@@ -388,13 +388,13 @@ public class HttpParser
     @Deprecated
     protected void reportComplianceViolation(Violation violation)
     {
-        checkViolation(violation, violation.getDescription());
+        checkAndReportViolation(violation, violation.getDescription());
     }
 
     @Deprecated
     protected void reportComplianceViolation(Violation violation, String reason)
     {
-        checkViolation(violation, reason);
+        checkAndReportViolation(violation, reason);
     }
 
     protected void reportComplianceViolation(Violation violation, String reason, boolean allowed)
@@ -799,7 +799,7 @@ public class HttpParser
                             }
                             else
                             {
-                                if (checkViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString))
+                                if (checkAndReportViolation(Violation.CASE_INSENSITIVE_METHOD, _methodString))
                                 {
                                     method = HttpMethod.INSENSITIVE_CACHE.get(_methodString);
                                     if (method != null)
@@ -969,7 +969,7 @@ public class HttpParser
                         case EOL:
                         {
                             // HTTP/0.9
-                            if (checkViolation(Violation.HTTP_0_9, HTTP_0_9.getDescription()))
+                            if (checkAndReportViolation(Violation.HTTP_0_9, HTTP_0_9.getDescription()))
                             {
                                 _requestHandler.startRequest(_methodString, _uri.toCompleteString(), HttpVersion.HTTP_0_9);
                                 setState(State.CONTENT);
@@ -1554,7 +1554,7 @@ public class HttpParser
                         case SPACE:
                         case HTAB:
                             //Ignore trailing whitespaces?
-                            if (checkViolation(WHITESPACE_AFTER_FIELD_NAME, _headerString))
+                            if (checkAndReportViolation(WHITESPACE_AFTER_FIELD_NAME, _headerString))
                             {
                                 _headerString = takeString();
                                 _header = HttpHeader.CACHE.get(_headerString);
@@ -1578,7 +1578,7 @@ public class HttpParser
                             _valueString = "";
                             _length = -1;
 
-                            if (checkViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
+                            if (checkAndReportViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
                             {
                                 setState(FieldState.FIELD);
                                 break;
@@ -1609,7 +1609,7 @@ public class HttpParser
                             break;
 
                         case EOL:
-                            if (checkViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
+                            if (checkAndReportViolation(NO_COLON_AFTER_FIELD_NAME, _headerString))
                             {
                                 setState(FieldState.FIELD);
                                 break;

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -269,9 +269,9 @@ public class HttpParser
     private int _headerBytes;
     private String _parsedHost;
     private boolean _headerComplete;
-    private volatile State _state = State.START;
-    private volatile FieldState _fieldState = FieldState.FIELD;
-    private volatile boolean _eof;
+    private State _state = State.START;
+    private FieldState _fieldState = FieldState.FIELD;
+    private boolean _eof;
     private HttpMethod _method;
     private String _methodString;
     private HttpVersion _version;

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -156,11 +156,10 @@ public class HttpChannelState implements HttpChannel, Components
                 case 1 -> listeners.get(0).initialize();
                 default -> new InitializedCompositeComplianceViolationListener(listeners);
             };
-
-            if (_complianceViolationListener != ComplianceViolation.Listener.NOOP &&
-                !_connectionMetaData.getHttpConfiguration().isNotifyForbiddenComplianceViolations())
-                _complianceViolationListener = new AllowedOnlyComplianceListener(_complianceViolationListener);
         }
+
+        if (!_connectionMetaData.getHttpConfiguration().isNotifyForbiddenComplianceViolations())
+            _complianceViolationListener = new AllowedOnlyComplianceListener(_complianceViolationListener);
     }
 
     private static class AllowedOnlyComplianceListener implements ComplianceViolation.Listener

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/internal/HttpChannelState.java
@@ -156,10 +156,11 @@ public class HttpChannelState implements HttpChannel, Components
                 case 1 -> listeners.get(0).initialize();
                 default -> new InitializedCompositeComplianceViolationListener(listeners);
             };
-        }
 
-        if (!_connectionMetaData.getHttpConfiguration().isNotifyForbiddenComplianceViolations())
-            _complianceViolationListener = new AllowedOnlyComplianceListener(_complianceViolationListener);
+            if (_complianceViolationListener != ComplianceViolation.Listener.NOOP &&
+                !_connectionMetaData.getHttpConfiguration().isNotifyForbiddenComplianceViolations())
+                _complianceViolationListener = new AllowedOnlyComplianceListener(_complianceViolationListener);
+        }
     }
 
     private static class AllowedOnlyComplianceListener implements ComplianceViolation.Listener


### PR DESCRIPTION
Several cleanups of HttpParser to improve performance:
 + prevent large fields from flushing the field cache
 + remove unnecessary volatiles
 + replaced enum set check with cheaper ordinal comparisons
 
