### PR TITLE
Remove LF_CHUNK_TERMINATION from non-legacy HttpCompliance modes (12.1)

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -201,7 +201,6 @@ public final class HttpCompliance implements ComplianceViolation.Mode
      * The HttpCompliance mode that supports <a href="https://tools.ietf.org/html/rfc7230">RFC 7230</a>.
      */
     public static final HttpCompliance RFC7230 = new HttpCompliance("RFC7230", of(
-        Violation.LF_CHUNK_TERMINATION,
         Violation.LF_HEADER_TERMINATION,
         Violation.WHITESPACE_IN_PARAMETER,
         Violation.BAD_QUOTES_IN_TOKEN));
@@ -214,7 +213,6 @@ public final class HttpCompliance implements ComplianceViolation.Mode
         Violation.HTTP_0_9,
         Violation.MULTILINE_FIELD_VALUE,
         Violation.MISMATCHED_AUTHORITY,
-        Violation.LF_CHUNK_TERMINATION,
         Violation.LF_HEADER_TERMINATION,
         Violation.WHITESPACE_IN_PARAMETER,
         Violation.BAD_QUOTES_IN_TOKEN
@@ -230,6 +228,7 @@ public final class HttpCompliance implements ComplianceViolation.Mode
      * colons after field names; {@code Transfer-Encoding} with {@code Content-Length} fields; and multiple {@code Content-Length} values.
      */
     public static final HttpCompliance RFC2616_LEGACY = RFC2616.with("RFC2616_LEGACY",
+        Violation.LF_CHUNK_TERMINATION,
         Violation.CASE_INSENSITIVE_METHOD,
         Violation.NO_COLON_AFTER_FIELD_NAME,
         Violation.TRANSFER_ENCODING_WITH_CONTENT_LENGTH,
@@ -240,7 +239,7 @@ public final class HttpCompliance implements ComplianceViolation.Mode
     /**
      * A legacy HttpCompliance mode that supports {@link #RFC7230}, but with case-insensitive methods allowed.
      */
-    public static final HttpCompliance RFC7230_LEGACY = RFC7230.with("RFC7230_LEGACY", Violation.CASE_INSENSITIVE_METHOD);
+    public static final HttpCompliance RFC7230_LEGACY = RFC7230.with("RFC7230_LEGACY", Violation.LF_CHUNK_TERMINATION, Violation.CASE_INSENSITIVE_METHOD);
 
     private static final List<HttpCompliance> KNOWN_MODES = Arrays.asList(STRICT, RFC9110, RFC7230, RFC2616, LEGACY, RFC2616_LEGACY, RFC7230_LEGACY);
     private static final AtomicInteger __custom = new AtomicInteger();

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -1340,7 +1340,7 @@ public class HttpParser
             if (t == null)
                 break;
             if (t == EOL_LF)
-                checkViolation(LF_HEADER_TERMINATION);
+                checkViolation(_state == State.HEADER ? LF_HEADER_TERMINATION : LF_CHUNK_TERMINATION);
 
             switch (_fieldState)
             {

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -1542,7 +1542,7 @@ public class HttpParserTest
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + scenario.eolChunk +
                 "0" + scenario.eolChunk +
                 "Trailer: value" + scenario.eolChunk +
-                scenario.eol);
+                scenario.eolChunk);
         HttpParser.RequestHandler handler = new Handler();
         HttpParser parser = new HttpParser(handler, scenario.compliance);
         parseAll(parser, buffer);
@@ -1586,9 +1586,9 @@ public class HttpParserTest
                 "1a" + scenario.eolChunk +
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + scenario.eolChunk +
                 "0" + scenario.eolChunk +
-                "Trailer: value" + scenario.eol +
-                "Foo: bar" + scenario.eol +
-                scenario.eol);
+                "Trailer: value" + scenario.eolChunk +
+                "Foo: bar" + scenario.eolChunk +
+                scenario.eolChunk);
         HttpParser.RequestHandler handler = new Handler();
         HttpParser parser = new HttpParser(handler, scenario.compliance);
         parseAll(parser, buffer);
@@ -1802,7 +1802,7 @@ public class HttpParserTest
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + scenario.eolChunk +
                 "0" + scenario.eolChunk +
 
-                scenario.eol +
+                scenario.eolChunk +
 
                 "POST /foo HTTP/1.0" + scenario.eol +
                 "Connection: Keep-Alive" + scenario.eol +
@@ -1879,7 +1879,7 @@ public class HttpParserTest
             "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + scenario.eolChunk +
             "0" + scenario.eolChunk +
 
-            scenario.eol +
+            scenario.eolChunk +
 
             "POST /foo HTTP/1.0" + scenario.eol +
             "Connection: Keep-Alive" + scenario.eol +
@@ -2714,7 +2714,7 @@ public class HttpParserTest
                 "1" + scenario.eolChunk +
                 "X" + scenario.eolChunk +
                 "0" + scenario.eolChunk +
