### PR TITLE
Issue #15514 - Avoid duplicate lifecycle failure logging

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/component/AbstractLifeCycle.java
@@ -294,8 +294,6 @@ public abstract class AbstractLifeCycle implements LifeCycle
     private void setFailed(Throwable th)
     {
         _state = State.FAILED;
-        if (LOG.isDebugEnabled())
-            LOG.warn("FAILED {}: {}", this, th, th);
         for (EventListener listener : _eventListeners)
         {
             if (listener instanceof Listener)

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/LifeCycleListenerTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/component/LifeCycleListenerTest.java
@@ -13,12 +13,12 @@
 
 package org.eclipse.jetty.util.component;
 
-import org.eclipse.jetty.logging.StacklessLogging;
 import org.eclipse.jetty.util.NanoTime;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -35,16 +35,10 @@ public class LifeCycleListenerTest
 
         lifecycle.setCause(cause);
 
-        try (StacklessLogging stackless = new StacklessLogging(AbstractLifeCycle.class))
-        {
-            lifecycle.start();
-            assertTrue(false);
-        }
-        catch (Exception e)
-        {
-            assertEquals(cause, e);
-            assertEquals(cause, listener.getCause());
-        }
+        Exception failure = assertThrows(Exception.class, lifecycle::start);
+        assertSame(cause, failure);
+        assertTrue(lifecycle.isFailed());
+        assertSame(cause, listener.getCause());
         lifecycle.setCause(null);
 
         lifecycle.start();
@@ -76,16 +70,10 @@ public class LifeCycleListenerTest
         lifecycle.start();
         lifecycle.setCause(cause);
 
-        try (StacklessLogging stackless = new StacklessLogging(AbstractLifeCycle.class))
-        {
-            lifecycle.stop();
-            assertTrue(false);
-        }
-        catch (Exception e)
-        {
-            assertEquals(cause, e);
-            assertEquals(cause, listener.getCause());
-        }
+        Exception failure = assertThrows(Exception.class, lifecycle::stop);
+        assertSame(cause, failure);
+        assertTrue(lifecycle.isFailed());
+        assertSame(cause, listener.getCause());
 
         lifecycle.setCause(null);
 


### PR DESCRIPTION
Removes the legacy failure WARN from `AbstractLifeCycle`, which was emitted only when DEBUG logging was enabled and could duplicate startup failure reporting.

Exceptions continue to propagate unchanged, the lifecycle still transitions to `FAILED`, and listeners receive the same failure cause. The lifecycle tests now assert those behaviors directly.

Fixes #15514.

### AI disclosure

I used OpenAI GPT-5.6 and Kimi K3 to assist with issue analysis and drafting the implementation and tests. I reviewed and verified the final changes.