### PR TITLE
Improve testing of @ServletServlet annotation

### DIFF
--- a/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ServletSecurityAnnotationHandler.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/main/java/org/eclipse/jetty/ee10/annotations/ServletSecurityAnnotationHandler.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.ee10.annotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletSecurityElement;
 import jakarta.servlet.annotation.ServletSecurity;
@@ -25,6 +27,7 @@ import org.eclipse.jetty.ee10.servlet.security.ConstraintAware;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee10.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee10.webapp.WebAppContext;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,28 +68,31 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
         if (servletSecurity == null)
             return;
 
-        //If there are already constraints defined (ie from web.xml) that match any
-        //of the url patterns defined for this servlet, then skip the security annotation.
-
         List<ServletMapping> servletMappings = getServletMappings(clazz.getCanonicalName());
-        List<ConstraintMapping> constraintMappings = ((ConstraintAware)_context.getSecurityHandler()).getConstraintMappings();
 
-        if (constraintsExist(servletMappings, constraintMappings))
-        {
-            LOG.warn("Constraints already defined for {}, skipping ServletSecurity annotation", clazz.getName());
-            return;
-        }
+        Set<String> existingConstraintMappingPathSpecs = securityHandler.getConstraintMappings()
+            .stream()
+            .map(ConstraintMapping::getPathSpec)
+            .filter(StringUtil::isNotBlank)
+            .collect(Collectors.toSet());
 
-        //Make a fresh list
-        constraintMappings = new ArrayList<>();
+        List<ConstraintMapping> constraintMappings = new ArrayList<>();
 
         ServletSecurityElement securityElement = new ServletSecurityElement(servletSecurity);
         for (ServletMapping sm : servletMappings)
         {
-            for (String url : sm.getPathSpecs())
+            for (String pathSpec : sm.getPathSpecs())
             {
-                _context.getMetaData().setOrigin("constraint.url." + url, servletSecurity, clazz);
-                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), url, securityElement));
+                // Per Jakarta Servlet Spec 13.4.1: @ServletSecurity
+                // The security-constraint elements defined in web.xml are authoritative for all exact match url-patterns.
+                // https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0#servletsecurity-annotation
+                if (existingConstraintMappingPathSpecs.contains(pathSpec))
+                {
+                    LOG.warn("Constraint Mapping already defined for {} on path-spec {}, skipping ServletSecurity annotation", clazz.getName(), pathSpec);
+                    continue; // skip
+                }
+                _context.getMetaData().setOrigin("constraint.url." + pathSpec, servletSecurity, clazz);
+                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), pathSpec, securityElement));
             }
         }
 
@@ -124,7 +130,9 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
      * @param servletMappings the servlet mappings
      * @param constraintMappings the constraint mappings
      * @return true if constraint exists
+     * @deprecated not used, no replacement
      */
+    @Deprecated(since = "12.1.12", forRemoval = true)
     protected boolean constraintsExist(List<ServletMapping> servletMappings, List<ConstraintMapping> constraintMappings)
     {
         boolean exists = false;

--- a/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestSecurityAnnotationConversions.java
+++ b/jetty-ee10/jetty-ee10-annotations/src/test/java/org/eclipse/jetty/ee10/annotations/TestSecurityAnnotationConversions.java
@@ -271,6 +271,51 @@ public class TestSecurityAnnotationConversions
         compareResults(expectedMappings, ((ConstraintAware)wac.getSecurityHandler()).getConstraintMappings());
     }
 
