### PR TITLE
Remove LF_CHUNK_TERMINATION from non-legacy HttpCompliance modes (12.0)

### DIFF
--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpCompliance.java
@@ -125,7 +125,12 @@ public final class HttpCompliance implements ComplianceViolation.Mode
          * must reject a request if the target URI has an authority that is different than a provided Host header.
          * A deployment may include this violation to allow different values on the target URI and the Host header on a received request.
          */
-        MISMATCHED_AUTHORITY("https://www.rfc-editor.org/rfc/rfc7230#section-5.4", "Mismatched Authority");
+        MISMATCHED_AUTHORITY("https://www.rfc-editor.org/rfc/rfc7230#section-5.4", "Mismatched Authority"),
+
+        /**
+         * Allow LF termination of chunk headers and chunks
+         */
+        LF_CHUNK_TERMINATION("https://www.rfc-editor.org/info/rfc7230/#section-4.1", "LF line terminator in chunk");
 
         private final String url;
         private final String description;
@@ -192,6 +197,7 @@ public final class HttpCompliance implements ComplianceViolation.Mode
      * colons after field names; {@code Transfer-Encoding} with {@code Content-Length} fields; and multiple {@code Content-Length} values.
      */
     public static final HttpCompliance RFC2616_LEGACY = RFC2616.with("RFC2616_LEGACY",
+        Violation.LF_CHUNK_TERMINATION,
         Violation.CASE_INSENSITIVE_METHOD,
         Violation.NO_COLON_AFTER_FIELD_NAME,
         Violation.TRANSFER_ENCODING_WITH_CONTENT_LENGTH,
@@ -200,7 +206,9 @@ public final class HttpCompliance implements ComplianceViolation.Mode
     /**
      * A legacy HttpCompliance mode that supports {@link #RFC7230}, but with case-insensitive methods allowed.
      */
-    public static final HttpCompliance RFC7230_LEGACY = RFC7230.with("RFC7230_LEGACY", Violation.CASE_INSENSITIVE_METHOD);
+    public static final HttpCompliance RFC7230_LEGACY = RFC7230.with("RFC7230_LEGACY",
+        Violation.LF_CHUNK_TERMINATION,
+        Violation.CASE_INSENSITIVE_METHOD);
 
     private static final List<HttpCompliance> KNOWN_MODES = Arrays.asList(RFC7230, RFC2616, LEGACY, RFC2616_LEGACY, RFC7230_LEGACY);
     private static final AtomicInteger __custom = new AtomicInteger();

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpParser.java
@@ -38,12 +38,15 @@ import static org.eclipse.jetty.http.HttpCompliance.Violation;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.CASE_SENSITIVE_FIELD_NAME;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.DUPLICATE_HOST_HEADERS;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.HTTP_0_9;
+import static org.eclipse.jetty.http.HttpCompliance.Violation.LF_CHUNK_TERMINATION;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.MULTIPLE_CONTENT_LENGTHS;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.NO_COLON_AFTER_FIELD_NAME;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.TRANSFER_ENCODING_WITH_CONTENT_LENGTH;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.UNSAFE_HOST_HEADER;
 import static org.eclipse.jetty.http.HttpCompliance.Violation.WHITESPACE_AFTER_FIELD_NAME;
 import static org.eclipse.jetty.http.HttpTokens.CARRIAGE_RETURN;
+import static org.eclipse.jetty.http.HttpTokens.EOL_CRLF;
+import static org.eclipse.jetty.http.HttpTokens.EOL_LF;
 import static org.eclipse.jetty.http.HttpTokens.LINE_FEED;
 
 /**
@@ -504,8 +507,12 @@ public class HttpParser
                 throw new IllegalCharacterException(_state, t, buffer);
 
             case LF:
-                _cr = false;
-                break;
+                if (_cr)
+                {
+                    _cr = false;
+                    return EOL_CRLF;
+                }
+                return EOL_LF;
 
             case CR:
                 if (_cr)
@@ -519,7 +526,7 @@ public class HttpParser
                     return switch (t.getType())
                     {
                         case CNTL -> throw new IllegalCharacterException(_state, t, buffer);
-                        case LF -> t;
+                        case LF -> EOL_CRLF;
                         default -> throw new BadMessageException("Bad EOL");
                     };
                 }
@@ -791,7 +798,7 @@ public class HttpParser
                             setState(State.SPACE1);
                             break;
 
-                        case LF:
+                        case EOL:
                             throw new BadMessageException("No URI");
 
                         case ALPHA:
@@ -823,8 +830,7 @@ public class HttpParser
                         case COLON:
                             _string.append(t.getChar());
                             break;
-                        case CR:
-                        case LF:
+                        case EOL:
                             throw new BadMessageException("No Status");
                         default:
                             throw new IllegalCharacterException(_state, t, buffer);
@@ -904,7 +910,7 @@ public class HttpParser
                                 throw new BadMessageException("Bad status");
                             break;
 
-                        case LF:
+                        case EOL:
                             _fieldCache.prepare();
                             setState(State.HEADER);
                             _responseHandler.startResponse(_version, _responseStatus, null);
@@ -948,7 +954,7 @@ public class HttpParser
                             setState(State.SPACE2);
                             break;
 
-                        case LF:
+                        case EOL:
                             // HTTP/0.9
                             if (Violation.HTTP_0_9.isAllowedBy(_complianceMode))
                             {
@@ -996,7 +1002,7 @@ public class HttpParser
                             setState(_requestParser ? State.REQUEST_VERSION : State.REASON);
                             break;
 
-                        case LF:
+                        case EOL:
                             if (!_requestParser)
                             {
                                 _fieldCache.prepare();
@@ -1023,7 +1029,7 @@ public class HttpParser
                 case REQUEST_VERSION:
                     switch (t.getType())
                     {
-                        case LF:
+                        case EOL:
                             if (_version == null)
                             {
                                 _length = _string.length();
@@ -1053,7 +1059,7 @@ public class HttpParser
                     assert !_requestParser;
                     switch (t.getType())
                     {
-                        case LF:
+                        case EOL:
                             String reason = takeString();
                             _fieldCache.prepare();
                             setState(State.HEADER);
@@ -1277,6 +1283,8 @@ public class HttpParser
             HttpTokens.Token t = next(buffer);
             if (t == null)
                 break;
+            if (t == EOL_LF && _state == State.TRAILER)
+                checkViolation(LF_CHUNK_TERMINATION);
 
             switch (_fieldState)
             {
@@ -1306,7 +1314,7 @@ public class HttpParser
                             break;
                         }
 
-                        case LF:
+                        case EOL:
                         {
                             // process previous header
                             if (_state == State.HEADER)
@@ -1450,6 +1458,8 @@ public class HttpParser
                                         addAndCheckHeadersSize(posAfterValue + 1 - position);
                                         if (peek == LINE_FEED)
                                         {
+                                            if (_state == State.TRAILER)
+                                                checkViolation(LF_CHUNK_TERMINATION);
                                             setState(FieldState.FIELD);
                                             break;
                                         }
@@ -1502,7 +1512,7 @@ public class HttpParser
                             setState(FieldState.VALUE);
                             break;
 
-                        case LF:
+                        case EOL:
                             _headerString = takeString();
                             _header = HttpHeader.CACHE.get(_headerString);
                             _string.setLength(0);
@@ -1540,7 +1550,7 @@ public class HttpParser
                             setState(FieldState.VALUE);
                             break;
 
-                        case LF:
+                        case EOL:
                             if (NO_COLON_AFTER_FIELD_NAME.isAllowedBy(_complianceMode))
                             {
                                 reportComplianceViolation(NO_COLON_AFTER_FIELD_NAME, "Field " + _headerString);
@@ -1557,7 +1567,7 @@ public class HttpParser
                 case VALUE:
                     switch (t.getType())
                     {
-                        case LF:
+                        case EOL:
                             _string.setLength(0);
                             _valueString = "";
                             _length = -1;
@@ -1588,7 +1598,7 @@ public class HttpParser
                 case IN_VALUE:
                     switch (t.getType())
                     {
-                        case LF:
+                        case EOL:
                             if (_length > 0)
                             {
                                 _valueString = takeString();
@@ -1880,7 +1890,7 @@ public class HttpParser
                     _chunkOffset = 0;
                     switch (t.getType())
                     {
-                        case LF:
+                        case EOL:
                             break;
 
                         case DIGIT:
@@ -1938,8 +1948,10 @@ public class HttpParser
                         break;
 
                     // We must be exactly on a line-terminator after consuming the chunk.
-                    if (t.getType() != HttpTokens.Type.LF)
+                    if (t.getType() != HttpTokens.Type.EOL)
                         throw new IllegalCharacterException(_state, t, buffer);
+                    if (t == EOL_LF)
+                        checkViolation(LF_CHUNK_TERMINATION);
                     setState(State.CHUNKED_CONTENT);
                     break;
                 }
@@ -1971,7 +1983,7 @@ public class HttpParser
             {
                 case SIZE ->
                 {
-                    if (t.getType() == HttpTokens.Type.LF)
+                    if (t.getType() == HttpTokens.Type.EOL)
                     {
                         if (chunkSizeEnd(t))
                             return true;
@@ -2009,7 +2021,7 @@ public class HttpParser
                 }
                 case EXT_NAME ->
                 {
-                    if (t.getType() == HttpTokens.Type.LF)
+                    if (t.getType() == HttpTokens.Type.EOL)
                     {
                         if (chunkSizeEnd(t))
                             return true;
@@ -2058,7 +2070,7 @@ public class HttpParser
                 }
                 case EXT_VALUE ->
                 {
-                    if (t.getType() == HttpTokens.Type.LF)
+                    if (t.getType() == HttpTokens.Type.EOL)
                     {
                         if (chunkSizeEnd(t))
                             return true;
@@ -2072,7 +2084,7 @@ public class HttpParser
                 }
                 case EXT_VALUE_CLOSE_QUOTE ->
                 {
-                    if (t.getType() == HttpTokens.Type.LF)
+                    if (t.getType() == HttpTokens.Type.EOL)
                     {
                         if (chunkSizeEnd(t))
                             return true;
@@ -2091,6 +2103,8 @@ public class HttpParser
 
     private boolean chunkSizeEnd(HttpTokens.Token t)
     {
+        if (t == EOL_LF)
+            checkViolation(LF_CHUNK_TERMINATION);
         setChunkSizeState(ChunkSizeState.SIZE);
         _chunkSizeDigits = 0;
         if (_chunkLength == 0)

--- a/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTokens.java
+++ b/jetty-core/jetty-http/src/main/java/org/eclipse/jetty/http/HttpTokens.java
@@ -39,6 +39,7 @@ public class HttpTokens
         HTAB,    // Horizontal tab 
         LF,      // Line feed
         CR,      // Carriage return
+        EOL,     // A CRLF or LF (depending on configuration)
         SPACE,   // Space 
         COLON,   // Colon character
         DIGIT,   // Digit
@@ -162,6 +163,8 @@ public class HttpTokens
         }
     }
 
+    public static final Token EOL_LF = new Token(LINE_FEED, Type.EOL);
+    public static final Token EOL_CRLF = new Token(LINE_FEED, Type.EOL);
     public static final Token[] TOKENS = new Token[256];
 
     static

--- a/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
+++ b/jetty-core/jetty-http/src/test/java/org/eclipse/jetty/http/HttpParserTest.java
@@ -42,6 +42,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -88,6 +89,11 @@ public class HttpParserTest
         return List.of(HttpMethod.values())
             .stream()
             .map(Arguments::of);
+    }
+
+    public static HttpCompliance getHttpCompliance(String eoln)
+    {
+        return "\n".equals(eoln) ? HttpCompliance.RFC7230_LEGACY : HttpCompliance.RFC7230;
     }
 
     @ParameterizedTest
@@ -1214,7 +1220,7 @@ public class HttpParserTest
             "0" + eoln +
             eoln);
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parseAll(parser, buffer);
 
         assertEquals("GET", _methodOrVersion);
@@ -1302,7 +1308,7 @@ public class HttpParserTest
                 "Trailer: value" + eoln +
                 eoln);
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parseAll(parser, buffer);
 
         assertEquals("GET", _methodOrVersion);
@@ -1338,7 +1344,7 @@ public class HttpParserTest
                 "Foo: bar" + eoln +
                 eoln);
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parseAll(parser, buffer);
 
         assertEquals("GET", _methodOrVersion);
@@ -1376,7 +1382,7 @@ public class HttpParserTest
                 "0" + eoln +
                 "Trailer: value");
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parseAll(parser, buffer);
         parser.atEOF();
         parser.parseNext(BufferUtil.EMPTY_BUFFER);
@@ -1408,7 +1414,7 @@ public class HttpParserTest
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + eoln +
                 "0" + eoln);
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parseAll(parser, buffer);
         parser.atEOF();
         parser.parseNext(BufferUtil.EMPTY_BUFFER);
@@ -1471,7 +1477,7 @@ public class HttpParserTest
                 "a;ext" + eoln +
                 "0123456789" + eoln);
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parser.atEOF();
         parseAll(parser, buffer);
 
@@ -1518,7 +1524,7 @@ public class HttpParserTest
                 "0123456789" + eoln);
 
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parser.parseNext(buffer);
         assertEquals("GET", _methodOrVersion);
         assertEquals("/mp", _uriOrStatus);
@@ -1584,7 +1590,7 @@ public class HttpParserTest
             "0123456789" + eoln);
 
         HttpParser.RequestHandler handler = new Handler();
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, getHttpCompliance(eoln));
         parser.parseNext(buffer0);
         parser.atEOF();
         parser.parseNext(buffer1);
@@ -2302,7 +2308,7 @@ public class HttpParserTest
         assertTrue(_headerCompleted);
         assertTrue(_messageCompleted);
 
-        assertThat(_complianceViolation, contains(TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
+        assertThat(_complianceViolation, hasItem(TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
     }
 
     @ParameterizedTest
@@ -2332,7 +2338,7 @@ public class HttpParserTest
         assertTrue(_headerCompleted);
         assertTrue(_messageCompleted);
 
-        assertThat(_complianceViolation, contains(TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
+        assertThat(_complianceViolation, hasItem(TRANSFER_ENCODING_WITH_CONTENT_LENGTH));
     }
 
     @ParameterizedTest
@@ -2857,7 +2863,7 @@ public class HttpParserTest
                 return true;
             }
         };
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, -1, getHttpCompliance(eoln));
 
         ByteBuffer buffer = BufferUtil.toBuffer(
             "HTTP/1.1 200 OK" + eoln +
@@ -2921,7 +2927,7 @@ public class HttpParserTest
                 return true;
             }
         };
-        HttpParser parser = new HttpParser(handler);
+        HttpParser parser = new HttpParser(handler, -1, getHttpCompliance(eoln));
 
         ByteBuffer buffer = BufferUtil.toBuffer(
             "HTTP/1.1 200 OK" + eoln +

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/CustomRequestLogTest.java
@@ -797,9 +797,9 @@ public class CustomRequestLogTest
             Host: localhost
             Transfer-Encoding: chunked
             
-            0
-            trailerName: 42
-            
+            0\r
+            trailerName: 42\r
+            \r
             """);
         assertEquals(HttpStatus.OK_200, response.getStatus());
         String log = _logs.poll(5, TimeUnit.SECONDS);

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/HttpServerTestBase.java
@@ -174,10 +174,10 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
                 Transfer-Encoding: chunked
                 Connection: close
                 
-                0a
-                0123456789
-                0
-                
+                0a\r
+                0123456789\r
+                0\r
+                \r
                 """;
             os.write(request.getBytes(StandardCharsets.ISO_8859_1));
             os.flush();
@@ -440,11 +440,11 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
                 Host: localhost
                 Transfer-Encoding: chunked
                 
-                0a
-                1234567890
-                xx
-                
-                
+                0a\r
+                1234567890\r
+                xx\r
+                \r
+                \r
                 """;
             os.write(request.getBytes(StandardCharsets.ISO_8859_1));
             os.flush();
@@ -970,7 +970,7 @@ public abstract class HttpServerTestBase extends HttpServerTestFixture
             Thread.sleep(10);
             os.write((
                 "a\r\n" +
-                    "123456890\r\n"
+                    "1234567890\r\n"
             ).getBytes());
             os.flush();
 

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/PartialRFC2616Test.java
@@ -154,22 +154,22 @@ public class PartialRFC2616Test
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "2\n" +
-                "12\n" +
-                "3\n" +
-                "345\n" +
-                "0\n\n" +
+                "2\r\n" +
+                "12\r\n" +
+                "3\r\n" +
+                "345\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "4\n" +
-                "6789\n" +
-                "5\n" +
-                "abcde\n" +
-                "0\n\n" +
+                "4\r\n" +
+                "6789\r\n" +
+                "5\r\n" +
+                "abcde\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R3 HTTP/1.1\n" +
                 "Host: localhost\n" +
@@ -199,22 +199,22 @@ public class PartialRFC2616Test
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "3\n" +
-                "fgh\n" +
-                "3\n" +
-                "Ijk\n" +
-                "0\n\n" +
+                "3\r\n" +
+                "fgh\r\n" +
+                "3\r\n" +
+                "Ijk\r\n" +
+                "0\r\n\r\n" +
 
                 "POST /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +
                 "Transfer-Encoding: chunked\n" +
                 "Content-Type: text/plain\n" +
                 "\n" +
-                "4\n" +
-                "lmno\n" +
-                "5\n" +
-                "Pqrst\n" +
-                "0\n\n" +
+                "4\r\n" +
+                "lmno\r\n" +
+                "5\r\n" +
+                "Pqrst\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R3 HTTP/1.1\n" +
                 "Host: localhost\n" +
@@ -249,11 +249,11 @@ public class PartialRFC2616Test
                 "Content-Type: text/plain\n" +
                 "Connection: keep-alive\n" +
                 "\n" +
-                "3\n" +
-                "123\n" +
-                "3\n" +
-                "456\n" +
-                "0\n\n" +
+                "3\r\n" +
+                "123\r\n" +
+                "3\r\n" +
+                "456\r\n" +
+                "0\r\n\r\n" +
 
                 "GET /R2 HTTP/1.1\n" +
                 "Host: localhost\n" +

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
@@ -1749,23 +1749,23 @@ public class ProxyServletTest
                 if (chunked)
                 {
                     request = """
-                        POST http://$A/ HTTP/1.1
-                        Host: $A
-                        Expect: 100-Continue
-                        Transfer-Encoding: chunked
-                        
-                        0
-                        
+                        POST http://$A/ HTTP/1.1\r
+                        Host: $A\r
+                        Expect: 100-Continue\r
+                        Transfer-Encoding: chunked\r
+                        \r
+                        0\r
+                        \r
                         """;
                 }
                 else
                 {
                     request = """
-                        POST http://$A/ HTTP/1.1
-                        Host: $A
-                        Expect: 100-Continue
-                        Content-Length: 0
-                        
+                        POST http://$A/ HTTP/1.1\r
+                        Host: $A\r
+                        Expect: 100-Continue\r
+                        Content-Length: 0\r
+                        \r
                         """;
                 }
                 request = request.replace("$A", authority);

--- a/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
+++ b/jetty-ee10/jetty-ee10-tests/jetty-ee10-test-integration/src/test/java/org/eclipse/jetty/ee10/test/rfcs/RFC2616BaseTest.java
@@ -190,22 +190,22 @@ public abstract class RFC2616BaseTest
         req2.append("Transfer-Encoding: chunked\n");
         req2.append("Content-Type: text/plain\n");
         req2.append("\n");
-        req2.append("2\n"); // 2 chars
-        req2.append("12\n");
-        req2.append("3\n"); // 3 chars
-        req2.append("345\n");
-        req2.append("0\n\n");
+        req2.append("2\r\n"); // 2 chars
+        req2.append("12\r\n");
+        req2.append("3\r\n"); // 3 chars
+        req2.append("345\r\n");
+        req2.append("0\r\n\r\n");
 
         req2.append("GET /echo/R2 HTTP/1.1\n");
         req2.append("Host: localhost\n");
         req2.append("Transfer-Encoding: chunked\n");
         req2.append("Content-Type: text/plain\n");
         req2.append("\n");
-        req2.append("4\n"); // 4 chars
-        req2.append("6789\n");
-        req2.append("5\n"); // 5 chars
-        req2.append("abcde\n");
-        req2.append("0\n\n"); // 0 chars
+        req2.append("4\r\n"); // 4 chars
+        req2.append("6789\r\n");
+        req2.append("5\r\n"); // 5 chars
+        req2.append("abcde\r\n");
+        req2.append("0\r\n\r\n"); // 0 chars
 
         req2.append("GET /echo/R3 HTTP/1.1\n");
         req2.append("Host: localhost\n");
@@ -243,22 +243,22 @@ public abstract class RFC2616BaseTest
         req3.append("Transfer-Encoding: chunked\n");
         req3.append("Content-Type: text/plain\n");
         req3.append("\n");
-        req3.append("3\n"); // 3 chars
-        req3.append("fgh\n");
-        req3.append("3\n"); // 3 chars
-        req3.append("Ijk\n");
-        req3.append("0\n\n"); // 0 chars
+        req3.append("3\r\n"); // 3 chars
+        req3.append("fgh\r\n");
+        req3.append("3\r\n"); // 3 chars
+        req3.append("Ijk\r\n");
+        req3.append("0\r\n\r\n"); // 0 chars
 
         req3.append("POST /echo/R2 HTTP/1.1\n");
         req3.append("Host: localhost\n");
         req3.append("Transfer-Encoding: chunked\n");
         req3.append("Content-Type: text/plain\n");
         req3.append("\n");
-        req3.append("4\n"); // 4 chars
-        req3.append("lmno\n");
-        req3.append("5\n"); // 5 chars
-        req3.append("Pqrst\n");
-        req3.append("0\n\n"); // 0 chars
+        req3.append("4\r\n"); // 4 chars
+        req3.append("lmno\r\n");
+        req3.append("5\r\n"); // 5 chars
+        req3.append("Pqrst\r\n");
+        req3.append("0\r\n\r\n"); // 0 chars
 
         req3.append("GET /echo/R3 HTTP/1.1\n");
         req3.append("Host: localhost\n");
@@ -297,11 +297,11 @@ public abstract class RFC2616BaseTest
         req4.append("Content-Type: text/plain\n");
         req4.append("Connection: keep-alive\n"); // keep-alive
         req4.append("\n");
-        req4.append("3\n"); // 3 chars
-        req4.append("123\n");
-        req4.append("3\n"); // 3 chars
-        req4.append("456\n");
-        req4.append("0\n\n"); // 0 chars
+        req4.append("3\r\n"); // 3 chars
+        req4.append("123\r\n");
+        req4.append("3\r\n"); // 3 chars
+        req4.append("456\r\n");
+        req4.append("0\r\n\r\n"); // 0 chars
 
         req4.append("GET /echo/R2 HTTP/1.1\n");
         req4.append("Host: localhost\n");

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
@@ -1747,23 +1747,23 @@ public class ProxyServletTest
                 if (chunked)
                 {
                     request = """
-                        POST http://$A/ HTTP/1.1
-                        Host: $A
-                        Expect: 100-Continue
-                        Transfer-Encoding: chunked
-
-                        0
-
+                        POST http://$A/ HTTP/1.1\r
+                        Host: $A\r
+                        Expect: 100-Continue\r
+                        Transfer-Encoding: chunked\r
+                        \r
+                        0\r
+                        \r
                         """;
                 }
                 else
                 {
                     request = """
-                        POST http://$A/ HTTP/1.1
-                        Host: $A
-                        Expect: 100-Continue
-                        Content-Length: 0
-                        
+                        POST http://$A/ HTTP/1.1\r
+                        Host: $A\r
+                        Expect: 100-Continue\r
+                        Content-Length: 0\r
+                        \r
                         """;
                 }
                 request = request.replace("$A", authority);

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616BaseTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/rfcs/RFC2616BaseTest.java
@@ -190,22 +190,22 @@ public abstract class RFC2616BaseTest
         req2.append("Transfer-Encoding: chunked\n");
         req2.append("Content-Type: text/plain\n");
         req2.append("\n");
-        req2.append("2\n"); // 2 chars
-        req2.append("12\n");
-        req2.append("3\n"); // 3 chars
-        req2.append("345\n");
-        req2.append("0\n\n");
+        req2.append("2\r\n"); // 2 chars
+        req2.append("12\r\n");
+        req2.append("3\r\n"); // 3 chars
+        req2.append("345\r\n");
+        req2.append("0\r\n\r\n");
 
         req2.append("GET /echo/R2 HTTP/1.1\n");
         req2.append("Host: localhost\n");
         req2.append("Transfer-Encoding: chunked\n");
         req2.append("Content-Type: text/plain\n");
         req2.append("\n");
-        req2.append("4\n"); // 4 chars
-        req2.append("6789\n");
-        req2.append("5\n"); // 5 chars
-        req2.append("abcde\n");
-        req2.append("0\n\n"); // 0 chars
+        req2.append("4\r\n"); // 4 chars
+        req2.append("6789\r\n");
+        req2.append("5\r\n"); // 5 chars
+        req2.append("abcde\r\n");
+        req2.append("0\r\n\r\n"); // 0 chars
 
         req2.append("GET /echo/R3 HTTP/1.1\n");
         req2.append("Host: localhost\n");
@@ -243,22 +243,22 @@ public abstract class RFC2616BaseTest
         req3.append("Transfer-Encoding: chunked\n");
         req3.append("Content-Type: text/plain\n");
         req3.append("\n");
-        req3.append("3\n"); // 3 chars
-        req3.append("fgh\n");
-        req3.append("3\n"); // 3 chars
-        req3.append("Ijk\n");
-        req3.append("0\n\n"); // 0 chars
+        req3.append("3\r\n"); // 3 chars
+        req3.append("fgh\r\n");
+        req3.append("3\r\n"); // 3 chars
+        req3.append("Ijk\r\n");
+        req3.append("0\r\n\r\n"); // 0 chars
 
         req3.append("POST /echo/R2 HTTP/1.1\n");
         req3.append("Host: localhost\n");
         req3.append("Transfer-Encoding: chunked\n");
         req3.append("Content-Type: text/plain\n");
         req3.append("\n");
-        req3.append("4\n"); // 4 chars
-        req3.append("lmno\n");
-        req3.append("5\n"); // 5 chars
-        req3.append("Pqrst\n");
-        req3.append("0\n\n"); // 0 chars
+        req3.append("4\r\n"); // 4 chars
+        req3.append("lmno\r\n");
+        req3.append("5\r\n"); // 5 chars
+        req3.append("Pqrst\r\n");
+        req3.append("0\r\n\r\n"); // 0 chars
 
         req3.append("GET /echo/R3 HTTP/1.1\n");
         req3.append("Host: localhost\n");
@@ -297,11 +297,11 @@ public abstract class RFC2616BaseTest
         req4.append("Content-Type: text/plain\n");
         req4.append("Connection: keep-alive\n"); // keep-alive
         req4.append("\n");
-        req4.append("3\n"); // 3 chars
-        req4.append("123\n");
-        req4.append("3\n"); // 3 chars
-        req4.append("456\n");
-        req4.append("0\n\n"); // 0 chars
+        req4.append("3\r\n"); // 3 chars
+        req4.append("123\r\n");
+        req4.append("3\r\n"); // 3 chars
+        req4.append("456\r\n");
+        req4.append("0\r\n\r\n"); // 0 chars
 
         req4.append("GET /echo/R2 HTTP/1.1\n");
         req4.append("Host: localhost\n");


### PR DESCRIPTION
Backport changes for https://github.com/jetty/jetty.project/pull/15502 to `jetty-12.0.x`.