### PR TITLE
Issue #15504 - Normalize empty Bouncy Castle ALPN protocol

### DIFF
--- a/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-client/src/main/java/org/eclipse/jetty/alpn/bouncycastle/client/BouncyCastleClientALPNProcessor.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-client/src/main/java/org/eclipse/jetty/alpn/bouncycastle/client/BouncyCastleClientALPNProcessor.java
@@ -76,7 +76,10 @@ public class BouncyCastleClientALPNProcessor implements ALPNProcessor.Client
                 String protocol = sslEngine.getApplicationProtocol();
                 if (LOG.isDebugEnabled())
                     LOG.debug("Selected {} for {}", protocol, alpnConnection);
-                alpnConnection.selected(protocol);
+                if (protocol != null && !protocol.isEmpty())
+                    alpnConnection.selected(protocol);
+                else
+                    alpnConnection.selected(null);
             }
             catch (Throwable e)
             {

--- a/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-server/src/test/java/org/eclipse/jetty/alpn/bouncycastle/server/BouncyCastleClientALPNTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-server/src/test/java/org/eclipse/jetty/alpn/bouncycastle/server/BouncyCastleClientALPNTest.java
@@ -13,9 +13,7 @@
 
 package org.eclipse.jetty.alpn.bouncycastle.server;
 
-import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.security.Security;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -36,6 +34,7 @@ import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.ServerConnector;
 import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.toolchain.test.MavenPaths;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
@@ -113,9 +112,8 @@ public class BouncyCastleClientALPNTest
 
     private void configureSslContextFactory(SslContextFactory sslContextFactory)
     {
-        Path path = Paths.get("src", "test", "resources");
-        File keys = path.resolve("keystore.p12").toFile();
-        sslContextFactory.setKeyStorePath(keys.getAbsolutePath());
+        Path ksPath = MavenPaths.findTestResourceFile("keystore.p12");
+        sslContextFactory.setKeyStorePath(ksPath);
         sslContextFactory.setKeyStorePassword("storepwd");
         sslContextFactory.setProvider(BouncyCastleJsseProvider.PROVIDER_NAME);
     }

--- a/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-server/src/test/java/org/eclipse/jetty/alpn/bouncycastle/server/BouncyCastleClientALPNTest.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-bouncycastle-server/src/test/java/org/eclipse/jetty/alpn/bouncycastle/server/BouncyCastleClientALPNTest.java
@@ -1,0 +1,122 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.alpn.bouncycastle.server;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Security;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.jsse.provider.BouncyCastleJsseProvider;
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.transport.HttpClientConnectionFactory;
+import org.eclipse.jetty.client.transport.HttpClientTransportDynamic;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpVersion;
+import org.eclipse.jetty.http2.client.HTTP2Client;
+import org.eclipse.jetty.http2.client.transport.ClientConnectionFactoryOverHTTP2;
+import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.HttpConnectionFactory;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.server.SslConnectionFactory;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class BouncyCastleClientALPNTest
+{
+    static
+    {
+        // Required to provide a SecureRandom with name "DEFAULT" used by the BC JSSE provider.
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
+        Security.insertProviderAt(new BouncyCastleJsseProvider(), 2);
+    }
+
+    private final Server server = new Server();
+
+    @AfterEach
+    public void stopServer() throws Exception
+    {
+        server.stop();
+    }
+
+    @Test
+    public void testHTTP11FallbackWithoutNegotiatedProtocol() throws Exception
+    {
+        HttpConnectionFactory http = new HttpConnectionFactory();
+        SslConnectionFactory ssl = new SslConnectionFactory(newServerSslContextFactory(), http.getProtocol());
+        ServerConnector connector = new ServerConnector(server, ssl, http);
+        connector.setPort(0);
+        server.addConnector(connector);
+        server.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback)
+            {
+                callback.succeeded();
+                return true;
+            }
+        });
+        server.start();
+
+        ClientConnector clientConnector = new ClientConnector();
+        clientConnector.setSslContextFactory(newClientSslContextFactory());
+        HTTP2Client http2Client = new HTTP2Client(clientConnector);
+        HttpClientTransportDynamic transport = new HttpClientTransportDynamic(
+            clientConnector,
+            HttpClientConnectionFactory.HTTP11,
+            new ClientConnectionFactoryOverHTTP2.HTTP2(http2Client));
+
+        try (HttpClient client = new HttpClient(transport))
+        {
+            client.start();
+            ContentResponse response = client.GET("https://localhost:" + connector.getLocalPort());
+            assertEquals(HttpStatus.OK_200, response.getStatus());
+            assertEquals(HttpVersion.HTTP_1_1, response.getVersion());
+        }
+    }
+
+    private SslContextFactory.Server newServerSslContextFactory()
+    {
+        SslContextFactory.Server sslContextFactory = new SslContextFactory.Server();
+        configureSslContextFactory(sslContextFactory);
+        return sslContextFactory;
+    }
+
+    private SslContextFactory.Client newClientSslContextFactory()
+    {
+        SslContextFactory.Client sslContextFactory = new SslContextFactory.Client();
+        configureSslContextFactory(sslContextFactory);
+        sslContextFactory.setEndpointIdentificationAlgorithm(null);
+        return sslContextFactory;
+    }
+
+    private void configureSslContextFactory(SslContextFactory sslContextFactory)
+    {
+        Path path = Paths.get("src", "test", "resources");
+        File keys = path.resolve("keystore.p12").toFile();
+        sslContextFactory.setKeyStorePath(keys.getAbsolutePath());
+        sslContextFactory.setKeyStorePassword("storepwd");
+        sslContextFactory.setProvider(BouncyCastleJsseProvider.PROVIDER_NAME);
+    }
+}

--- a/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/main/java/org/eclipse/jetty/alpn/conscrypt/client/ConscryptClientALPNProcessor.java
+++ b/jetty-core/jetty-alpn/jetty-alpn-conscrypt-client/src/main/java/org/eclipse/jetty/alpn/conscrypt/client/ConscryptClientALPNProcessor.java
@@ -86,7 +86,10 @@ public class ConscryptClientALPNProcessor implements ALPNProcessor.Client
                 String protocol = Conscrypt.getApplicationProtocol(sslEngine);
                 if (LOG.isDebugEnabled())
                     LOG.debug("Selected {} for {}", protocol, alpnConnection);
-                alpnConnection.selected(protocol);
+                if (protocol != null && !protocol.isEmpty())
+                    alpnConnection.selected(protocol);
+                else
+                    alpnConnection.selected(null);
             }
             catch (Throwable e)
             {


### PR DESCRIPTION
Normalize empty application protocol values in the Bouncy Castle and Conscrypt client ALPN processors to `null`, matching the JDK ALPN processor, so dynamic transports use their configured fallback.

Adds a local BCJSSE integration test that verifies a dynamic HTTP/1.1 and HTTP/2 client falls back to HTTP/1.1 when the server does not negotiate ALPN.

Fixes #15504.

Testing:

- `mvn -pl jetty-core/jetty-alpn/jetty-alpn-bouncycastle-server -am -DskipITs -Dtest="BouncyCastle*Test" -Dsurefire.failIfNoSpecifiedTests=false package`
- `mvn -pl jetty-core/jetty-alpn/jetty-alpn-conscrypt-server -am -DskipITs -Dtest=ConscryptHTTP2ServerTest -Dsurefire.failIfNoSpecifiedTests=false package`
- A broader `verify` attempt stopped before the ALPN modules because the external `UrlResourceFactoryTest.testHttps` received HTTP 500 from `webtide.com`.