+    @ServletSecurity(@HttpConstraint(value = EmptyRoleSemantic.DENY))
+    public static class EmptyDenyServlet extends HttpServlet
+    {
+    }
+
+    @Test
+    public void testWebXmlPathSpecAuthoritative()
+    {
+        // A ServletSecurity annotation that has HttpConstraint of EmptyRoleSemantic.DENY
+        WebAppContext wac = makeWebAppContext(EmptyDenyServlet.class.getCanonicalName(), "emptyDenyServlet", new String[]{
+            "/annotation/*", "/descriptor/*"
+        });
+
+        AnnotationIntrospector introspector = new AnnotationIntrospector(wac);
+        ServletSecurityAnnotationHandler annotationHandler = new ServletSecurityAnnotationHandler(wac);
+        introspector.registerHandler(annotationHandler);
+
+        // Add another constraint, overriding the existing one on the same path spec
+        // This should be the Jakarta Servlet Spec 13.4.1 authoritative constraint.
+        Constraint descriptorConstraint = new Constraint.Builder()
+            .authorization(Constraint.Authorization.FORBIDDEN)
+            .build();
+        ConstraintMapping descriptorMapping = new ConstraintMapping();
+        descriptorMapping.setPathSpec("/descriptor/*");
+        descriptorMapping.setConstraint(descriptorConstraint);
+
+        ConstraintAware constraintSecurityHandler = (ConstraintAware)wac.getSecurityHandler();
+        constraintSecurityHandler.addConstraintMapping(descriptorMapping);
+
+        ConstraintMapping[] expectedMappings = new ConstraintMapping[2];
+        expectedMappings[0] = new ConstraintMapping();
+        expectedMappings[0].setConstraint(new Constraint.Builder()
+            .transport(Transport.INHERIT)
+            .authorization(Constraint.Authorization.FORBIDDEN).build());
+        expectedMappings[0].setPathSpec("/descriptor/*");
+        expectedMappings[1] = new ConstraintMapping();
+        expectedMappings[1].setConstraint(new Constraint.Builder()
+            .transport(Transport.ANY)
+            .authorization(Constraint.Authorization.FORBIDDEN).build());
+        expectedMappings[1].setPathSpec("/annotation/*");
+
+        introspector.introspect(new EmptyDenyServlet(), null);
+        compareResults(expectedMappings, constraintSecurityHandler.getConstraintMappings());
+    }
+
     private void compareResults(ConstraintMapping[] expectedMappings, List<ConstraintMapping> actualMappings)
     {
         assertNotNull(actualMappings);

--- a/jetty-ee11/jetty-ee11-annotations/src/main/java/org/eclipse/jetty/ee11/annotations/ServletSecurityAnnotationHandler.java
+++ b/jetty-ee11/jetty-ee11-annotations/src/main/java/org/eclipse/jetty/ee11/annotations/ServletSecurityAnnotationHandler.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.ee11.annotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletSecurityElement;
 import jakarta.servlet.annotation.ServletSecurity;
@@ -25,6 +27,7 @@ import org.eclipse.jetty.ee11.servlet.security.ConstraintAware;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintMapping;
 import org.eclipse.jetty.ee11.servlet.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee11.webapp.WebAppContext;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,28 +68,31 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
         if (servletSecurity == null)
             return;
 
-        //If there are already constraints defined (ie from web.xml) that match any
-        //of the url patterns defined for this servlet, then skip the security annotation.
-
         List<ServletMapping> servletMappings = getServletMappings(clazz.getCanonicalName());
-        List<ConstraintMapping> constraintMappings = ((ConstraintAware)_context.getSecurityHandler()).getConstraintMappings();
 
-        if (constraintsExist(servletMappings, constraintMappings))
-        {
-            LOG.warn("Constraints already defined for {}, skipping ServletSecurity annotation", clazz.getName());
-            return;
-        }
+        Set<String> existingConstraintMappingPathSpecs = securityHandler.getConstraintMappings()
+            .stream()
+            .map(ConstraintMapping::getPathSpec)
+            .filter(StringUtil::isNotBlank)
+            .collect(Collectors.toSet());
 
-        //Make a fresh list
-        constraintMappings = new ArrayList<>();
+        List<ConstraintMapping> constraintMappings = new ArrayList<>();
 
         ServletSecurityElement securityElement = new ServletSecurityElement(servletSecurity);
         for (ServletMapping sm : servletMappings)
         {
-            for (String url : sm.getPathSpecs())
+            for (String pathSpec : sm.getPathSpecs())
             {
-                _context.getMetaData().setOrigin("constraint.url." + url, servletSecurity, clazz);
-                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), url, securityElement));
+                // Per Jakarta Servlet Spec 13.4.1: @ServletSecurity
+                // The security-constraint elements defined in web.xml are authoritative for all exact match url-patterns.
+                // https://jakarta.ee/specifications/servlet/6.1/jakarta-servlet-spec-6.1#servletsecurity-annotation
+                if (existingConstraintMappingPathSpecs.contains(pathSpec))
+                {
+                    LOG.warn("Constraint Mapping already defined for {} on path-spec {}, skipping ServletSecurity annotation", clazz.getName(), pathSpec);
+                    continue; // skip
+                }
+                _context.getMetaData().setOrigin("constraint.url." + pathSpec, servletSecurity, clazz);
+                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), pathSpec, securityElement));
             }
         }
 
