### PR TITLE
Issue #13569 - connector.shutdown() gracefully closes HTTP/2 sessions

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
@@ -23,6 +23,7 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.SessionContainer;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
@@ -35,6 +36,7 @@ import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -49,6 +51,63 @@ public class GracefulShutdownTest extends AbstractTest
         // Don't let the default shutdown idleTimeout
         // of just 1000 ms interfere with the test.
         connector.setShutdownIdleTimeout(15000);
+    }
+
+    // Issue #13569: connector.shutdown() (as opposed to Graceful.shutdown(connector)) must also
+    // gracefully close live HTTP/2 sessions by sending a GOAWAY, so that new streams are refused
+    // and the shutdown future completes as soon as active streams finish (not at the idle timeout).
+    @Test
+    public void testConnectorShutdownSendsGoAwayOnHTTP2() throws Exception
+    {
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY);
+                stream.headers(new HeadersFrame(stream.getId(), response, null, true), Callback.NOOP);
+                return null;
+            }
+        });
+
+        CountDownLatch clientRequestLatch = new CountDownLatch(1);
+        CountDownLatch clientGoAwayLatch = new CountDownLatch(1);
+        Session clientSession = newClientSession(new Session.Listener()
+        {
+            @Override
+            public void onGoAway(Session session, GoAwayFrame frame)
+            {
+                clientGoAwayLatch.countDown();
+            }
+        });
+        MetaData.Request request = newRequest(HttpMethod.GET.asString(), HttpFields.EMPTY);
+        clientSession.newStream(new HeadersFrame(request, null, true), new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                MetaData.Response response = (MetaData.Response)frame.getMetaData();
+                if (frame.isEndStream() && response.getStatus() == HttpStatus.OK_200)
+                    clientRequestLatch.countDown();
+            }
+        });
+        assertTrue(clientRequestLatch.await(5, TimeUnit.SECONDS));
+
+        // Wait until the server-side session is registered in the connector's SessionContainer before
+        // shutting down. The client receiving the response does not guarantee the server has finished
+        // SessionContainer.onOpened(); shutting down before that registration would find an empty
+        // container and send no GOAWAY (a setup race, not a fix regression).
+        SessionContainer sessionContainer = connector.getContainedBeans(SessionContainer.class).iterator().next();
+        await().atMost(5, TimeUnit.SECONDS).until(() -> sessionContainer.getSize() > 0);
+
+        // The reporter's path: connector.shutdown() directly (NOT Graceful.shutdown(connector)).
+        CompletableFuture<Void> completable = connector.shutdown();
+
+        // The live HTTP/2 session must receive a GOAWAY promptly (currently FAILS: connector.shutdown()
+        // only reduces idle timeouts and does not propagate graceful close to live connections).
+        assertTrue(clientGoAwayLatch.await(5, TimeUnit.SECONDS), "client did not receive GOAWAY after connector.shutdown()");
+        // And shutdown must complete quickly (not wait for the 15s shutdown idle timeout).
+        assertNull(completable.get(5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -46,6 +46,7 @@ import org.eclipse.jetty.util.annotation.ManagedAttribute;
 import org.eclipse.jetty.util.annotation.ManagedObject;
 import org.eclipse.jetty.util.component.ContainerLifeCycle;
 import org.eclipse.jetty.util.component.Dumpable;
+import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.ScheduledExecutorScheduler;
@@ -354,6 +355,13 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
         // Signal for the acceptors to stop
         CompletableFuture<Void> done = shutdown.shutdown();
         interruptAcceptors();
+
+        // Gracefully shut down the contained Graceful beans (e.g. the HTTP/2 SessionContainer) so live
+        // connections are closed at the protocol level (a GOAWAY for HTTP/2). Only contained gracefuls,
+        // as the connector is itself Graceful. Their futures are not awaited: completion below stays
+        // gated on acceptors and endpoints.
+        for (Graceful graceful : getContainedBeans(Graceful.class))
+            graceful.shutdown();
 
         // Reduce the idle timeout of existing connections
         if (getShutdownIdleTimeout() >= 0)


### PR DESCRIPTION
Closes #13569.

`Connector.shutdown()` (the `Graceful` contract) promises the component "should not accept any new load" and returns a future completed once existing load is done. For HTTP/2 that was not honored: `connector.shutdown()` only stopped the acceptors and reduced idle timeouts, so a live HTTP/2 session kept accepting new streams until the shutdown idle timeout.

This makes `AbstractConnector.shutdown()` also shut down its contained `Graceful` beans — notably the HTTP/2 `SessionContainer` — so a live session receives a GOAWAY and refuses new streams. Only contained gracefuls are shut down, since the connector is itself `Graceful`; their futures are not awaited, so `shutdown()` completion stays gated on acceptors and endpoints, preserving HTTP/1.1 and server-stop behavior.

Added `GracefulShutdownTest.testConnectorShutdownSendsGoAwayOnHTTP2`.

Found while working on #15368 / #15435; this is the server-side counterpart. @sbordet this is the fix I offered on the issue — opened as a PR for convenience, no pressure, happy to adjust the approach or hand it off.