-                scenario.eol);
+                scenario.eolChunk);
 
         HttpParser.RequestHandler handler = new Handler();
         HttpParser parser = new HttpParser(handler, scenario.compliance.with("test", TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
@@ -2756,10 +2756,7 @@ public class HttpParserTest
             expectedEvents.add("HttpCompliance.LF_CHUNK_TERMINATION (allowed)");
             expectedEvents.add("HttpCompliance.LF_CHUNK_TERMINATION (allowed)");
             expectedEvents.add("HttpCompliance.LF_CHUNK_TERMINATION (allowed)");
-        }
-        if (scenario.eol.equals("\n"))
-        {
-            expectedEvents.add("HttpCompliance.LF_HEADER_TERMINATION (allowed)");
+            expectedEvents.add("HttpCompliance.LF_CHUNK_TERMINATION (allowed)");
         }
 
         assertComplianceViolationEvents(expectedEvents);
@@ -2778,7 +2775,7 @@ public class HttpParserTest
                 "1" + scenario.eolChunk +
                 "X" + scenario.eolChunk +
                 "0" + scenario.eolChunk +
-                scenario.eol);
+                scenario.eolChunk);
 
         HttpParser.RequestHandler handler = new Handler();
         HttpParser parser = new HttpParser(handler, scenario.compliance.with("test", TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
@@ -2812,14 +2809,9 @@ public class HttpParserTest
         expectedEvents.add("HttpCompliance.TRANSFER_ENCODING_WITH_CONTENT_LENGTH (allowed)");
         if (scenario.eolChunk.equals("\n"))
         {
-            // add 3 for chunk eol
-            for (int i = 0; i < 3; i++)
+            // add 4 for chunk eol
+            for (int i = 0; i < 4; i++)
                 expectedEvents.add("HttpCompliance.LF_CHUNK_TERMINATION (allowed)");
-        }
-        if (scenario.eol.equals("\n")) // handle LF specific scenarios
-        {
-            // add one for the end of headers delim (before body)
-            expectedEvents.add("HttpCompliance.LF_HEADER_TERMINATION (allowed)");
         }
 
         assertComplianceViolationEvents(expectedEvents);
@@ -3452,7 +3444,7 @@ public class HttpParserTest
                 "Transfer-Encoding: chunked" + scenario.eol +
                 scenario.eol +
                 "0" + scenario.eolChunk +
-                scenario.eol);
+                scenario.eolChunk);
         boolean handle = parser.parseNext(buffer);
         if (scenario.expectBad())
         {
@@ -3533,7 +3525,7 @@ public class HttpParserTest
                 "Transfer-Encoding: chunked" + scenario.eol +
                 scenario.eol +
                 "0" + scenario.eolChunk +
-                scenario.eol);
+                scenario.eolChunk);
         boolean handle = parser.parseNext(buffer);
         if (scenario.expectBad())
         {

--- a/jetty-core/jetty-tests/jetty-test-rfc/src/test/java/org/eclipse/jetty/test/rfc/RFC2616Test.java
+++ b/jetty-core/jetty-tests/jetty-test-rfc/src/test/java/org/eclipse/jetty/test/rfc/RFC2616Test.java
@@ -242,22 +242,22 @@ public class RFC2616Test
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "2\n" +
-                "12\n" +
-                "3\n" +
-                "345\n" +
-                "0\n\n" +
+                "2\r\n" +
+                "12\r\n" +
+                "3\r\n" +
+                "345\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "4\n" +
-                "6789\n" +
-                "5\n" +
-                "abcde\n" +
-                "0\n\n" +
+                "4\r\n" +
+                "6789\r\n" +
+                "5\r\n" +
+                "abcde\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R3 HTTP/1.1\n" +
                 "Host: localhost\n" +
@@ -287,22 +287,22 @@ public class RFC2616Test
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "3\n" +
-                "fgh\n" +
-                "3\n" +
-                "Ijk\n" +
-                "0\n\n" +
+                "3\r\n" +
+                "fgh\r\n" +
+                "3\r\n" +
+                "Ijk\r\n" +
+                "0\r\n\r\n" +
 
                 "POST /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "4\n" +
-                "lmno\n" +
-                "5\n" +
-                "Pqrst\n" +
-                "0\n\n" +
+                "4\r\n" +
+                "lmno\r\n" +
+                "5\r\n" +
+                "Pqrst\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R3 HTTP/1.1\n" +
                 "Host: localhost\n" +
@@ -337,11 +337,11 @@ public class RFC2616Test
                 "Content-Type: text/plain\n" +
                 "Connection: keep-alive\n" +
                 "\n" +
-                "3\n" +
-                "123\n" +
-                "3\n" +
-                "456\n" +
-                "0\n\n" +
+                "3\r\n" +
+                "123\r\n" +
+                "3\r\n" +
+                "456\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +


### PR DESCRIPTION
Make the `RFC7230` and `RFC2616` more strict by moving `LF_CHUNK_TERMINATION` into the `LEGACY` modes.