@@ -124,7 +130,9 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
      * @param servletMappings the servlet mappings
      * @param constraintMappings the constraint mappings
      * @return true if constraint exists
+     * @deprecated not used, no replacement
      */
+    @Deprecated(since = "12.1.12", forRemoval = true)
     protected boolean constraintsExist(List<ServletMapping> servletMappings, List<ConstraintMapping> constraintMappings)
     {
         boolean exists = false;

--- a/jetty-ee11/jetty-ee11-annotations/src/test/java/org/eclipse/jetty/ee11/annotations/TestSecurityAnnotationConversions.java
+++ b/jetty-ee11/jetty-ee11-annotations/src/test/java/org/eclipse/jetty/ee11/annotations/TestSecurityAnnotationConversions.java
@@ -271,6 +271,51 @@ public class TestSecurityAnnotationConversions
         compareResults(expectedMappings, ((ConstraintAware)wac.getSecurityHandler()).getConstraintMappings());
     }
 
+    @ServletSecurity(@HttpConstraint(value = EmptyRoleSemantic.DENY))
+    public static class EmptyDenyServlet extends HttpServlet
+    {
+    }
+
+    @Test
+    public void testWebXmlPathSpecAuthoritative()
+    {
+        // A ServletSecurity annotation that has HttpConstraint of EmptyRoleSemantic.DENY
+        WebAppContext wac = makeWebAppContext(EmptyDenyServlet.class.getCanonicalName(), "emptyDenyServlet", new String[]{
+            "/annotation/*", "/descriptor/*"
+        });
+
+        AnnotationIntrospector introspector = new AnnotationIntrospector(wac);
+        ServletSecurityAnnotationHandler annotationHandler = new ServletSecurityAnnotationHandler(wac);
+        introspector.registerHandler(annotationHandler);
+
+        // Add another constraint, overriding the existing one on the same path spec
+        // This should be the Jakarta Servlet Spec 13.4.1 authoritative constraint.
+        Constraint descriptorConstraint = new Constraint.Builder()
+            .authorization(Constraint.Authorization.FORBIDDEN)
+            .build();
+        ConstraintMapping descriptorMapping = new ConstraintMapping();
+        descriptorMapping.setPathSpec("/descriptor/*");
+        descriptorMapping.setConstraint(descriptorConstraint);
+
+        ConstraintAware constraintSecurityHandler = (ConstraintAware)wac.getSecurityHandler();
+        constraintSecurityHandler.addConstraintMapping(descriptorMapping);
+
+        ConstraintMapping[] expectedMappings = new ConstraintMapping[2];
+        expectedMappings[0] = new ConstraintMapping();
+        expectedMappings[0].setConstraint(new Constraint.Builder()
+            .transport(Transport.INHERIT)
+            .authorization(Constraint.Authorization.FORBIDDEN).build());
+        expectedMappings[0].setPathSpec("/descriptor/*");
+        expectedMappings[1] = new ConstraintMapping();
+        expectedMappings[1].setConstraint(new Constraint.Builder()
+            .transport(Transport.ANY)
+            .authorization(Constraint.Authorization.FORBIDDEN).build());
+        expectedMappings[1].setPathSpec("/annotation/*");
+
+        introspector.introspect(new EmptyDenyServlet(), null);
+        compareResults(expectedMappings, constraintSecurityHandler.getConstraintMappings());
+    }
+
     private void compareResults(ConstraintMapping[] expectedMappings, List<ConstraintMapping> actualMappings)
     {
         assertNotNull(actualMappings);

--- a/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/ServletSecurityAnnotationHandler.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/main/java/org/eclipse/jetty/ee9/annotations/ServletSecurityAnnotationHandler.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.ee9.annotations;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import jakarta.servlet.ServletSecurityElement;
 import jakarta.servlet.annotation.ServletSecurity;
@@ -28,6 +30,7 @@ import org.eclipse.jetty.ee9.security.ConstraintSecurityHandler;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
 import org.eclipse.jetty.ee9.servlet.ServletMapping;
 import org.eclipse.jetty.ee9.webapp.WebAppContext;
+import org.eclipse.jetty.util.StringUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,50 +59,49 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
     }
 
     @Override
