### PR TITLE
Updating Constraint Testing to modern Jakarta Servlet Spec

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/ConstraintMapping.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/ConstraintMapping.java
@@ -15,7 +15,9 @@ package org.eclipse.jetty.ee10.servlet.security;
 
 import java.util.Arrays;
 
+import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.security.Constraint;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 
 public class ConstraintMapping
@@ -54,6 +56,9 @@ public class ConstraintMapping
      */
     public void setMethod(String method)
     {
+        if (method != null)
+            checkHttpMethodName(method, "Servlet Constraint HTTP Method");
+
         this._method = method;
     }
 
@@ -78,6 +83,12 @@ public class ConstraintMapping
      */
     public void setMethodOmissions(String[] omissions)
     {
+        if (omissions != null)
+        {
+            for (String omission: omissions)
+                checkHttpMethodName(omission, "Servlet Constraint HTTP Method Omission");
+        }
+
         _methodOmissions = omissions;
     }
 
@@ -86,10 +97,24 @@ public class ConstraintMapping
         return _methodOmissions;
     }
 
+    public boolean hasMethodOmissions()
+    {
+        return _methodOmissions != null && _methodOmissions.length > 0;
+    }
+
+    private void checkHttpMethodName(String methodName, String msg)
+    {
+        if (StringUtil.isBlank(methodName))
+            throw new IllegalArgumentException("Blank HTTP Method Name: " + msg);
+        if ("*".equals(methodName))
+            throw new IllegalArgumentException("Invalid HTTP Method Name '*': " + msg);
+        Syntax.requireValidRFC2616Token(methodName, msg);
+    }
+
     @Override
     public String toString()
     {
-        return "%s@%x{%s,%s %s -> %s}".formatted(
+        return "%s@%x{method=%s,omissions=%s,pathSpec=%s -> %s}".formatted(
             TypeUtil.toShortName(getClass()),
             hashCode(),
             _method,

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/ConstraintSecurityHandler.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/security/ConstraintSecurityHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,10 +60,14 @@ import org.slf4j.LoggerFactory;
  */
 public class ConstraintSecurityHandler extends SecurityHandler implements ConstraintAware
 {
-    private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class); //use same as SecurityHandler
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class); // use same as SecurityHandler
 
     private static final String OMISSION_SUFFIX = ".omission";
-    private static final String ALL_METHODS = "*";
+    /**
+     * Used as a key in various {@code Map} in this class (to avoid null keys).
+     * This cannot be used as a value in a web.xml or in the public constraint API.
+     */
+    private static final String ALL_METHODS_KEY = "*";
 
     public static final String ANY_KNOWN_ROLE = "*";
     public static final String ANY_ROLE = "**";
@@ -76,6 +81,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected Constraint getConstraint(String pathInContext, Request request)
     {
+        return getConstraint(pathInContext, request.getMethod());
+    }
+
+    protected Constraint getConstraint(String pathInContext, String httpMethod)
+    {
         MatchedResource<Map<String, Constraint>> resource = _constraintsByPathAndMethod.getMatched(pathInContext);
         if (resource == null)
             return null;
@@ -84,19 +94,18 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         if (mappings == null)
             return null;
 
-        String httpMethod = request.getMethod();
         Constraint constraint = mappings.get(httpMethod);
         if (constraint == null)
         {
-            //No specific http-method names matched
-            //Get info for constraint that matches all methods if it exists
-            constraint = mappings.get(ALL_METHODS);
+            // No specific http-method names matched
+            // Get info for constraint that matches all methods if it exists
+            constraint = mappings.get(ALL_METHODS_KEY);
 
-            //Get info for constraints that name method omissions where target method name is not omitted
-            //(ie matches because target method is not omitted, hence considered covered by the constraint)
+            // Get info for constraints that name method omissions where target method name is not omitted
+            // (ie matches because target method is not omitted, hence considered covered by the constraint)
             for (Map.Entry<String, Constraint> entry : mappings.entrySet())
             {
-                if (entry.getKey() != null && entry.getKey().endsWith(OMISSION_SUFFIX) && !entry.getKey().contains(httpMethod))
+                if (isMethodOmission(entry.getKey()) && !getOmittedMethods(entry.getKey()).contains(httpMethod))
                     constraint = combineServletConstraints(constraint, entry.getValue());
             }
 
@@ -136,26 +145,29 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             if (permitOrDeny.equals(EmptyRoleSemantic.DENY))
             {
-                //Equivalent to <auth-constraint> with no roles
+                // Equivalent to <auth-constraint> with no roles
                 constraint.name(name + "-Deny");
                 constraint.authorization(Constraint.Authorization.FORBIDDEN);
             }
             else
             {
-                //Equivalent to no <auth-constraint>
+                // Equivalent to no <auth-constraint>
                 constraint.name(name + "-Permit");
                 constraint.authorization(Constraint.Authorization.ALLOWED);
             }
         }
         else
         {
-            //Equivalent to <auth-constraint> with list of <security-role-name>s
+            // Equivalent to <auth-constraint> with list of <security-role-name>
             constraint.authorization(Constraint.Authorization.SPECIFIC_ROLE);
             constraint.roles(rolesAllowed);
             constraint.name(name + "-RolesAllowed");
         }
 
-        //Equivalent to //<user-data-constraint><transport-guarantee>CONFIDENTIAL</transport-guarantee></user-data-constraint>
+        // Equivalent to:
+        // <user-data-constraint>
+        //   <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        // </user-data-constraint>
         constraint.transport(TransportGuarantee.CONFIDENTIAL.equals(transport) ? Transport.SECURE : Transport.ANY);
 
         return constraint.build();
@@ -171,13 +183,13 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     public static List<ConstraintMapping> removeConstraintMappingsForPath(String pathSpec, List<ConstraintMapping> constraintMappings)
     {
-        if (pathSpec == null || "".equals(pathSpec.trim()) || constraintMappings == null || constraintMappings.size() == 0)
+        if (StringUtil.isBlank(pathSpec) || constraintMappings == null || constraintMappings.isEmpty())
             return Collections.emptyList();
 
         List<ConstraintMapping> mappings = new ArrayList<>();
         for (ConstraintMapping mapping : constraintMappings)
         {
-            //Remove the matching mappings by only copying in non-matching mappings
+            // Remove the matching mappings by only copying in non-matching mappings
             if (!pathSpec.equals(mapping.getPathSpec()))
             {
                 mappings.add(mapping);
@@ -193,12 +205,14 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      * @param pathSpec the path spec
      * @param securityElement the servlet security element
      * @return the list of constraint mappings
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#mapping-servletsecurity-to-security-constraint">Jakarta Servlet Spec 13.4.1.2: "Mapping @ServletSecurity to security-constraint"</a>
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#servletsecurity-annotation">Jakarta Servlet Spec 13.4.1: "@ServletSecurity Annotation" - @HttpConstraint</a>
      */
     public static List<ConstraintMapping> createConstraintsWithMappingsForPath(String name, String pathSpec, ServletSecurityElement securityElement)
     {
         List<ConstraintMapping> mappings = new ArrayList<>();
 
-        //Create a constraint that will describe the default case (ie if not overridden by specific HttpMethodConstraints)
+        // Create a constraint that will describe the default case (ie if not overridden by specific HttpMethodConstraints)
         Constraint httpConstraint;
         ConstraintMapping httpConstraintMapping = null;
 
@@ -208,23 +222,22 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             httpConstraint = ConstraintSecurityHandler.createConstraint(name, securityElement);
 
-            //Create a mapping for the pathSpec for the default case
+            // Create a mapping for the pathSpec for the default case
             httpConstraintMapping = new ConstraintMapping();
             httpConstraintMapping.setPathSpec(pathSpec);
             httpConstraintMapping.setConstraint(httpConstraint);
             mappings.add(httpConstraintMapping);
         }
 
-        //See Spec 13.4.1.2 p127
         List<String> methodOmissions = new ArrayList<>();
 
-        //make constraint mappings for this url for each of the HttpMethodConstraintElements
+        // make constraint mappings for this url for each of the HttpMethodConstraintElements
         java.util.Collection<HttpMethodConstraintElement> methodConstraintElements = securityElement.getHttpMethodConstraints();
         if (methodConstraintElements != null)
         {
             for (HttpMethodConstraintElement methodConstraintElement : methodConstraintElements)
             {
-                //Make a Constraint that captures the <auth-constraint> and <user-data-constraint> elements supplied for the HttpMethodConstraintElement
+                // Make a Constraint that captures the <auth-constraint> and <user-data-constraint> elements supplied for the HttpMethodConstraintElement
                 Constraint methodConstraint = ConstraintSecurityHandler.createConstraint(name, methodConstraintElement);
                 ConstraintMapping mapping = new ConstraintMapping();
                 mapping.setConstraint(methodConstraint);
@@ -232,15 +245,15 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 if (methodConstraintElement.getMethodName() != null)
                 {
                     mapping.setMethod(methodConstraintElement.getMethodName());
-                    //See spec 13.4.1.2 p127 - add an omission for every method name to the default constraint
+                    // Spec: Add an omission for every method name to the default constraint
                     methodOmissions.add(methodConstraintElement.getMethodName());
                 }
                 mappings.add(mapping);
             }
         }
-        //See spec 13.4.1.2 p127 - add an omission for every method name to the default constraint
-        //UNLESS the default constraint contains all default values. In that case, we won't add it. See Servlet Spec 3.1 pg 129
-        if (methodOmissions.size() > 0 && httpConstraintMapping != null)
+        // Spec: Add an omission for every method name to the default constraint
+        // UNLESS the default constraint contains all default values. In that case, we won't add it.
+        if (!methodOmissions.isEmpty() && httpConstraintMapping != null)
             httpConstraintMapping.setMethodOmissions(methodOmissions.toArray(new String[0]));
 
         return mappings;
@@ -259,8 +272,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set, from which the set of known roles
      * is determined.
@@ -271,8 +287,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set as array, from which the set of known roles
      * is determined.  Needed to retain API compatibility for 7.x
@@ -283,8 +302,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set.
      * @param roles The known roles (or null to determine them from the mappings)
@@ -292,7 +314,6 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void setConstraintMappings(List<ConstraintMapping> constraintMappings, Set<String> roles)
     {
-
         _constraintMappings.clear();
         _constraintMappings.addAll(constraintMappings);
 
@@ -312,7 +333,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 {
                     for (String r : cmr)
                     {
-                        if (!ALL_METHODS.equals(r))
+                        if (!ANY_KNOWN_ROLE.equals(r))
                             roles.add(r);
                     }
                 }
@@ -321,7 +342,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         setRoles(roles);
 
         if (isStarted())
-            _constraintMappings.forEach(this::processConstraintMapping);
+            rebuildMappings();
     }
 
     /**
@@ -347,18 +368,29 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
 
         if (mapping.getConstraint() != null && mapping.getConstraint().getRoles() != null)
         {
-            //allow for lazy role naming: if a role is named in a security constraint, try and
-            //add it to the list of declared roles (ie as if it was declared with a security-role
+            // allow for lazy role naming: if a role is named in a security constraint, try and
+            // add it to the list of declared roles (ie as if it was declared with a security-role
             for (String role : mapping.getConstraint().getRoles())
             {
-                if ("*".equals(role) || "**".equals(role))
+                if (ANY_KNOWN_ROLE.equals(role) || ANY_ROLE.equals(role))
                     continue;
                 addKnownRole(role);
             }
         }
 
         if (isStarted())
-            processConstraintMapping(mapping);
+            rebuildMappings();
+    }
+
+    private void rebuildMappings()
+    {
+        _constraintsByPathAndMethod.reset();
+        _constraintMappings.forEach(this::processConstraintMapping);
+
+        // Jakarta Servlet Spec 13.8.4.2: "Handling Uncovered HTTP Methods"
+        // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#handling-uncovered-http-methods
+        // log paths for which there are uncovered http methods
+        checkPathsWithUncoveredHttpMethods();
     }
 
     @Override
@@ -370,11 +402,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected void doStart() throws Exception
     {
-        _constraintsByPathAndMethod.reset();
-        _constraintMappings.forEach(this::processConstraintMapping);
-
-        //Servlet Spec 3.1 pg 147 sec 13.8.4.2 log paths for which there are uncovered http methods
-        checkPathsWithUncoveredHttpMethods();
+        rebuildMappings();
 
         Context context = ContextHandler.getCurrentContext();
         if (context instanceof ServletContextHandler.ServletScopedContext servletScopedContext)
@@ -403,7 +431,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * <p>Combine constrains as per the servlet specification.
+     * <p>Combine constraints as per the servlet specification.
      * This is NOT equivalent to {@link Constraint#combine(Constraint, Constraint)}, which implements
      * a more secure combination.</p>
      * @param constraintA A constraint
@@ -413,7 +441,8 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     protected Constraint combineServletConstraints(Constraint constraintA, Constraint constraintB)
     {
         // This method is not identical to Constraint.combine.
-        // Instead, it implements the bizarre section 13.8.1 of Servlet 6.0 specification
+        // Instead, it implements the bizarre Jakarta Servlet Spec section 13.8.1: "Combining Constraints"
+        // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints
 
         if (constraintA == null)
             return constraintB == null ? Constraint.ALLOWED_ANY_TRANSPORT : constraintB;
@@ -484,36 +513,52 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             mappings = new HashMap<>();
             _constraintsByPathAndMethod.put(mapping.getPathSpec(), mappings);
         }
-        Constraint allMethodsConstraint = mappings.get(ALL_METHODS);
+        Constraint allMethodsConstraint = mappings.get(ALL_METHODS_KEY);
         if (allMethodsConstraint != null && allMethodsConstraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
             return;
 
-        if (mapping.getMethodOmissions() != null && mapping.getMethodOmissions().length > 0)
+        // Does this mapping have method omissions?
+        if (mapping.hasMethodOmissions())
         {
-            processConstraintMappingWithMethodOmissions(mapping, mappings);
-            return;
-        }
-
-        String httpMethod = mapping.getMethod();
-        if (httpMethod == null)
-            httpMethod = ALL_METHODS;
-        Constraint constraint = mappings.get(httpMethod);
-        if (constraint == null)
-            constraint = allMethodsConstraint;
-        if (constraint != null && constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
-            return;
-
-        // add in info from the constraint
-        constraint = combineServletConstraints(constraint, mapping.getConstraint());
-
-        if (constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN && httpMethod.equals(ALL_METHODS))
-        {
-            mappings.clear();
-            mappings.put(ALL_METHODS, constraint);
+            String methodOmissionKey = toMethodOmissions(mapping);
+            // Is there any existing mapping to the same omissions?
+            Constraint existingConstraint = mappings.get(methodOmissionKey);
+            if (existingConstraint != null)
+            {
+                // combine them
+                Constraint constraint = combineServletConstraints(existingConstraint, mapping.getConstraint());
+                mappings.put(methodOmissionKey, constraint);
+            }
+            else
+            {
+                // new mapping discovered, add to map, we're done.
+                mappings.put(methodOmissionKey, mapping.getConstraint());
+            }
         }
         else
         {
-            mappings.put(httpMethod, constraint);
+            // We have a normal method constraint.
+            String httpMethod = mapping.getMethod();
+            if (httpMethod == null)
+                httpMethod = ALL_METHODS_KEY;
+            Constraint constraint = mappings.get(httpMethod);
+            if (constraint == null)
+                constraint = allMethodsConstraint;
+            if (constraint != null && constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
+                return;
+
+            // add in info from the constraint
+            constraint = combineServletConstraints(constraint, mapping.getConstraint());
+
+            if (constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN && httpMethod.equals(ALL_METHODS_KEY))
+            {
+                mappings.clear();
+                mappings.put(ALL_METHODS_KEY, constraint);
+            }
+            else
+            {
+                mappings.put(httpMethod, constraint);
+            }
         }
     }
 
@@ -529,19 +574,17 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      *
      * @param mapping the constraint mapping
      * @param mappings the mappings of roles
+     * @deprecated Not used, no replacement
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     protected void processConstraintMappingWithMethodOmissions(ConstraintMapping mapping, Map<String, Constraint> mappings)
     {
-        String[] omissions = mapping.getMethodOmissions();
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < omissions.length; i++)
-        {
-            if (i > 0)
-                sb.append(".");
-            sb.append(omissions[i]);
-        }
-        sb.append(OMISSION_SUFFIX);
-        mappings.put(sb.toString(), mapping.getConstraint());
+        mappings.put(toMethodOmissions(mapping), mapping.getConstraint());
+    }
+
+    private String toMethodOmissions(ConstraintMapping mapping)
+    {
+        return String.join(".", mapping.getMethodOmissions()) + OMISSION_SUFFIX;
     }
 
     @Override
@@ -565,7 +608,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Servlet spec 3.1 pg. 147.
+     * Checking paths with uncovered http methods.
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#uncovered-http-protocol-methods">Jakarta Servlet 6.1, sec 13.8.4: "Uncovered HTTP Protocol Methods"</a>
      */
     @Override
     public boolean checkPathsWithUncoveredHttpMethods()
@@ -581,16 +626,16 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Servlet spec 3.1 pg. 147.
      * The container must check all the combined security constraint
      * information and log any methods that are not protected and the
-     * urls at which they are not protected
+     * URLs at which they are not protected
      *
      * @return Set of paths for which there are uncovered methods
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#uncovered-http-protocol-methods">Jakarta Servlet 6.1, sec 13.8.4: "Uncovered HTTP Protocol Methods"</a>
      */
     public Set<String> getPathsWithUncoveredHttpMethods()
     {
-        //if automatically denying uncovered methods, there are no uncovered methods
+        // if automatically denying uncovered methods, there are no uncovered methods
         if (_denyUncoveredMethods)
             return Collections.emptySet();
 
@@ -600,18 +645,18 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             String path = resource.getPathSpec().getDeclaration();
             Map<String, Constraint> methodMappings = resource.getResource();
-            //Each key is either:
-            // : an exact method name
-            // : * which means that the constraint applies to every method
-            // : a name of the form <method>.<method>.<method>.omission, which means it applies to every method EXCEPT those named
-            if (methodMappings.get(ALL_METHODS) != null)
-                continue; //can't be any uncovered methods for this url path
+            // Each key is either:
+            //  - an exact method name
+            //  - `*` which means that the constraint applies to every method
+            //  - a name of the form <method>.<method>.<method>.omission, which means it applies to every method EXCEPT those named
+            if (methodMappings.get(ALL_METHODS_KEY) != null)
+                continue; // can't be any uncovered methods for this url path
 
             boolean hasOmissions = omissionsExist(methodMappings);
 
             for (String method : methodMappings.keySet())
             {
-                if (method.endsWith(OMISSION_SUFFIX))
+                if (isMethodOmission(method))
                 {
                     Set<String> omittedMethods = getOmittedMethods(method);
                     for (String m : omittedMethods)
@@ -622,9 +667,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 }
                 else
                 {
-                    //an exact method name
+                    // an exact method name
                     if (!hasOmissions)
-                        //an http-method does not have http-method-omission to cover the other method names
+                        // an http-method does not have http-method-omission to cover the other method names
                         uncoveredPaths.add(path);
                 }
             }
@@ -645,10 +690,17 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             return false;
         for (String m : methodMappings.keySet())
         {
-            if (m.endsWith(OMISSION_SUFFIX))
+            if (isMethodOmission(m))
                 return true;
         }
         return false;
+    }
+
+    private boolean isMethodOmission(String method)
+    {
+        if (method == null)
+            return false;
+        return method.endsWith(OMISSION_SUFFIX);
     }
 
     /**
@@ -671,7 +723,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      * Constraints can be added to the ConstraintSecurityHandler before the
      * associated context is started. These constraints should persist across
      * a stop/start. Others can be added after the associated context is starting
-     * (eg by a web.xml/web-fragment.xml, annotation or jakarta.servlet api call) -
+     * (e.g. by a {@code web.xml/web-fragment.xml}, annotation or {@code jakarta.servlet} api call) -
      * these should not be persisted across a stop/start as they will be re-added on
      * the restart.
      *

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/ConstraintTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/security/ConstraintTest.java
@@ -63,13 +63,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
@@ -82,6 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConstraintTest
@@ -457,11 +461,17 @@ public class ConstraintTest
     }
     
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-1
-     * &#064;ServletSecurity
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-1</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity
+     *     public class Example1 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample131()
+    public void testSecurityElementExample13_1()
     {
         ServletSecurityElement element = new ServletSecurityElement();
         List<ConstraintMapping> mappings = ConstraintSecurityHandler.createConstraintsWithMappingsForPath("foo", "/foo/*", element);
@@ -469,11 +479,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-2
-     * &#064;ServletSecurity(@HttpConstraint(transportGuarantee = TransportGuarantee.CONFIDENTIAL))
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-2</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(transportGuarantee = TransportGuarantee.CONFIDENTIAL))
+     *     public class Example2 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample132()
+    public void testSecurityElementExample13_2()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(TransportGuarantee.CONFIDENTIAL);
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -485,14 +501,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-3
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-3</p>
      *
-     * <pre>
-     * &#064;ServletSecurity(@HttpConstraint(EmptyRoleSemantic.DENY))
-     * </pre>
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(EmptyRoleSemantic.DENY))
+     *     public class Example3 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample133()
+    public void testSecurityElementExample13_3()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(EmptyRoleSemantic.DENY);
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -505,13 +524,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-4
-     * <pre>
-     * &#064;ServletSecurity(&#064;HttpConstraint(rolesAllowed = "R1"))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-4</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(rolesAllowed = "R1"))
+     *     public class Example4 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample134()
+    public void testSecurityElementExample13_4()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(TransportGuarantee.NONE, "R1");
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -526,16 +549,21 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-5
-     * <pre>
-     * &#064;ServletSecurity((httpMethodConstraints = {
-     * &#064;HttpMethodConstraint(value = "GET", rolesAllowed = "R1"),
-     * &#064;HttpMethodConstraint(value = "POST", rolesAllowed = "R1",
-     * transportGuarantee = TransportGuarantee.CONFIDENTIAL)})
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-5</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity((httpMethodConstraints = {
+     *         @HttpMethodConstraint(value = "GET", rolesAllowed = "R1"),
+     *         @HttpMethodConstraint(value = "POST", rolesAllowed = "R1",
+     *                               transportGuarantee = TransportGuarantee.CONFIDENTIAL)
+     *     })
+     *     public class Example5 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample135()
+    public void testSecurityElementExample13_5()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("GET", new HttpConstraintElement(TransportGuarantee.NONE, "R1")));
@@ -555,13 +583,18 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-6
-     * <pre>
-     * &#064;ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"), httpMethodConstraints = @HttpMethodConstraint("GET"))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-6</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
+     *                      httpMethodConstraints = @HttpMethodConstraint("GET"))
+     *     public class Example6 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample136()
+    public void testSecurityElementExample13_6()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("GET"));
@@ -580,15 +613,19 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-7
-     * <pre>
-     * &#064;ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
-     * httpMethodConstraints = @HttpMethodConstraint(value="TRACE",
-     * emptyRoleSemantic = EmptyRoleSemantic.DENY))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-7</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
+     *                      httpMethodConstraints = @HttpMethodConstraint(value="TRACE",
+     *                      emptyRoleSemantic = EmptyRoleSemantic.DENY))
+     *     public class Example7 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample137()
+    public void testSecurityElementExample13_7()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("TRACE", new HttpConstraintElement(EmptyRoleSemantic.DENY)));
@@ -610,7 +647,7 @@ public class ConstraintTest
     @Test
     public void testUncoveredHttpMethodDetection() throws Exception
     {
-        //Test no methods named
+        // Test no methods named
         Constraint.Builder constraint1 = new Constraint.Builder();
         constraint1.authorization(Constraint.Authorization.ANY_USER);
         constraint1.name("** constraint");
@@ -1879,8 +1916,6 @@ public class ConstraintTest
         assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
 
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-        // assertThat(response,containsString(" 302 Found"));
-        // assertThat(response,containsString("/ctx/testLoginPage"));
         assertThat(response, containsString("Cache-Control: no-cache"));
         assertThat(response, containsString("Expires"));
         assertThat(response, containsString("URI=/ctx/testLoginPage"));
@@ -1921,8 +1956,6 @@ public class ConstraintTest
 
         // log in again as user2
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -1949,8 +1982,6 @@ public class ConstraintTest
 
         // log in again as admin
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -2083,8 +2114,6 @@ public class ConstraintTest
 
         // log in again as admin
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -2364,6 +2393,363 @@ public class ConstraintTest
 
         response = _connector.getResponse("OPTIONS /ctx/some/constraint/info HTTP/1.0\r\n\r\n");
         assertThat(response, startsWith("HTTP/1.1 403 "));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethod(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethod(name));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethodOmission(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(new String[]{name}));
+    }
+
+    @Test
+    public void testSetHttpMethodOmissionWithNullEntries()
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        String[] names = new String[]{"GET", null, "POST"};
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(names));
+    }
+
+    public static Stream<Arguments> jakartaSpecCombinedConstraintExampleCases()
+    {
+        return Stream.of(
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/*"
+            Arguments.of("PUT", "/foo", true, is(empty()), is(Constraint.Authorization.FORBIDDEN), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/foo", false, null, null, null),
+            Arguments.of("POST", "/foo", false, null, null, null),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/wholesale/*"
+            Arguments.of("PUT", "/acme/wholesale/foo", true, contains("SALESCLERK"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/acme/wholesale/foo", true, containsInAnyOrder("CONTRACTOR", "SALESCLERK"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("POST", "/acme/wholesale/foo", true, contains("CONTRACTOR"), is(Constraint.Authorization.SPECIFIC_ROLE), is(Constraint.Transport.SECURE)),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/retail/*"
+            Arguments.of("PUT", "/acme/retail/foo", true, is(empty()), is(Constraint.Authorization.FORBIDDEN), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/acme/retail/foo", true, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("POST", "/acme/retail/foo", true, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE)))
+        );
+    }
+
+    /**
+     * Replication of Constraint combination from
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta Servlet Spec 13.8.1 : Combining Constraints</a>.
+     */
+    @ParameterizedTest
+    @MethodSource("jakartaSpecCombinedConstraintExampleCases")
+    public void testJakartaSpecCombinedConstraintsExamples(String httpMethod, String requestPath,
+                                                           boolean coveredByConstraint,
+                                                           org.hamcrest.Matcher<Set<String>> rolesMatcher,
+                                                           org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher,
+                                                           org.hamcrest.Matcher<Constraint.Transport> transportMatcher) throws Exception
+    {
+        List<ConstraintMapping> mappings = new ArrayList<>();
+
+        // Note: the path spec `/*` is known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>precluded methods</web-resource-name>
+            <url-pattern>/*</url-pattern>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method-omission>GET</http-method-omission>
+            <http-method-omission>POST</http-method-omission>
+          </web-resource-collection>
+          <auth-constraint/>
+        </security-constraint>
+         */
+        for (String pathSpec: List.of("/*", "/acme/wholesale/*", "/acme/retail/*"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec(pathSpec);
+            mapping.setMethodOmissions(new String[]{"GET", "POST"});
+            mapping.setConstraint(Constraint.FORBIDDEN);
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>PUT</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>SALESCLERK</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder wholesaleConstraint = new Constraint.Builder();
+        wholesaleConstraint.name("salesclerk");
+        wholesaleConstraint.roles("SALESCLERK");
+        for (String wholesaleMethod: List.of("GET", "PUT"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesaleMethod);
+            mapping.setConstraint(wholesaleConstraint.build());
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale 2</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+          </auth-constraint>
+          <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+          </user-data-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder wholesale2Constraint = new Constraint.Builder();
+        wholesale2Constraint.name("contractor");
+        wholesale2Constraint.roles("CONTRACTOR");
+        wholesale2Constraint.transport(Constraint.Transport.SECURE);
+        for (String wholesale2Method: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesale2Method);
+            mapping.setConstraint(wholesale2Constraint.build());
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>retail</web-resource-name>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+            <role-name>HOMEOWNER</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder retailConstraint = new Constraint.Builder();
+        retailConstraint.roles("CONTRACTOR", "HOMEOWNER");
+        for (String retailMethod: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/retail/*");
+            mapping.setMethod(retailMethod);
+            mapping.setConstraint(retailConstraint.build());
+            mappings.add(mapping);
+        }
+
+        Set<String> knownRoles = Set.of("SALESCLERK", "CONTRACTOR", "HOMEOWNER");
+        _security.setConstraintMappings(mappings, knownRoles);
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+        {
+            assertThat("%s %s roles".formatted(httpMethod, requestPath), constraint.getRoles(), rolesMatcher);
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+            assertThat("%s %s transport".formatted(httpMethod, requestPath), constraint.getTransport(), transportMatcher);
+        }
+    }
+
+    public static Stream<Arguments> singleForbiddenMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", null),
+            Arguments.of("GET", "PUT", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("GET", "POST", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("GET", "DELETE", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", null),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", null),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", null),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", null),
+            Arguments.of("CorpQuery", "GET", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("CorpQuery", "POST", "/test/foo", is(Constraint.Authorization.FORBIDDEN))
+        );
+    }
+
+    /**
+     * Tests forbidden http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleForbiddenMethodOmissionCases")
+    public void testSingleForbiddenMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath,
+                                     org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        boolean coveredByConstraint = !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+        _security.setConstraintMappings(List.of(forbiddenMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, requestHttpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(requestHttpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(requestHttpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    public static Stream<Arguments> singleAllowedMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", null),
+            Arguments.of("GET", "PUT", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("GET", "POST", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("GET", "DELETE", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", null),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", null),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", null),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", null),
+            Arguments.of("CorpQuery", "GET", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("CorpQuery", "POST", "/test/foo", is(Constraint.Authorization.ALLOWED))
+        );
+    }
+
+    /**
+     * Tests allowed http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleAllowedMethodOmissionCases")
+    public void testSingleAllowedMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath,
+                                                          org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        boolean coveredByConstraint = !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+        _security.setConstraintMappings(List.of(allowedMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, requestHttpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(requestHttpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(requestHttpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    public static Stream<Arguments> combinedAllowedForbiddenMethodOmissionConstraintsCases()
+    {
+        return Stream.of(
+            // Neither constraint covers GET
+            Arguments.of("GET", "/test/foo", false, null),
+            // The forbidden constraint wins
+            Arguments.of("PUT", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("POST", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("DELETE", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN))
+        );
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedAllowedForbiddenMethodOmissionConstraints(String httpMethod, String requestPath,
+                                                                      boolean coveredByConstraint,
+                                                                      org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+
+        // This is the reverse order from testCombinedForbiddenAllowedMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(allowedMapping, forbiddenMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedForbiddenAllowedMethodOmissionConstraints(String httpMethod, String requestPath,
+                                                                      boolean coveredByConstraint,
+                                                                      org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+
+        // This is the reverse order from testCombinedAllowedForbiddenMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(forbiddenMapping, allowedMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
     }
 
     @Test

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/security/ConstraintMapping.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/security/ConstraintMapping.java
@@ -15,7 +15,9 @@ package org.eclipse.jetty.ee11.servlet.security;
 
 import java.util.Arrays;
 
+import org.eclipse.jetty.http.Syntax;
 import org.eclipse.jetty.security.Constraint;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
 
 public class ConstraintMapping
@@ -54,6 +56,9 @@ public class ConstraintMapping
      */
     public void setMethod(String method)
     {
+        if (method != null)
+            checkHttpMethodName(method, "Servlet Constraint HTTP Method");
+
         this._method = method;
     }
 
@@ -78,6 +83,12 @@ public class ConstraintMapping
      */
     public void setMethodOmissions(String[] omissions)
     {
+        if (omissions != null)
+        {
+            for (String omission: omissions)
+                checkHttpMethodName(omission, "Servlet Constraint HTTP Method Omission");
+        }
+
         _methodOmissions = omissions;
     }
 
@@ -86,10 +97,24 @@ public class ConstraintMapping
         return _methodOmissions;
     }
 
+    public boolean hasMethodOmissions()
+    {
+        return _methodOmissions != null && _methodOmissions.length > 0;
+    }
+
+    private void checkHttpMethodName(String methodName, String msg)
+    {
+        if (StringUtil.isBlank(methodName))
+            throw new IllegalArgumentException("Blank HTTP Method Name: " + msg);
+        if ("*".equals(methodName))
+            throw new IllegalArgumentException("Invalid HTTP Method Name '*': " + msg);
+        Syntax.requireValidRFC2616Token(methodName, msg);
+    }
+
     @Override
     public String toString()
     {
-        return "%s@%x{%s,%s %s -> %s}".formatted(
+        return "%s@%x{method=%s,omissions=%s,pathSpec=%s -> %s}".formatted(
             TypeUtil.toShortName(getClass()),
             hashCode(),
             _method,

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/security/ConstraintSecurityHandler.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/security/ConstraintSecurityHandler.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.server.Context;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,10 +60,14 @@ import org.slf4j.LoggerFactory;
  */
 public class ConstraintSecurityHandler extends SecurityHandler implements ConstraintAware
 {
-    private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class); //use same as SecurityHandler
+    private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class); // use same as SecurityHandler
 
     private static final String OMISSION_SUFFIX = ".omission";
-    private static final String ALL_METHODS = "*";
+    /**
+     * Used as a key in various {@code Map} in this class (to avoid null keys).
+     * This cannot be used as a value in a web.xml or in the public constraint API.
+     */
+    private static final String ALL_METHODS_KEY = "*";
 
     public static final String ANY_KNOWN_ROLE = "*";
     public static final String ANY_ROLE = "**";
@@ -76,6 +81,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected Constraint getConstraint(String pathInContext, Request request)
     {
+        return getConstraint(pathInContext, request.getMethod());
+    }
+
+    protected Constraint getConstraint(String pathInContext, String httpMethod)
+    {
         MatchedResource<Map<String, Constraint>> resource = _constraintsByPathAndMethod.getMatched(pathInContext);
         if (resource == null)
             return null;
@@ -84,19 +94,18 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         if (mappings == null)
             return null;
 
-        String httpMethod = request.getMethod();
         Constraint constraint = mappings.get(httpMethod);
         if (constraint == null)
         {
-            //No specific http-method names matched
-            //Get info for constraint that matches all methods if it exists
-            constraint = mappings.get(ALL_METHODS);
+            // No specific http-method names matched
+            // Get info for constraint that matches all methods if it exists
+            constraint = mappings.get(ALL_METHODS_KEY);
 
-            //Get info for constraints that name method omissions where target method name is not omitted
-            //(ie matches because target method is not omitted, hence considered covered by the constraint)
+            // Get info for constraints that name method omissions where target method name is not omitted
+            // (ie matches because target method is not omitted, hence considered covered by the constraint)
             for (Map.Entry<String, Constraint> entry : mappings.entrySet())
             {
-                if (entry.getKey() != null && entry.getKey().endsWith(OMISSION_SUFFIX) && !entry.getKey().contains(httpMethod))
+                if (isMethodOmission(entry.getKey()) && !getOmittedMethods(entry.getKey()).contains(httpMethod))
                     constraint = combineServletConstraints(constraint, entry.getValue());
             }
 
@@ -136,26 +145,29 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             if (permitOrDeny.equals(EmptyRoleSemantic.DENY))
             {
-                //Equivalent to <auth-constraint> with no roles
+                // Equivalent to <auth-constraint> with no roles
                 constraint.name(name + "-Deny");
                 constraint.authorization(Constraint.Authorization.FORBIDDEN);
             }
             else
             {
-                //Equivalent to no <auth-constraint>
+                // Equivalent to no <auth-constraint>
                 constraint.name(name + "-Permit");
                 constraint.authorization(Constraint.Authorization.ALLOWED);
             }
         }
         else
         {
-            //Equivalent to <auth-constraint> with list of <security-role-name>s
+            // Equivalent to <auth-constraint> with list of <security-role-name>
             constraint.authorization(Constraint.Authorization.SPECIFIC_ROLE);
             constraint.roles(rolesAllowed);
             constraint.name(name + "-RolesAllowed");
         }
 
-        //Equivalent to //<user-data-constraint><transport-guarantee>CONFIDENTIAL</transport-guarantee></user-data-constraint>
+        // Equivalent to:
+        // <user-data-constraint>
+        //   <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+        // </user-data-constraint>
         constraint.transport(TransportGuarantee.CONFIDENTIAL.equals(transport) ? Transport.SECURE : Transport.ANY);
 
         return constraint.build();
@@ -171,13 +183,13 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     public static List<ConstraintMapping> removeConstraintMappingsForPath(String pathSpec, List<ConstraintMapping> constraintMappings)
     {
-        if (pathSpec == null || "".equals(pathSpec.trim()) || constraintMappings == null || constraintMappings.size() == 0)
+        if (StringUtil.isBlank(pathSpec) || constraintMappings == null || constraintMappings.isEmpty())
             return Collections.emptyList();
 
         List<ConstraintMapping> mappings = new ArrayList<>();
         for (ConstraintMapping mapping : constraintMappings)
         {
-            //Remove the matching mappings by only copying in non-matching mappings
+            // Remove the matching mappings by only copying in non-matching mappings
             if (!pathSpec.equals(mapping.getPathSpec()))
             {
                 mappings.add(mapping);
@@ -193,12 +205,14 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      * @param pathSpec the path spec
      * @param securityElement the servlet security element
      * @return the list of constraint mappings
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#mapping-servletsecurity-to-security-constraint">Jakarta Servlet Spec 13.4.1.2: "Mapping @ServletSecurity to security-constraint"</a>
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#servletsecurity-annotation">Jakarta Servlet Spec 13.4.1: "@ServletSecurity Annotation" - @HttpConstraint</a>
      */
     public static List<ConstraintMapping> createConstraintsWithMappingsForPath(String name, String pathSpec, ServletSecurityElement securityElement)
     {
         List<ConstraintMapping> mappings = new ArrayList<>();
 
-        //Create a constraint that will describe the default case (ie if not overridden by specific HttpMethodConstraints)
+        // Create a constraint that will describe the default case (ie if not overridden by specific HttpMethodConstraints)
         Constraint httpConstraint;
         ConstraintMapping httpConstraintMapping = null;
 
@@ -208,23 +222,22 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             httpConstraint = ConstraintSecurityHandler.createConstraint(name, securityElement);
 
-            //Create a mapping for the pathSpec for the default case
+            // Create a mapping for the pathSpec for the default case
             httpConstraintMapping = new ConstraintMapping();
             httpConstraintMapping.setPathSpec(pathSpec);
             httpConstraintMapping.setConstraint(httpConstraint);
             mappings.add(httpConstraintMapping);
         }
 
-        //See Spec 13.4.1.2 p127
         List<String> methodOmissions = new ArrayList<>();
 
-        //make constraint mappings for this url for each of the HttpMethodConstraintElements
+        // make constraint mappings for this url for each of the HttpMethodConstraintElements
         java.util.Collection<HttpMethodConstraintElement> methodConstraintElements = securityElement.getHttpMethodConstraints();
         if (methodConstraintElements != null)
         {
             for (HttpMethodConstraintElement methodConstraintElement : methodConstraintElements)
             {
-                //Make a Constraint that captures the <auth-constraint> and <user-data-constraint> elements supplied for the HttpMethodConstraintElement
+                // Make a Constraint that captures the <auth-constraint> and <user-data-constraint> elements supplied for the HttpMethodConstraintElement
                 Constraint methodConstraint = ConstraintSecurityHandler.createConstraint(name, methodConstraintElement);
                 ConstraintMapping mapping = new ConstraintMapping();
                 mapping.setConstraint(methodConstraint);
@@ -232,15 +245,15 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 if (methodConstraintElement.getMethodName() != null)
                 {
                     mapping.setMethod(methodConstraintElement.getMethodName());
-                    //See spec 13.4.1.2 p127 - add an omission for every method name to the default constraint
+                    // Spec: Add an omission for every method name to the default constraint
                     methodOmissions.add(methodConstraintElement.getMethodName());
                 }
                 mappings.add(mapping);
             }
         }
-        //See spec 13.4.1.2 p127 - add an omission for every method name to the default constraint
-        //UNLESS the default constraint contains all default values. In that case, we won't add it. See Servlet Spec 3.1 pg 129
-        if (methodOmissions.size() > 0 && httpConstraintMapping != null)
+        // Spec: Add an omission for every method name to the default constraint
+        // UNLESS the default constraint contains all default values. In that case, we won't add it.
+        if (!methodOmissions.isEmpty() && httpConstraintMapping != null)
             httpConstraintMapping.setMethodOmissions(methodOmissions.toArray(new String[0]));
 
         return mappings;
@@ -259,8 +272,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set, from which the set of known roles
      * is determined.
@@ -271,8 +287,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set as array, from which the set of known roles
      * is determined.  Needed to retain API compatibility for 7.x
@@ -283,8 +302,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Process the constraints following the combining rules in Servlet 3.0 EA
-     * spec section 13.7.1 Note that much of the logic is in the Constraint class.
+     * <p>
+     * Process the constraints following the combining rules in
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta
+     * Servlet Spec 13.8.1. "Combining Constraints"</a>
+     * </p>
      *
      * @param constraintMappings The constraintMappings to set.
      * @param roles The known roles (or null to determine them from the mappings)
@@ -292,7 +314,6 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     public void setConstraintMappings(List<ConstraintMapping> constraintMappings, Set<String> roles)
     {
-
         _constraintMappings.clear();
         _constraintMappings.addAll(constraintMappings);
 
@@ -312,7 +333,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 {
                     for (String r : cmr)
                     {
-                        if (!ALL_METHODS.equals(r))
+                        if (!ANY_KNOWN_ROLE.equals(r))
                             roles.add(r);
                     }
                 }
@@ -321,7 +342,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         setRoles(roles);
 
         if (isStarted())
-            _constraintMappings.forEach(this::processConstraintMapping);
+            rebuildMappings();
     }
 
     /**
@@ -347,18 +368,29 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
 
         if (mapping.getConstraint() != null && mapping.getConstraint().getRoles() != null)
         {
-            //allow for lazy role naming: if a role is named in a security constraint, try and
-            //add it to the list of declared roles (ie as if it was declared with a security-role
+            // allow for lazy role naming: if a role is named in a security constraint, try and
+            // add it to the list of declared roles (ie as if it was declared with a security-role
             for (String role : mapping.getConstraint().getRoles())
             {
-                if ("*".equals(role) || "**".equals(role))
+                if (ANY_KNOWN_ROLE.equals(role) || ANY_ROLE.equals(role))
                     continue;
                 addKnownRole(role);
             }
         }
 
         if (isStarted())
-            processConstraintMapping(mapping);
+            rebuildMappings();
+    }
+
+    private void rebuildMappings()
+    {
+        _constraintsByPathAndMethod.reset();
+        _constraintMappings.forEach(this::processConstraintMapping);
+
+        // Jakarta Servlet Spec 13.8.4.2: "Handling Uncovered HTTP Methods"
+        // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#handling-uncovered-http-methods
+        // log paths for which there are uncovered http methods
+        checkPathsWithUncoveredHttpMethods();
     }
 
     @Override
@@ -370,11 +402,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected void doStart() throws Exception
     {
-        _constraintsByPathAndMethod.reset();
-        _constraintMappings.forEach(this::processConstraintMapping);
-
-        //Servlet Spec 3.1 pg 147 sec 13.8.4.2 log paths for which there are uncovered http methods
-        checkPathsWithUncoveredHttpMethods();
+        rebuildMappings();
 
         Context context = ContextHandler.getCurrentContext();
         if (context instanceof ServletContextHandler.ServletScopedContext servletScopedContext)
@@ -403,7 +431,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * <p>Combine constrains as per the servlet specification.
+     * <p>Combine constraints as per the servlet specification.
      * This is NOT equivalent to {@link Constraint#combine(Constraint, Constraint)}, which implements
      * a more secure combination.</p>
      * @param constraintA A constraint
@@ -413,7 +441,8 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     protected Constraint combineServletConstraints(Constraint constraintA, Constraint constraintB)
     {
         // This method is not identical to Constraint.combine.
-        // Instead, it implements the bizarre section 13.8.1 of Servlet 6.0 specification
+        // Instead, it implements the bizarre Jakarta Servlet Spec section 13.8.1: "Combining Constraints"
+        // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints
 
         if (constraintA == null)
             return constraintB == null ? Constraint.ALLOWED_ANY_TRANSPORT : constraintB;
@@ -484,36 +513,52 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             mappings = new HashMap<>();
             _constraintsByPathAndMethod.put(mapping.getPathSpec(), mappings);
         }
-        Constraint allMethodsConstraint = mappings.get(ALL_METHODS);
+        Constraint allMethodsConstraint = mappings.get(ALL_METHODS_KEY);
         if (allMethodsConstraint != null && allMethodsConstraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
             return;
 
-        if (mapping.getMethodOmissions() != null && mapping.getMethodOmissions().length > 0)
+        // Does this mapping have method omissions?
+        if (mapping.hasMethodOmissions())
         {
-            processConstraintMappingWithMethodOmissions(mapping, mappings);
-            return;
-        }
-
-        String httpMethod = mapping.getMethod();
-        if (httpMethod == null)
-            httpMethod = ALL_METHODS;
-        Constraint constraint = mappings.get(httpMethod);
-        if (constraint == null)
-            constraint = allMethodsConstraint;
-        if (constraint != null && constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
-            return;
-
-        // add in info from the constraint
-        constraint = combineServletConstraints(constraint, mapping.getConstraint());
-
-        if (constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN && httpMethod.equals(ALL_METHODS))
-        {
-            mappings.clear();
-            mappings.put(ALL_METHODS, constraint);
+            String methodOmissionKey = toMethodOmissions(mapping);
+            // Is there any existing mapping to the same omissions?
+            Constraint existingConstraint = mappings.get(methodOmissionKey);
+            if (existingConstraint != null)
+            {
+                // combine them
+                Constraint constraint = combineServletConstraints(existingConstraint, mapping.getConstraint());
+                mappings.put(methodOmissionKey, constraint);
+            }
+            else
+            {
+                // new mapping discovered, add to map, we're done.
+                mappings.put(methodOmissionKey, mapping.getConstraint());
+            }
         }
         else
         {
-            mappings.put(httpMethod, constraint);
+            // We have a normal method constraint.
+            String httpMethod = mapping.getMethod();
+            if (httpMethod == null)
+                httpMethod = ALL_METHODS_KEY;
+            Constraint constraint = mappings.get(httpMethod);
+            if (constraint == null)
+                constraint = allMethodsConstraint;
+            if (constraint != null && constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN)
+                return;
+
+            // add in info from the constraint
+            constraint = combineServletConstraints(constraint, mapping.getConstraint());
+
+            if (constraint.getAuthorization() == Constraint.Authorization.FORBIDDEN && httpMethod.equals(ALL_METHODS_KEY))
+            {
+                mappings.clear();
+                mappings.put(ALL_METHODS_KEY, constraint);
+            }
+            else
+            {
+                mappings.put(httpMethod, constraint);
+            }
         }
     }
 
@@ -529,19 +574,17 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      *
      * @param mapping the constraint mapping
      * @param mappings the mappings of roles
+     * @deprecated Not used, no replacement
      */
+    @Deprecated(since = "12.1.11", forRemoval = true)
     protected void processConstraintMappingWithMethodOmissions(ConstraintMapping mapping, Map<String, Constraint> mappings)
     {
-        String[] omissions = mapping.getMethodOmissions();
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < omissions.length; i++)
-        {
-            if (i > 0)
-                sb.append(".");
-            sb.append(omissions[i]);
-        }
-        sb.append(OMISSION_SUFFIX);
-        mappings.put(sb.toString(), mapping.getConstraint());
+        mappings.put(toMethodOmissions(mapping), mapping.getConstraint());
+    }
+
+    private String toMethodOmissions(ConstraintMapping mapping)
+    {
+        return String.join(".", mapping.getMethodOmissions()) + OMISSION_SUFFIX;
     }
 
     @Override
@@ -565,7 +608,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Servlet spec 3.1 pg. 147.
+     * Checking paths with uncovered http methods.
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#uncovered-http-protocol-methods">Jakarta Servlet 6.1, sec 13.8.4: "Uncovered HTTP Protocol Methods"</a>
      */
     @Override
     public boolean checkPathsWithUncoveredHttpMethods()
@@ -581,16 +626,16 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Servlet spec 3.1 pg. 147.
      * The container must check all the combined security constraint
      * information and log any methods that are not protected and the
-     * urls at which they are not protected
+     * URLs at which they are not protected
      *
      * @return Set of paths for which there are uncovered methods
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#uncovered-http-protocol-methods">Jakarta Servlet 6.1, sec 13.8.4: "Uncovered HTTP Protocol Methods"</a>
      */
     public Set<String> getPathsWithUncoveredHttpMethods()
     {
-        //if automatically denying uncovered methods, there are no uncovered methods
+        // if automatically denying uncovered methods, there are no uncovered methods
         if (_denyUncoveredMethods)
             return Collections.emptySet();
 
@@ -600,18 +645,18 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         {
             String path = resource.getPathSpec().getDeclaration();
             Map<String, Constraint> methodMappings = resource.getResource();
-            //Each key is either:
-            // : an exact method name
-            // : * which means that the constraint applies to every method
-            // : a name of the form <method>.<method>.<method>.omission, which means it applies to every method EXCEPT those named
-            if (methodMappings.get(ALL_METHODS) != null)
-                continue; //can't be any uncovered methods for this url path
+            // Each key is either:
+            //  - an exact method name
+            //  - `*` which means that the constraint applies to every method
+            //  - a name of the form <method>.<method>.<method>.omission, which means it applies to every method EXCEPT those named
+            if (methodMappings.get(ALL_METHODS_KEY) != null)
+                continue; // can't be any uncovered methods for this url path
 
             boolean hasOmissions = omissionsExist(methodMappings);
 
             for (String method : methodMappings.keySet())
             {
-                if (method.endsWith(OMISSION_SUFFIX))
+                if (isMethodOmission(method))
                 {
                     Set<String> omittedMethods = getOmittedMethods(method);
                     for (String m : omittedMethods)
@@ -622,9 +667,9 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 }
                 else
                 {
-                    //an exact method name
+                    // an exact method name
                     if (!hasOmissions)
-                        //an http-method does not have http-method-omission to cover the other method names
+                        // an http-method does not have http-method-omission to cover the other method names
                         uncoveredPaths.add(path);
                 }
             }
@@ -645,10 +690,17 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             return false;
         for (String m : methodMappings.keySet())
         {
-            if (m.endsWith(OMISSION_SUFFIX))
+            if (isMethodOmission(m))
                 return true;
         }
         return false;
+    }
+
+    private boolean isMethodOmission(String method)
+    {
+        if (method == null)
+            return false;
+        return method.endsWith(OMISSION_SUFFIX);
     }
 
     /**
@@ -671,7 +723,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      * Constraints can be added to the ConstraintSecurityHandler before the
      * associated context is started. These constraints should persist across
      * a stop/start. Others can be added after the associated context is starting
-     * (eg by a web.xml/web-fragment.xml, annotation or jakarta.servlet api call) -
+     * (e.g. by a {@code web.xml/web-fragment.xml}, annotation or {@code jakarta.servlet} api call) -
      * these should not be persisted across a stop/start as they will be re-added on
      * the restart.
      *

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/ConstraintTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/security/ConstraintTest.java
@@ -63,13 +63,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
@@ -82,6 +85,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConstraintTest
@@ -457,11 +461,17 @@ public class ConstraintTest
     }
     
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-1
-     * &#064;ServletSecurity
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-1</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity
+     *     public class Example1 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample131()
+    public void testSecurityElementExample13_1()
     {
         ServletSecurityElement element = new ServletSecurityElement();
         List<ConstraintMapping> mappings = ConstraintSecurityHandler.createConstraintsWithMappingsForPath("foo", "/foo/*", element);
@@ -469,11 +479,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-2
-     * &#064;ServletSecurity(@HttpConstraint(transportGuarantee = TransportGuarantee.CONFIDENTIAL))
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-2</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(transportGuarantee = TransportGuarantee.CONFIDENTIAL))
+     *     public class Example2 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample132()
+    public void testSecurityElementExample13_2()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(TransportGuarantee.CONFIDENTIAL);
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -485,14 +501,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-3
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-3</p>
      *
-     * <pre>
-     * &#064;ServletSecurity(@HttpConstraint(EmptyRoleSemantic.DENY))
-     * </pre>
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(EmptyRoleSemantic.DENY))
+     *     public class Example3 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample133()
+    public void testSecurityElementExample13_3()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(EmptyRoleSemantic.DENY);
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -505,13 +524,17 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-4
-     * <pre>
-     * &#064;ServletSecurity(&#064;HttpConstraint(rolesAllowed = "R1"))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-4</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(@HttpConstraint(rolesAllowed = "R1"))
+     *     public class Example4 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample134()
+    public void testSecurityElementExample13_4()
     {
         HttpConstraintElement httpConstraintElement = new HttpConstraintElement(TransportGuarantee.NONE, "R1");
         ServletSecurityElement element = new ServletSecurityElement(httpConstraintElement);
@@ -526,16 +549,21 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-5
-     * <pre>
-     * &#064;ServletSecurity((httpMethodConstraints = {
-     * &#064;HttpMethodConstraint(value = "GET", rolesAllowed = "R1"),
-     * &#064;HttpMethodConstraint(value = "POST", rolesAllowed = "R1",
-     * transportGuarantee = TransportGuarantee.CONFIDENTIAL)})
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-5</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity((httpMethodConstraints = {
+     *         @HttpMethodConstraint(value = "GET", rolesAllowed = "R1"),
+     *         @HttpMethodConstraint(value = "POST", rolesAllowed = "R1",
+     *                               transportGuarantee = TransportGuarantee.CONFIDENTIAL)
+     *     })
+     *     public class Example5 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample135()
+    public void testSecurityElementExample13_5()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("GET", new HttpConstraintElement(TransportGuarantee.NONE, "R1")));
@@ -555,13 +583,18 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-6
-     * <pre>
-     * &#064;ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"), httpMethodConstraints = @HttpMethodConstraint("GET"))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-6</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
+     *                      httpMethodConstraints = @HttpMethodConstraint("GET"))
+     *     public class Example6 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample136()
+    public void testSecurityElementExample13_6()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("GET"));
@@ -580,15 +613,19 @@ public class ConstraintTest
     }
 
     /**
-     * Equivalent of Servlet Spec 3.1 pg 132, sec 13.4.1.1, Example 13-7
-     * <pre>
-     * &#064;ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
-     * httpMethodConstraints = @HttpMethodConstraint(value="TRACE",
-     * emptyRoleSemantic = EmptyRoleSemantic.DENY))
-     * </pre>
+     * <p>Equivalent of Jakarta Servlet Spec, sec 13.4.1.1, Example 13-7</p>
+     *
+     * <pre>{@code
+     *     @ServletSecurity(value = @HttpConstraint(rolesAllowed = "R1"),
+     *                      httpMethodConstraints = @HttpMethodConstraint(value="TRACE",
+     *                      emptyRoleSemantic = EmptyRoleSemantic.DENY))
+     *     public class Example7 extends HttpServlet { }
+     * }</pre>
+     *
+     * @see <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#examples">Jakarta Servlet Spec 6.1, sec 13.4.1.1: Examples</a>
      */
     @Test
-    public void testSecurityElementExample137()
+    public void testSecurityElementExample13_7()
     {
         List<HttpMethodConstraintElement> methodElements = new ArrayList<>();
         methodElements.add(new HttpMethodConstraintElement("TRACE", new HttpConstraintElement(EmptyRoleSemantic.DENY)));
@@ -610,7 +647,7 @@ public class ConstraintTest
     @Test
     public void testUncoveredHttpMethodDetection() throws Exception
     {
-        //Test no methods named
+        // Test no methods named
         Constraint.Builder constraint1 = new Constraint.Builder();
         constraint1.authorization(Constraint.Authorization.ANY_USER);
         constraint1.name("** constraint");
@@ -1879,8 +1916,6 @@ public class ConstraintTest
         assertThat(response, startsWith("HTTP/1.1 403 Forbidden"));
 
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-        // assertThat(response,containsString(" 302 Found"));
-        // assertThat(response,containsString("/ctx/testLoginPage"));
         assertThat(response, containsString("Cache-Control: no-cache"));
         assertThat(response, containsString("Expires"));
         assertThat(response, containsString("URI=/ctx/testLoginPage"));
@@ -1921,8 +1956,6 @@ public class ConstraintTest
 
         // log in again as user2
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -1949,8 +1982,6 @@ public class ConstraintTest
 
         // log in again as admin
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -2083,8 +2114,6 @@ public class ConstraintTest
 
         // log in again as admin
         response = _connector.getResponse("GET /ctx/auth/info HTTP/1.0\r\n\r\n");
-//        assertThat(response,startsWith("HTTP/1.1 302 "));
-//        assertThat(response,containsString("testLoginPage"));
         session = response.substring(response.indexOf("JSESSIONID=") + 11, response.indexOf("; Path=/ctx"));
 
         response = _connector.getResponse("POST /ctx/j_security_check HTTP/1.0\r\n" +
@@ -2364,6 +2393,363 @@ public class ConstraintTest
 
         response = _connector.getResponse("OPTIONS /ctx/some/constraint/info HTTP/1.0\r\n\r\n");
         assertThat(response, startsWith("HTTP/1.1 403 "));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethod(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethod(name));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethodOmission(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(new String[]{name}));
+    }
+
+    @Test
+    public void testSetHttpMethodOmissionWithNullEntries()
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        String[] names = new String[]{"GET", null, "POST"};
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(names));
+    }
+
+    public static Stream<Arguments> jakartaSpecCombinedConstraintExampleCases()
+    {
+        return Stream.of(
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/*"
+            Arguments.of("PUT", "/foo", true, is(empty()), is(Constraint.Authorization.FORBIDDEN), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/foo", false, null, null, null),
+            Arguments.of("POST", "/foo", false, null, null, null),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/wholesale/*"
+            Arguments.of("PUT", "/acme/wholesale/foo", true, contains("SALESCLERK"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/acme/wholesale/foo", true, containsInAnyOrder("CONTRACTOR", "SALESCLERK"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("POST", "/acme/wholesale/foo", true, contains("CONTRACTOR"), is(Constraint.Authorization.SPECIFIC_ROLE), is(Constraint.Transport.SECURE)),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/retail/*"
+            Arguments.of("PUT", "/acme/retail/foo", true, is(empty()), is(Constraint.Authorization.FORBIDDEN), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("GET", "/acme/retail/foo", true, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE))),
+            Arguments.of("POST", "/acme/retail/foo", true, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(Constraint.Authorization.SPECIFIC_ROLE), is(not(Constraint.Transport.SECURE)))
+        );
+    }
+
+    /**
+     * Replication of Constraint combination from
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta Servlet Spec 13.8.1 : Combining Constraints</a>.
+     */
+    @ParameterizedTest
+    @MethodSource("jakartaSpecCombinedConstraintExampleCases")
+    public void testJakartaSpecCombinedConstraintsExamples(String httpMethod, String requestPath,
+                                                           boolean coveredByConstraint,
+                                                           org.hamcrest.Matcher<Set<String>> rolesMatcher,
+                                                           org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher,
+                                                           org.hamcrest.Matcher<Constraint.Transport> transportMatcher) throws Exception
+    {
+        List<ConstraintMapping> mappings = new ArrayList<>();
+
+        // Note: the path spec `/*` is known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>precluded methods</web-resource-name>
+            <url-pattern>/*</url-pattern>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method-omission>GET</http-method-omission>
+            <http-method-omission>POST</http-method-omission>
+          </web-resource-collection>
+          <auth-constraint/>
+        </security-constraint>
+         */
+        for (String pathSpec: List.of("/*", "/acme/wholesale/*", "/acme/retail/*"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec(pathSpec);
+            mapping.setMethodOmissions(new String[]{"GET", "POST"});
+            mapping.setConstraint(Constraint.FORBIDDEN);
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>PUT</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>SALESCLERK</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder wholesaleConstraint = new Constraint.Builder();
+        wholesaleConstraint.name("salesclerk");
+        wholesaleConstraint.roles("SALESCLERK");
+        for (String wholesaleMethod: List.of("GET", "PUT"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesaleMethod);
+            mapping.setConstraint(wholesaleConstraint.build());
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale 2</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+          </auth-constraint>
+          <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+          </user-data-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder wholesale2Constraint = new Constraint.Builder();
+        wholesale2Constraint.name("contractor");
+        wholesale2Constraint.roles("CONTRACTOR");
+        wholesale2Constraint.transport(Constraint.Transport.SECURE);
+        for (String wholesale2Method: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesale2Method);
+            mapping.setConstraint(wholesale2Constraint.build());
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>retail</web-resource-name>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+            <role-name>HOMEOWNER</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        Constraint.Builder retailConstraint = new Constraint.Builder();
+        retailConstraint.roles("CONTRACTOR", "HOMEOWNER");
+        for (String retailMethod: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/retail/*");
+            mapping.setMethod(retailMethod);
+            mapping.setConstraint(retailConstraint.build());
+            mappings.add(mapping);
+        }
+
+        Set<String> knownRoles = Set.of("SALESCLERK", "CONTRACTOR", "HOMEOWNER");
+        _security.setConstraintMappings(mappings, knownRoles);
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+        {
+            assertThat("%s %s roles".formatted(httpMethod, requestPath), constraint.getRoles(), rolesMatcher);
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+            assertThat("%s %s transport".formatted(httpMethod, requestPath), constraint.getTransport(), transportMatcher);
+        }
+    }
+
+    public static Stream<Arguments> singleForbiddenMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", null),
+            Arguments.of("GET", "PUT", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("GET", "POST", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("GET", "DELETE", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", null),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", null),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", null),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", null),
+            Arguments.of("CorpQuery", "GET", "/test/foo", is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("CorpQuery", "POST", "/test/foo", is(Constraint.Authorization.FORBIDDEN))
+        );
+    }
+
+    /**
+     * Tests forbidden http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleForbiddenMethodOmissionCases")
+    public void testSingleForbiddenMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath,
+                                     org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        boolean coveredByConstraint = !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+        _security.setConstraintMappings(List.of(forbiddenMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, requestHttpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(requestHttpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(requestHttpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    public static Stream<Arguments> singleAllowedMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", null),
+            Arguments.of("GET", "PUT", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("GET", "POST", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("GET", "DELETE", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", null),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", null),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", null),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", null),
+            Arguments.of("CorpQuery", "GET", "/test/foo", is(Constraint.Authorization.ALLOWED)),
+            Arguments.of("CorpQuery", "POST", "/test/foo", is(Constraint.Authorization.ALLOWED))
+        );
+    }
+
+    /**
+     * Tests allowed http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleAllowedMethodOmissionCases")
+    public void testSingleAllowedMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath,
+                                                          org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        boolean coveredByConstraint = !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+        _security.setConstraintMappings(List.of(allowedMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, requestHttpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(requestHttpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(requestHttpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    public static Stream<Arguments> combinedAllowedForbiddenMethodOmissionConstraintsCases()
+    {
+        return Stream.of(
+            // Neither constraint covers GET
+            Arguments.of("GET", "/test/foo", false, null),
+            // The forbidden constraint wins
+            Arguments.of("PUT", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("POST", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN)),
+            Arguments.of("DELETE", "/test/foo", true, is(Constraint.Authorization.FORBIDDEN))
+        );
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedAllowedForbiddenMethodOmissionConstraints(String httpMethod, String requestPath,
+                                                                      boolean coveredByConstraint,
+                                                                      org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+
+        // This is the reverse order from testCombinedForbiddenAllowedMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(allowedMapping, forbiddenMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedForbiddenAllowedMethodOmissionConstraints(String httpMethod, String requestPath,
+                                                                      boolean coveredByConstraint,
+                                                                      org.hamcrest.Matcher<Constraint.Authorization> authorizationMatcher) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(Constraint.FORBIDDEN);
+
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(Constraint.ALLOWED);
+
+        // This is the reverse order from testCombinedAllowedForbiddenMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(forbiddenMapping, allowedMapping));
+        _server.start();
+
+        Constraint constraint = _security.getConstraint(requestPath, httpMethod);
+        if (!coveredByConstraint)
+            assertThat("%s %s constraint not covered".formatted(httpMethod, requestPath), constraint, nullValue());
+        else
+            assertThat("%s %s authorization".formatted(httpMethod, requestPath), constraint.getAuthorization(), authorizationMatcher);
     }
 
     @Test

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintMapping.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintMapping.java
@@ -13,7 +13,12 @@
 
 package org.eclipse.jetty.ee9.security;
 
+import java.util.Arrays;
+
 import org.eclipse.jetty.ee9.nested.ServletConstraint;
+import org.eclipse.jetty.http.Syntax;
+import org.eclipse.jetty.util.StringUtil;
+import org.eclipse.jetty.util.TypeUtil;
 
 public class ConstraintMapping
 {
@@ -53,6 +58,9 @@ public class ConstraintMapping
      */
     public void setMethod(String method)
     {
+        if (method != null)
+            checkHttpMethodName(method, "Servlet Constraint HTTP Method");
+
         this._method = method;
     }
 
@@ -77,11 +85,43 @@ public class ConstraintMapping
      */
     public void setMethodOmissions(String[] omissions)
     {
+        if (omissions != null)
+        {
+            for (String omission: omissions)
+                checkHttpMethodName(omission, "Servlet Constraint HTTP Method Omission");
+        }
+
         _methodOmissions = omissions;
     }
 
     public String[] getMethodOmissions()
     {
         return _methodOmissions;
+    }
+
+    public boolean hasMethodOmissions()
+    {
+        return _methodOmissions != null && _methodOmissions.length > 0;
+    }
+
+    private void checkHttpMethodName(String methodName, String msg)
+    {
+        if (StringUtil.isBlank(methodName))
+            throw new IllegalArgumentException("Blank HTTP Method Name: " + msg);
+        if ("*".equals(methodName))
+            throw new IllegalArgumentException("Invalid HTTP Method Name '*': " + msg);
+        Syntax.requireValidRFC2616Token(methodName, msg);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "%s@%x{method=%s,omissions=%s,pathSpec=%s -> %s}".formatted(
+            TypeUtil.toShortName(getClass()),
+            hashCode(),
+            _method,
+            _methodOmissions == null ? null : Arrays.asList(_methodOmissions),
+            _pathSpec,
+            _constraint);
     }
 }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.http.pathmap.PathSpec;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.server.HttpConfiguration;
 import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
@@ -61,7 +62,15 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class); //use same as SecurityHandler
 
     private static final String OMISSION_SUFFIX = ".omission";
-    private static final String ALL_METHODS = "*";
+    /**
+     * Used as a key in various {@code Map} in this class (to avoid null keys).
+     * This cannot be used as a value in a web.xml or in the public constraint API.
+     */
+    private static final String ALL_METHODS_KEY = "*";
+
+    public static final String ANY_KNOWN_ROLE = "*";
+    public static final String ANY_ROLE = "**";
+
     private final List<ConstraintMapping> _constraintMappings = new CopyOnWriteArrayList<>();
     private final List<ConstraintMapping> _durableConstraintMappings = new CopyOnWriteArrayList<>();
     private final Set<String> _roles = new CopyOnWriteArraySet<>();
@@ -184,7 +193,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     public static List<ConstraintMapping> removeConstraintMappingsForPath(String pathSpec, List<ConstraintMapping> constraintMappings)
     {
-        if (pathSpec == null || "".equals(pathSpec.trim()) || constraintMappings == null || constraintMappings.size() == 0)
+        if (StringUtil.isBlank(pathSpec) || constraintMappings == null || constraintMappings.isEmpty())
             return Collections.emptyList();
 
         List<ConstraintMapping> mappings = new ArrayList<>();
@@ -200,7 +209,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     }
 
     /**
-     * Generate Constraints and ContraintMappings for the given url pattern and ServletSecurityElement
+     * Generate Constraints and ConstraintMappings for the given url pattern and ServletSecurityElement
      *
      * @param name the name
      * @param pathSpec the path spec
@@ -325,7 +334,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
                 {
                     for (String r : cmr)
                     {
-                        if (!ALL_METHODS.equals(r))
+                        if (!ANY_KNOWN_ROLE.equals(r))
                             roles.add(r);
                     }
                 }
@@ -334,9 +343,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         setRoles(roles);
 
         if (isStarted())
-        {
-            _constraintMappings.stream().forEach(m -> processConstraintMapping(m));
-        }
+            rebuildMappings();
     }
 
     /**
@@ -373,7 +380,18 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         }
 
         if (isStarted())
-            processConstraintMapping(mapping);
+            rebuildMappings();
+    }
+
+    private void rebuildMappings()
+    {
+        _constraintRoles.reset();
+        _constraintMappings.forEach(this::processConstraintMapping);
+
+        // Jakarta Servlet Spec 13.8.4.2: "Handling Uncovered HTTP Methods"
+        // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#handling-uncovered-http-methods
+        // log paths for which there are uncovered http methods
+        checkPathsWithUncoveredHttpMethods();
     }
 
     @Override
@@ -398,11 +416,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected void doStart() throws Exception
     {
-        _constraintRoles.reset();
-        _constraintMappings.forEach(this::processConstraintMapping);
-
-        //Servlet Spec 3.1 pg 147 sec 13.8.4.2 log paths for which there are uncovered http methods
-        checkPathsWithUncoveredHttpMethods();
+        rebuildMappings();
 
         super.doStart();
     }
@@ -431,41 +445,56 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             mappings = new HashMap<>();
             _constraintRoles.put(pathSpec, mappings);
         }
-        RoleInfo allMethodsRoleInfo = mappings.get(ALL_METHODS);
+        RoleInfo allMethodsRoleInfo = mappings.get(ALL_METHODS_KEY);
         if (allMethodsRoleInfo != null && allMethodsRoleInfo.isForbidden())
             return;
 
-        if (mapping.getMethodOmissions() != null && mapping.getMethodOmissions().length > 0)
+        // Does this mapping have method omissions?
+        if (mapping.hasMethodOmissions())
         {
-            processConstraintMappingWithMethodOmissions(mapping, mappings);
-            return;
-        }
-
-        String httpMethod = mapping.getMethod();
-        if (httpMethod == null)
-            httpMethod = ALL_METHODS;
-        RoleInfo roleInfo = mappings.get(httpMethod);
-        if (roleInfo == null)
-        {
-            roleInfo = new RoleInfo();
-            mappings.put(httpMethod, roleInfo);
-            if (allMethodsRoleInfo != null)
+            String methodOmissionKey = toMethodOmissions(mapping);
+            // Attempt to get any existing mapping to the same omissions first
+            RoleInfo ri = mappings.get(methodOmissionKey);
+            if (ri == null)
             {
-                roleInfo.combine(allMethodsRoleInfo);
+                ri = new RoleInfo();
+                ri.setForbidden(mapping.getConstraint().isForbidden());
             }
+            boolean isForbidden = ri.isForbidden();
+            configureRoleInfo(ri, mapping);
+            if (isForbidden) // maintain forbidden state if previously seen.
+                ri.setForbidden(true);
+            mappings.put(methodOmissionKey, ri);
         }
-        if (roleInfo.isForbidden())
-            return;
-
-        //add in info from the constraint
-        configureRoleInfo(roleInfo, mapping);
-
-        if (roleInfo.isForbidden())
+        else
         {
-            if (httpMethod.equals(ALL_METHODS))
+            // We have a normal method constraint.
+            String httpMethod = mapping.getMethod();
+            if (httpMethod == null)
+                httpMethod = ALL_METHODS_KEY;
+            RoleInfo roleInfo = mappings.get(httpMethod);
+            if (roleInfo == null)
             {
-                mappings.clear();
-                mappings.put(ALL_METHODS, roleInfo);
+                roleInfo = new RoleInfo();
+                mappings.put(httpMethod, roleInfo);
+                if (allMethodsRoleInfo != null)
+                {
+                    roleInfo.combine(allMethodsRoleInfo);
+                }
+            }
+            if (roleInfo.isForbidden())
+                return;
+
+            //add in info from the constraint
+            configureRoleInfo(roleInfo, mapping);
+
+            if (roleInfo.isForbidden())
+            {
+                if (httpMethod.equals(ALL_METHODS_KEY))
+                {
+                    mappings.clear();
+                    mappings.put(ALL_METHODS_KEY, roleInfo);
+                }
             }
         }
     }
@@ -492,18 +521,14 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      */
     protected void processConstraintMappingWithMethodOmissions(ConstraintMapping mapping, Map<String, RoleInfo> mappings)
     {
-        String[] omissions = mapping.getMethodOmissions();
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < omissions.length; i++)
-        {
-            if (i > 0)
-                sb.append(".");
-            sb.append(omissions[i]);
-        }
-        sb.append(OMISSION_SUFFIX);
         RoleInfo ri = new RoleInfo();
-        mappings.put(sb.toString(), ri);
+        mappings.put(toMethodOmissions(mapping), ri);
         configureRoleInfo(ri, mapping);
+    }
+
+    private String toMethodOmissions(ConstraintMapping mapping)
+    {
+        return String.join(".", mapping.getMethodOmissions()) + OMISSION_SUFFIX;
     }
 
     /**
@@ -577,6 +602,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     @Override
     protected RoleInfo prepareConstraintInfo(String pathInContext, Request request)
     {
+        return prepareConstraintInfo(pathInContext, request.getMethod());
+    }
+
+    protected RoleInfo prepareConstraintInfo(String pathInContext, String httpMethod)
+    {
         MatchedResource<Map<String, RoleInfo>> resource = _constraintRoles.getMatched(pathInContext);
         if (resource == null)
             return null;
@@ -585,7 +615,6 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         if (mappings == null)
             return null;
 
-        String httpMethod = request.getMethod();
         RoleInfo roleInfo = mappings.get(httpMethod);
         if (roleInfo == null)
         {
@@ -593,7 +622,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             List<RoleInfo> applicableConstraints = new ArrayList<>();
 
             //Get info for constraint that matches all methods if it exists
-            RoleInfo all = mappings.get(ALL_METHODS);
+            RoleInfo all = mappings.get(ALL_METHODS_KEY);
             if (all != null)
                 applicableConstraints.add(all);
 
@@ -601,11 +630,11 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             //(ie matches because target method is not omitted, hence considered covered by the constraint)
             for (Entry<String, RoleInfo> entry : mappings.entrySet())
             {
-                if (entry.getKey() != null && entry.getKey().endsWith(OMISSION_SUFFIX) && !entry.getKey().contains(httpMethod))
+                if (isMethodOmission(entry.getKey()) && !getOmittedMethods(entry.getKey()).contains(httpMethod))
                     applicableConstraints.add(entry.getValue());
             }
 
-            if (applicableConstraints.size() == 0 && isDenyUncoveredHttpMethods())
+            if (applicableConstraints.isEmpty() && isDenyUncoveredHttpMethods())
             {
                 roleInfo = new RoleInfo();
                 roleInfo.setForbidden(true);
@@ -782,14 +811,14 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             // : an exact method name
             // : * which means that the constraint applies to every method
             // : a name of the form <method>.<method>.<method>.omission, which means it applies to every method EXCEPT those named
-            if (methodMappings.get(ALL_METHODS) != null)
+            if (methodMappings.get(ALL_METHODS_KEY) != null)
                 continue; //can't be any uncovered methods for this url path
 
             boolean hasOmissions = omissionsExist(path, methodMappings);
 
             for (String method : methodMappings.keySet())
             {
-                if (method.endsWith(OMISSION_SUFFIX))
+                if (isMethodOmission(method))
                 {
                     Set<String> omittedMethods = getOmittedMethods(method);
                     for (String m : omittedMethods)
@@ -814,7 +843,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
      * Check if any http method omissions exist in the list of method
      * to auth info mappings.
      *
-     * @param path the path
+     * @param path the path (not used anymore)
      * @param methodMappings the method mappings
      * @return true if omission exist
      */
@@ -822,13 +851,19 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
     {
         if (methodMappings == null)
             return false;
-        boolean hasOmissions = false;
         for (String m : methodMappings.keySet())
         {
-            if (m.endsWith(OMISSION_SUFFIX))
-                hasOmissions = true;
+            if (isMethodOmission(m))
+                return true;
         }
-        return hasOmissions;
+        return false;
+    }
+
+    private boolean isMethodOmission(String method)
+    {
+        if (method == null)
+            return false;
+        return method.endsWith(OMISSION_SUFFIX);
     }
 
     /**
@@ -844,12 +879,7 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
             return Collections.emptySet();
 
         String[] strings = omission.split("\\.");
-        Set<String> methods = new HashSet<>();
-        for (int i = 0; i < strings.length - 1; i++)
-        {
-            methods.add(strings[i]);
-        }
-        return methods;
+        return new HashSet<>(Arrays.asList(strings).subList(0, strings.length - 1));
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/RoleInfo.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/RoleInfo.java
@@ -149,12 +149,12 @@ public class RoleInfo
     @Override
     public String toString()
     {
-        return String.format("RoleInfo@%x{%s%s%s%s,%s}",
+        return String.format("RoleInfo@%x{f=%b,c=%b,aa=%b,ar=%b,udc=%s}",
             hashCode(),
-            (_forbidden ? "Forbidden," : ""),
-            (_checked ? "Checked," : ""),
-            (_isAnyAuth ? "AnyAuth," : ""),
-            (_isAnyRole ? "*" : _roles),
+            _forbidden,
+            _checked,
+            _isAnyAuth,
+            _isAnyRole,
             _userDataConstraint);
     }
 }

--- a/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/ConstraintTest.java
+++ b/jetty-ee9/jetty-ee9-security/src/test/java/org/eclipse/jetty/ee9/security/ConstraintTest.java
@@ -67,13 +67,16 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -83,6 +86,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class ConstraintTest
@@ -2366,6 +2370,383 @@ public class ConstraintTest
 
         response = _connector.getResponse("OPTIONS /ctx/some/constraint/info HTTP/1.0\r\n\r\n");
         assertThat(response, startsWith("HTTP/1.1 403 "));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethod(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethod(name));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "*",
+        "  ",
+        "\t",
+        "bogus name"
+    })
+    public void testSetInvalidHttpMethodOmission(String name)
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(new String[]{name}));
+    }
+
+    @Test
+    public void testSetHttpMethodOmissionWithNullEntries()
+    {
+        ConstraintMapping mapping = new ConstraintMapping();
+        String[] names = new String[]{"GET", null, "POST"};
+        assertThrows(IllegalArgumentException.class, () -> mapping.setMethodOmissions(names));
+    }
+
+    public static Stream<Arguments> servletSpecCombinedConstraintExampleCases()
+    {
+        return Stream.of(
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/*"
+            Arguments.of("PUT", "/foo", true, true, is(empty()), is(not(UserDataConstraint.Confidential))),
+            Arguments.of("GET", "/foo", false, false, null, null),
+            Arguments.of("POST", "/foo", false, false, null, null),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/wholesale/*"
+            Arguments.of("PUT", "/acme/wholesale/foo", true, false, contains("SALESCLERK"), is(not(UserDataConstraint.Confidential))),
+            Arguments.of("GET", "/acme/wholesale/foo", true, false, containsInAnyOrder("CONTRACTOR", "SALESCLERK"), is(not(UserDataConstraint.Confidential))),
+            Arguments.of("POST", "/acme/wholesale/foo", true, false, contains("CONTRACTOR"), is(UserDataConstraint.Confidential)),
+            // Test the Table 13-4 "Security Constraint Table" url-pattern of "/acme/retail/*"
+            Arguments.of("PUT", "/acme/retail/foo", true, true, is(empty()), is(not(UserDataConstraint.Confidential))),
+            Arguments.of("GET", "/acme/retail/foo", true, false, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(not(UserDataConstraint.Confidential))),
+            Arguments.of("POST", "/acme/retail/foo", true, false, containsInAnyOrder("CONTRACTOR", "HOMEOWNER"), is(not(UserDataConstraint.Confidential)))
+        );
+    }
+
+    /**
+     * Replication of Constraint combination from
+     * <a href="https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#combining-constraints">Jakarta Servlet Spec 13.8.1 : Combining Constraints</a>.
+     */
+    @ParameterizedTest
+    @MethodSource("servletSpecCombinedConstraintExampleCases")
+    public void testServletSpecCombinedConstraintsExamples(String httpMethod, String requestPath,
+                                                           boolean expectedIsChecked,
+                                                           boolean expectedForbidden,
+                                                           org.hamcrest.Matcher<Set<String>> rolesMatcher,
+                                                           org.hamcrest.Matcher<UserDataConstraint> dataConstraintMatcher) throws Exception
+    {
+        List<ConstraintMapping> mappings = new ArrayList<>();
+
+        // Note: the path spec `/*` is known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>precluded methods</web-resource-name>
+            <url-pattern>/*</url-pattern>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method-omission>GET</http-method-omission>
+            <http-method-omission>POST</http-method-omission>
+          </web-resource-collection>
+          <auth-constraint/>
+        </security-constraint>
+         */
+        ServletConstraint forbidConstraint = new ServletConstraint();
+        forbidConstraint.setAuthenticate(true);
+        forbidConstraint.setName("forbidden");
+        for (String pathSpec: List.of("/*", "/acme/wholesale/*", "/acme/retail/*"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec(pathSpec);
+            mapping.setMethodOmissions(new String[]{"GET", "POST"});
+            mapping.setConstraint(forbidConstraint);
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>PUT</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>SALESCLERK</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        ServletConstraint wholesaleConstraint = new ServletConstraint();
+        wholesaleConstraint.setAuthenticate(true);
+        wholesaleConstraint.setRoles(new String[]{"SALESCLERK"});
+        for (String wholesaleMethod: List.of("GET", "PUT"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesaleMethod);
+            mapping.setConstraint(wholesaleConstraint);
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>wholesale 2</web-resource-name>
+            <url-pattern>/acme/wholesale/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+          </auth-constraint>
+          <user-data-constraint>
+            <transport-guarantee>CONFIDENTIAL</transport-guarantee>
+          </user-data-constraint>
+        </security-constraint>
+         */
+        ServletConstraint wholesale2Constraint = new ServletConstraint();
+        wholesale2Constraint.setAuthenticate(true);
+        wholesale2Constraint.setRoles(new String[]{"CONTRACTOR"});
+        wholesale2Constraint.setDataConstraint(ServletConstraint.DC_CONFIDENTIAL);
+        for (String wholesale2Method: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/wholesale/*");
+            mapping.setMethod(wholesale2Method);
+            mapping.setConstraint(wholesale2Constraint);
+            mappings.add(mapping);
+        }
+
+        /*
+        <security-constraint>
+          <web-resource-collection>
+            <web-resource-name>retail</web-resource-name>
+            <url-pattern>/acme/retail/*</url-pattern>
+            <http-method>GET</http-method>
+            <http-method>POST</http-method>
+          </web-resource-collection>
+
+          <auth-constraint>
+            <role-name>CONTRACTOR</role-name>
+            <role-name>HOMEOWNER</role-name>
+          </auth-constraint>
+        </security-constraint>
+         */
+        ServletConstraint retailConstraint = new ServletConstraint();
+        retailConstraint.setAuthenticate(true);
+        retailConstraint.setRoles(new String[]{"CONTRACTOR", "HOMEOWNER"});
+        for (String retailMethod: List.of("GET", "POST"))
+        {
+            ConstraintMapping mapping = new ConstraintMapping();
+            mapping.setPathSpec("/acme/retail/*");
+            mapping.setMethod(retailMethod);
+            mapping.setConstraint(retailConstraint);
+            mappings.add(mapping);
+        }
+
+        Set<String> knownRoles = Set.of("SALESCLERK", "CONTRACTOR", "HOMEOWNER");
+        _security.setConstraintMappings(mappings, knownRoles);
+        _server.start();
+
+        RoleInfo roleInfo = _security.prepareConstraintInfo(requestPath, httpMethod);
+        assertThat("%s %s roleInfo isChecked".formatted(httpMethod, requestPath), roleInfo.isChecked(), is(expectedIsChecked));
+        if (roleInfo.isChecked())
+        {
+            assertThat("%s %s forbidden".formatted(httpMethod, requestPath), roleInfo.isForbidden(), is(expectedForbidden));
+            assertThat("%s %s roles".formatted(httpMethod, requestPath), roleInfo.getRoles(), rolesMatcher);
+            assertThat("%s %s user data constraint".formatted(httpMethod, requestPath), roleInfo.getUserDataConstraint(), dataConstraintMatcher);
+        }
+    }
+
+    public static Stream<Arguments> singleForbiddenMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", false),
+            Arguments.of("GET", "PUT", "/test/foo", true),
+            Arguments.of("GET", "POST", "/test/foo", true),
+            Arguments.of("GET", "DELETE", "/test/foo", true),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", false),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", true),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", true),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", true),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", true),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", false),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", true),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", true),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", false),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", false),
+            Arguments.of("CorpQuery", "GET", "/test/foo", true),
+            Arguments.of("CorpQuery", "POST", "/test/foo", true)
+        );
+    }
+
+    /**
+     * Tests forbidden http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleForbiddenMethodOmissionCases")
+    public void testSingleForbiddenMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath,
+                                                            boolean expectedForbidden) throws Exception
+    {
+        ServletConstraint forbidConstraint = new ServletConstraint();
+        forbidConstraint.setAuthenticate(true);
+        forbidConstraint.setName("forbid");
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        forbiddenMapping.setConstraint(forbidConstraint);
+        _security.setConstraintMappings(List.of(forbiddenMapping));
+        _server.start();
+
+        RoleInfo roleInfo = _security.prepareConstraintInfo(requestPath, requestHttpMethod);
+        boolean constraintIsChecked = expectedForbidden && !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+        assertThat("%s %s roleInfo isChecked".formatted(requestHttpMethod, requestPath), roleInfo.isChecked(), is(constraintIsChecked));
+        if (roleInfo.isChecked())
+        {
+            assertThat("%s %s forbidden".formatted(requestHttpMethod, requestPath), roleInfo.isForbidden(), is(expectedForbidden));
+        }
+    }
+
+    public static Stream<Arguments> singleAllowedMethodOmissionCases()
+    {
+        return Stream.of(
+            // Try some RFC9110 standardized method declarations
+            Arguments.of("GET", "GET", "/test/foo", false),
+            Arguments.of("GET", "PUT", "/test/foo", true),
+            Arguments.of("GET", "POST", "/test/foo", true),
+            Arguments.of("GET", "DELETE", "/test/foo", true),
+            // Try some WebDav methods
+            Arguments.of("PATCH", "PATCH", "/test/foo", false),
+            Arguments.of("PATCH", "PROPPATCH", "/test/foo", true),
+            Arguments.of("PATCH", "ORDERPATCH", "/test/foo", true),
+            Arguments.of("PATCH", "PROPFIND", "/test/foo", true),
+            Arguments.of("PATCH", "MKCOL", "/test/foo", true),
+            Arguments.of("MKCOL", "MKCOL", "/test/foo", false),
+            Arguments.of("PROPPATCH", "PATCH", "/test/foo", true),
+            Arguments.of("PROPPATCH", "ORDERPATCH", "/test/foo", true),
+            Arguments.of("PROPFIND", "PROPFIND", "/test/foo", false),
+            // Try some non-standard method declarations
+            Arguments.of("CorpQuery", "CorpQuery", "/test/foo", false),
+            Arguments.of("CorpQuery", "GET", "/test/foo", true),
+            Arguments.of("CorpQuery", "POST", "/test/foo", true)
+        );
+    }
+
+    /**
+     * Tests allowed http-method-omission
+     */
+    @ParameterizedTest
+    @MethodSource("singleAllowedMethodOmissionCases")
+    public void testSingleAllowedMethodOmissionConstraint(String httpMethodOmission, String requestHttpMethod, String requestPath, boolean expectAllowed) throws Exception
+    {
+        ServletConstraint allowConstraint = new ServletConstraint();
+        allowConstraint.setAuthenticate(false);
+        allowConstraint.setName("allowed");
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{httpMethodOmission});
+        allowedMapping.setConstraint(allowConstraint);
+        _security.setConstraintMappings(List.of(allowedMapping));
+        _server.start();
+
+        RoleInfo roleInfo = _security.prepareConstraintInfo(requestPath, requestHttpMethod);
+        boolean constraintIsChecked = !expectAllowed && !httpMethodOmission.equalsIgnoreCase(requestHttpMethod);
+        assertThat("%s %s roleInfo isChecked".formatted(requestHttpMethod, requestPath), roleInfo.isChecked(), is(constraintIsChecked));
+        if (roleInfo.isChecked())
+        {
+            assertThat("%s %s allowed".formatted(requestHttpMethod, requestPath), roleInfo.isForbidden(), is(not(expectAllowed)));
+        }
+    }
+
+    public static Stream<Arguments> combinedAllowedForbiddenMethodOmissionConstraintsCases()
+    {
+        return Stream.of(
+            // Neither constraint covers GET
+            Arguments.of("GET", "/test/foo", false),
+            // The forbidden constraint wins
+            Arguments.of("PUT", "/test/foo", true),
+            Arguments.of("POST", "/test/foo", true),
+            Arguments.of("DELETE", "/test/foo", true)
+        );
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedAllowedForbiddenMethodOmissionConstraints(String httpMethod, String requestPath, boolean expectedForbidden) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ServletConstraint forbidConstraint = new ServletConstraint();
+        forbidConstraint.setAuthenticate(true);
+        forbidConstraint.setName("forbidden");
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(forbidConstraint);
+
+        ServletConstraint allowConstraint = new ServletConstraint();
+        allowConstraint.setAuthenticate(false);
+        allowConstraint.setName("allowed");
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(allowConstraint);
+
+        // This is the reverse order from testCombinedForbiddenAllowedMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(allowedMapping, forbiddenMapping));
+        _server.start();
+
+        RoleInfo roleInfo = _security.prepareConstraintInfo(requestPath, httpMethod);
+        boolean constraintIsChecked = expectedForbidden && !"GET".equalsIgnoreCase(httpMethod);
+        assertThat("%s %s roleInfo isChecked".formatted(httpMethod, requestPath), roleInfo.isChecked(), is(constraintIsChecked));
+        if (roleInfo.isChecked())
+        {
+            assertThat("%s %s forbidden".formatted(httpMethod, requestPath), roleInfo.isForbidden(), is(expectedForbidden));
+        }
+    }
+
+    /**
+     * Test of two constraints that have the same path, same http-method-omission, no roles, but different auth-constraint settings.
+     */
+    @ParameterizedTest
+    @MethodSource("combinedAllowedForbiddenMethodOmissionConstraintsCases")
+    public void testCombinedForbiddenAllowedMethodOmissionConstraints(String httpMethod, String requestPath, boolean expectedForbidden) throws Exception
+    {
+        // Note: these two constraints are known to produce the "has uncovered HTTP methods" warning, do not try to fix by changing these constraints.
+        ServletConstraint forbidConstraint = new ServletConstraint();
+        forbidConstraint.setAuthenticate(true);
+        forbidConstraint.setName("forbidden");
+        ConstraintMapping forbiddenMapping = new ConstraintMapping();
+        forbiddenMapping.setPathSpec("/test/*");
+        forbiddenMapping.setMethodOmissions(new String[]{"GET"});
+        forbiddenMapping.setConstraint(forbidConstraint);
+
+        ServletConstraint allowConstraint = new ServletConstraint();
+        allowConstraint.setAuthenticate(false);
+        allowConstraint.setName("allowed");
+        ConstraintMapping allowedMapping = new ConstraintMapping();
+        allowedMapping.setPathSpec("/test/*");
+        allowedMapping.setMethodOmissions(new String[]{"GET"});
+        allowedMapping.setConstraint(allowConstraint);
+
+        // This is the reverse order from testCombinedAllowedForbiddenMethodOmissionConstraints
+        _security.setConstraintMappings(List.of(forbiddenMapping, allowedMapping));
+        _server.start();
+
+        RoleInfo roleInfo = _security.prepareConstraintInfo(requestPath, httpMethod);
+        boolean constraintIsChecked = expectedForbidden && !"GET".equalsIgnoreCase(httpMethod);
+        assertThat("%s %s roleInfo isChecked".formatted(httpMethod, requestPath), roleInfo.isChecked(), is(constraintIsChecked));
+        if (roleInfo.isChecked())
+        {
+            assertThat("%s %s forbidden".formatted(httpMethod, requestPath), roleInfo.isForbidden(), is(expectedForbidden));
+        }
     }
 
     @Test


### PR DESCRIPTION
## Updates to `ConstraintTest.java`

* Adding new tests for http-method
  and http-method-omission behaviors
  on one constraint or combining
  multiple constraints.
* Added examples from Jakarta
  Servlet Spec document.
* Updated spec references in javadoc
* Added tests for IllegalArgumentException from http-method and http-method-omission.
* Added test for null entry behavior in http-method-omission

## Updates to `ConstraintMapping.java`

* Added http-method and http-method-omission argument checks
* Added hasMethodOmissions() method
* Improved toString

## Changes to `ConstraintSecurityHandler.java`

* Changed ALL_METHODS to ALL_METHODS_KEY and only use for Map keys
* Introduced isMethodOmission(String) and used it everywhere
* Linked to modern Jakarta Servlet spec locations in javadoc (updated from Servlet 3.1 refereneces and page numbers)
* Used ALL_KNOWN_ROLE appropriately (not the badly used ALL_METHODS constant)
* Introduced rebuildMappings() to properly rebuild the internal mappings under the various scenarios of constraint additions.
* Use ANY_KNOWN_ROLE and ANY_ROLE better.
* Improve processConstraintMapping() flow to follow Spec (a constraint either has http-method OR http-method-constraint, not both) as old code made it difficult to understand how the flow worked (even though it worked properly).
* Inlined processConstraintMappingWithMethodOmissions to allow for comparision of previous http-method-omission mappings easier.
* Many small javadoc cleanups
* Many small code cleanups

Closes: #15469 