### PR TITLE
Issue #13602 - complete pending shutdown() future on connector stop

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
@@ -18,6 +18,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
@@ -49,6 +50,65 @@ public class GracefulShutdownTest extends AbstractTest
         // Don't let the default shutdown idleTimeout
         // of just 1000 ms interfere with the test.
         connector.setShutdownIdleTimeout(15000);
+    }
+
+    // Issue #13602: connector.shutdown() then connector.stop() while an HTTP/2 client is connected must
+    // still complete the shutdown future rather than leave it uncompleted.
+    @Test
+    public void testConnectorShutdownThenStopCompletesFutureOnHTTP2() throws Exception
+    {
+        start(new org.eclipse.jetty.server.Handler.Abstract()
+        {
+            @Override
+            public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                response.setStatus(HttpStatus.OK_200);
+                callback.succeeded();
+                return true;
+            }
+        });
+        connector.setShutdownIdleTimeout(15000);
+
+        ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+            .method(HttpMethod.GET)
+            .send();
+        assertTrue(response.getStatus() == HttpStatus.OK_200 || response.getStatus() == HttpStatus.NOT_FOUND_404);
+
+        CompletableFuture<Void> shutdownFuture = connector.shutdown();
+        Thread.sleep(1000);
+        connector.stop();
+
+        // Bounded so a never-completing future fails the test rather than blocking forever.
+        assertNull(shutdownFuture.get(10, TimeUnit.SECONDS));
+    }
+
+    // Issue #13602 with a stream still active during shutdown: connector.stop() must still complete the
+    // shutdown future even when the connection cannot be closed before stop().
+    @Test
+    public void testShutdownThenStopWithActiveStreamStillCompletes() throws Exception
+    {
+        CountDownLatch serverGotRequest = new CountDownLatch(1);
+        start(new org.eclipse.jetty.server.Handler.Abstract()
+        {
+            @Override
+            public boolean handle(org.eclipse.jetty.server.Request request, org.eclipse.jetty.server.Response response, Callback callback)
+            {
+                // Never complete the callback, keeping the stream active across the shutdown.
+                serverGotRequest.countDown();
+                return true;
+            }
+        });
+        connector.setShutdownIdleTimeout(15000);
+
+        httpClient.newRequest("localhost", connector.getLocalPort()).method(HttpMethod.GET).send(result -> {});
+        assertTrue(serverGotRequest.await(5, TimeUnit.SECONDS));
+
+        CompletableFuture<Void> shutdownFuture = connector.shutdown();
+        Thread.sleep(1000);
+        connector.stop();
+
+        // Bounded so a never-completing future fails the test rather than blocking forever.
+        assertNull(shutdownFuture.get(10, TimeUnit.SECONDS));
     }
 
     @Test

--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/AbstractConnector.java
@@ -288,6 +288,10 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
             @Override
             public boolean isShutdownDone()
             {
+                // A connector that is no longer running has no remaining load to wait for.
+                if (!isRunning())
+                    return true;
+
                 if (!_endpoints.isEmpty())
                     return false;
 
@@ -385,6 +389,10 @@ public abstract class AbstractConnector extends ContainerLifeCycle implements Co
         for (Acceptor a : getBeans(Acceptor.class))
             removeBean(a);
 
+        // Complete any pending shutdown() future now that the connector is stopped, before clearing it.
+        Shutdown shutdown = _shutdown;
+        if (shutdown != null)
+            shutdown.check();
         _shutdown = null;
 
         LOG.info("Stopped {}", this);


### PR DESCRIPTION
Closes #13602.

The future returned by `Connector.shutdown()` was never completed if `Connector.stop()` was called afterwards while an HTTP/2 client was connected. `doStop()` cleared `_shutdown` before the asynchronous HTTP/2 endpoint disconnect fired `onEndPointClosed()`, so the final `Shutdown.check()` was skipped and the future stayed pending. (HTTP/1.1 disconnects synchronously enough to avoid the window, which matches the reporter's observation that swapping to HTTP/1.1 returns the future as expected.)

Fix: `isShutdownDone()` returns true once the connector is no longer running (a stopped connector has no remaining load), and `doStop()` checks the pending shutdown before clearing `_shutdown`.

Added `GracefulShutdownTest` cases for `shutdown()`-then-`stop()`, including with a stream still active during shutdown (which a graceful-close-timing fix alone would not cover).

Same graceful-shutdown area as #13569 / #15368, but independent of them (verified this fix resolves #13602 on its own).