-    public void doHandle(Class clazz)
+    public void doHandle(Class<?> clazz)
     {
-        if (!(_context.getSecurityHandler() instanceof ConstraintAware))
+        if (!(_context.getSecurityHandler() instanceof ConstraintAware securityHandler))
         {
             LOG.warn("SecurityHandler not ConstraintAware, skipping security annotation processing");
             return;
         }
 
-        ServletSecurity servletSecurity = (ServletSecurity)clazz.getAnnotation(ServletSecurity.class);
+        ServletSecurity servletSecurity = clazz.getAnnotation(ServletSecurity.class);
         if (servletSecurity == null)
             return;
 
-        //If there are already constraints defined (ie from web.xml) that match any
-        //of the url patterns defined for this servlet, then skip the security annotation.
-
         List<ServletMapping> servletMappings = getServletMappings(clazz.getCanonicalName());
-        List<ConstraintMapping> constraintMappings = ((ConstraintAware)_context.getSecurityHandler()).getConstraintMappings();
 
-        if (constraintsExist(servletMappings, constraintMappings))
-        {
-            LOG.warn("Constraints already defined for {}, skipping ServletSecurity annotation", clazz.getName());
-            return;
-        }
+        Set<String> existingConstraintMappingPathSpecs = securityHandler.getConstraintMappings()
+            .stream()
+            .map(ConstraintMapping::getPathSpec)
+            .filter(StringUtil::isNotBlank)
+            .collect(Collectors.toSet());
 
-        //Make a fresh list
-        constraintMappings = new ArrayList<ConstraintMapping>();
+        List<ConstraintMapping> constraintMappings = new ArrayList<>();
 
         ServletSecurityElement securityElement = new ServletSecurityElement(servletSecurity);
         for (ServletMapping sm : servletMappings)
         {
-            for (String url : sm.getPathSpecs())
+            for (String pathSpec : sm.getPathSpecs())
             {
-                _context.getMetaData().setOrigin("constraint.url." + url, servletSecurity, clazz);
-                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), url, securityElement));
+                // Per Jakarta Servlet Spec 13.4.1: @ServletSecurity
+                // The security-constraint elements defined in web.xml are authoritative for all exact match url-patterns.
+                // https://jakarta.ee/specifications/servlet/5.0/jakarta-servlet-spec-5.0#servletsecurity-annotation
+                // Note: for ee8 conversion, the rules here still apply on Jakarta Servlet 4.0 / EE8
+                if (existingConstraintMappingPathSpecs.contains(pathSpec))
+                {
+                    LOG.warn("Constraint Mapping already defined for {} on path-spec {}, skipping ServletSecurity annotation", clazz.getName(), pathSpec);
+                    continue; // skip
+                }
+                _context.getMetaData().setOrigin("constraint.url." + pathSpec, servletSecurity, clazz);
+                constraintMappings.addAll(ConstraintSecurityHandler.createConstraintsWithMappingsForPath(clazz.getName(), pathSpec, securityElement));
             }
         }
 
         //set up the security constraints produced by the annotation
-        ConstraintAware securityHandler = (ConstraintAware)_context.getSecurityHandler();
-
-        for (ConstraintMapping m : constraintMappings)
-        {
-            securityHandler.addConstraintMapping(m);
-        }
+        constraintMappings.forEach(securityHandler::addConstraintMapping);
 
         //Servlet Spec 3.1 requires paths with uncovered http methods to be reported
         securityHandler.checkPathsWithUncoveredHttpMethods();
@@ -147,7 +149,9 @@ public class ServletSecurityAnnotationHandler extends AbstractIntrospectableAnno
      * @param servletMappings the servlet mappings
      * @param constraintMappings the constraint mappings
      * @return true if constraint exists
+     * @deprecated not used, no replacement
      */
+    @Deprecated(since = "12.1.12", forRemoval = true)
     protected boolean constraintsExist(List<ServletMapping> servletMappings, List<ConstraintMapping> constraintMappings)
     {
         boolean exists = false;

--- a/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestSecurityAnnotationConversions.java
+++ b/jetty-ee9/jetty-ee9-annotations/src/test/java/org/eclipse/jetty/ee9/annotations/TestSecurityAnnotationConversions.java
@@ -270,6 +270,54 @@ public class TestSecurityAnnotationConversions
         compareResults(expectedMappings, ((ConstraintAware)wac.getSecurityHandler()).getConstraintMappings());
     }
 
+    @ServletSecurity(@HttpConstraint(value = EmptyRoleSemantic.DENY))
+    public static class EmptyDenyServlet extends HttpServlet
+    {
+    }
+
+    @Test
+    public void testWebXmlPathSpecAuthoritative()
+    {
+        // A ServletSecurity annotation that has HttpConstraint of EmptyRoleSemantic.DENY
+        WebAppContext wac = makeWebAppContext(EmptyDenyServlet.class.getCanonicalName(), "emptyDenyServlet", new String[]{
+            "/annotation/*", "/descriptor/*"
+        });
+
+        AnnotationIntrospector introspector = new AnnotationIntrospector(wac);
+        ServletSecurityAnnotationHandler annotationHandler = new ServletSecurityAnnotationHandler(wac);
+        introspector.registerHandler(annotationHandler);
+
+        // Add another constraint, overriding the existing one on the same path spec
+        // This should be the Jakarta Servlet Spec 13.4.1 authoritative constraint.
+        ServletConstraint descriptorConstraint = new ServletConstraint();
+        descriptorConstraint.setAuthenticate(true);
+        descriptorConstraint.setDataConstraint(ServletConstraint.DC_NONE);
+        ConstraintMapping descriptorMapping = new ConstraintMapping();
+        descriptorMapping.setPathSpec("/descriptor/*");
+        descriptorMapping.setConstraint(descriptorConstraint);
+
+        ConstraintAware constraintSecurityHandler = (ConstraintAware)wac.getSecurityHandler();
+        constraintSecurityHandler.addConstraintMapping(descriptorMapping);
+
+        ServletConstraint expectedDescriptorConstraint = new ServletConstraint();
+        expectedDescriptorConstraint.setAuthenticate(true);
+        expectedDescriptorConstraint.setDataConstraint(ServletConstraint.DC_NONE);
+        ServletConstraint expectedAnnotationConstraint = new ServletConstraint();
+        expectedAnnotationConstraint.setAuthenticate(true);
+        expectedAnnotationConstraint.setDataConstraint(ServletConstraint.DC_NONE);
+
+        ConstraintMapping[] expectedMappings = new ConstraintMapping[2];
+        expectedMappings[0] = new ConstraintMapping();
+        expectedMappings[0].setConstraint(expectedDescriptorConstraint);
+        expectedMappings[0].setPathSpec("/descriptor/*");
+        expectedMappings[1] = new ConstraintMapping();
+        expectedMappings[1].setConstraint(expectedAnnotationConstraint);
+        expectedMappings[1].setPathSpec("/annotation/*");
+
+        introspector.introspect(new EmptyDenyServlet(), null);
+        compareResults(expectedMappings, constraintSecurityHandler.getConstraintMappings());
+    }
+
     private void compareResults(ConstraintMapping[] expectedMappings, List<ConstraintMapping> actualMappings)
     {
         assertNotNull(actualMappings);


### PR DESCRIPTION
Noticed that there wasn't adequate test coverage of the authoritative url-pattern code paths in ServletSecurityHandler, this fixes that gap in testing.