### PR TITLE
[Backport] Use `IncludeExclude` instead for Host filtering

### DIFF
--- a/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
+++ b/jetty-core/jetty-server/src/main/java/org/eclipse/jetty/server/handler/ConnectHandler.java
@@ -20,7 +20,6 @@ import java.nio.ByteBuffer;
 import java.nio.channels.SelectableChannel;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -45,8 +44,10 @@ import org.eclipse.jetty.server.HttpStream;
 import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.TunnelSupport;
+import org.eclipse.jetty.util.AsciiLowerCaseSet;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.HostPort;
+import org.eclipse.jetty.util.IncludeExclude;
 import org.eclipse.jetty.util.IteratingCallback;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.thread.Scheduler;
@@ -60,8 +61,7 @@ public class ConnectHandler extends Handler.Wrapper
 {
     private static final Logger LOG = LoggerFactory.getLogger(ConnectHandler.class);
 
-    private final Set<String> whiteList = new HashSet<>();
-    private final Set<String> blackList = new HashSet<>();
+    private final IncludeExclude<String> hosts = new IncludeExclude<>(AsciiLowerCaseSet.class);
     private Executor executor;
     private Scheduler scheduler;
     private ByteBufferPool bufferPool;
@@ -437,14 +437,38 @@ public class ConnectHandler extends Handler.Wrapper
         endPoint.write(callback, buffer);
     }
 
-    public Set<String> getWhiteListHosts()
+    /**
+     * Get the {@link IncludeExclude} used for host whitelists and blacklists
+     *
+     * @return the {@link IncludeExclude} used for host matching
+     */
+    public IncludeExclude<String> getHostIncludeExclude()
     {
-        return whiteList;
+        return hosts;
     }
 
+    /**
+     * The set of whitelisted hosts.
+     *
+     * @return the set of whitelisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#include(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
+    public Set<String> getWhiteListHosts()
+    {
+        return hosts.getIncluded();
+    }
+
+    /**
+     * The set of blacklisted hosts.
+     *
+     * @return the set of blacklisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#exclude(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
     public Set<String> getBlackListHosts()
     {
-        return blackList;
+        return hosts.getExcluded();
     }
 
     /**
@@ -457,25 +481,10 @@ public class ConnectHandler extends Handler.Wrapper
     public boolean validateDestination(String host, int port)
     {
         String hostPort = host + ":" + port;
-        if (!whiteList.isEmpty())
-        {
-            if (!whiteList.contains(hostPort))
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Host {}:{} not whitelisted", host, port);
-                return false;
-            }
-        }
-        if (!blackList.isEmpty())
-        {
-            if (blackList.contains(hostPort))
-            {
-                if (LOG.isDebugEnabled())
-                    LOG.debug("Host {}:{} blacklisted", host, port);
-                return false;
-            }
-        }
-        return true;
+        boolean allowed = hosts.test(hostPort);
+        if (LOG.isDebugEnabled())
+            LOG.debug("Host {} is {}", hostPort, allowed ? "allowed" : "denied");
+        return allowed;
     }
 
     protected class ConnectManager extends SelectorManager

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ConnectHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ConnectHandlerTest.java
@@ -202,7 +202,7 @@ public class ConnectHandlerTest extends AbstractConnectHandlerTest
     {
         int port = serverConnector.getLocalPort();
         String hostPort = "127.0.0.1:" + port;
-        connectHandler.getWhiteListHosts().add(hostPort);
+        connectHandler.getHostIncludeExclude().include(hostPort);
 
         // Try with the wrong host
         String request =
@@ -265,7 +265,7 @@ public class ConnectHandlerTest extends AbstractConnectHandlerTest
     {
         int port = serverConnector.getLocalPort();
         String hostPort = "localhost:" + port;
-        connectHandler.getBlackListHosts().add(hostPort);
+        connectHandler.getHostIncludeExclude().exclude(hostPort);
 
         // Try with the wrong host
         String request =

--- a/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
+++ b/jetty-core/jetty-server/src/test/java/org/eclipse/jetty/server/handler/ContextHandlerTest.java
@@ -95,6 +95,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -656,8 +657,25 @@ public class ContextHandlerTest
         assertThat(stream.getResponse().getStatus(), equalTo(200));
     }
 
-    @Test
-    public void testVirtualHost() throws Exception
+    public static Stream<Arguments> virtualHostCases()
+    {
+        return Stream.of(
+            Arguments.of("/ctx", null, 404),
+            Arguments.of("http://localhost/ctx/", null, 404),
+            Arguments.of("http://nope.example.com/ctx/", null, 404),
+            Arguments.of("http://example.com/ctx/", null, 200),
+            Arguments.of("http://EXAMPLE.com/ctx/", null, 200),
+            Arguments.of("http://wild.org/ctx/", null, 404),
+            Arguments.of("http://match.wild.org/ctx/", null, 200),
+            Arguments.of("http://acme.com/ctx/", null, 404),
+            Arguments.of("http://ACME.com/ctx/", "special", 200),
+            Arguments.of("http://acme.com/ctx/", "special", 200)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("virtualHostCases")
+    public void testVirtualHost(String requestedTarget, String requestedConnectorName, int expectedStatus) throws Exception
     {
         HelloHandler helloHandler = new HelloHandler();
         _contextHandler.setHandler(helloHandler);
@@ -681,50 +699,15 @@ public class ContextHandlerTest
             }
         };
 
+        connectorName.set(requestedConnectorName);
         ConnectionMetaData connectionMetaData = new MockConnectionMetaData(connector);
         HttpChannel channel = new HttpChannelState(connectionMetaData);
         HttpFields fields = HttpFields.build().asImmutable();
 
         MockHttpStream stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("/ctx/"), HttpVersion.HTTP_1_0, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(404));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://localhost/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(404));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://nope.example.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(404));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://example.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(200));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://wild.org/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(404));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://match.wild.org/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(200));
-
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://acme.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(404));
-
-        connectorName.set("special");
-        stream = new MockHttpStream(channel);
-        channel.onRequest(new MetaData.Request("GET", HttpURI.from("http://acme.com/ctx/"), HttpVersion.HTTP_1_1, fields, 0)).run();
-        assertThat(stream.isComplete(), is(true));
-        assertThat(stream.getResponse().getStatus(), equalTo(200));
+        channel.onRequest(new MetaData.Request("GET", HttpURI.from(requestedTarget), HttpVersion.HTTP_1_0, fields, 0)).run();
+        assertTrue(stream.isComplete(), "isComplete : " + requestedTarget);
+        assertEquals(expectedStatus, stream.getResponse().getStatus(), "status: " + requestedTarget);
     }
 
     @Test

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/HostPort.java
@@ -80,7 +80,7 @@ public class HostPort
 
         if (authority.isEmpty())
         {
-            _host = authority;
+            _host = "";
             _port = URIUtil.UNDEFINED_PORT;
             return;
         }
@@ -299,8 +299,11 @@ public class HostPort
      */
     public static String normalizeHost(String host)
     {
+        if (host == null)
+            return null;
+
         // if it is normalized IPv6 or could not be IPv6, return
-        if (host == null || host.isEmpty() || host.charAt(0) == '[' || host.indexOf(':') < 0)
+        if (host.isEmpty() || host.charAt(0) == '[' || host.indexOf(':') < 0)
             return host;
 
         // normalize with [ ]

--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/HostPortTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class HostPortTest
@@ -138,5 +139,26 @@ public class HostPortTest
         HostPort hostPort = HostPort.unsafe(rawAuthority);
         assertThat("(unsafe) Host for: " + rawAuthority, hostPort.getHost(), is(expectedHost));
         assertThat("(unsafe) Port for: " + rawAuthority, hostPort.getPort(), is(expectedPort));
+    }
+
+    public static Stream<Arguments> normalizeHostProvider()
+    {
+        return Stream.of(
+            Arguments.of("localhost", "localhost"),
+            Arguments.of("demo.example.org", "demo.example.org"),
+            Arguments.of("127.0.0.1", "127.0.0.1"),
+            Arguments.of("::1", "[::1]"),
+            Arguments.of("[::1]", "[::1]"),
+            Arguments.of("::FFFF:129.144.52.38", "[::FFFF:129.144.52.38]"),
+            Arguments.of("[::FFFF:129.144.52.38]", "[::FFFF:129.144.52.38]")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("normalizeHostProvider")
+    public void testNormalizeHost(String rawHost, String expectedHost)
+    {
+        String actualHost = HostPort.normalizeHost(rawHost);
+        assertEquals(expectedHost, actualHost);
     }
 }

--- a/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ProxyServer.java
+++ b/jetty-ee10/jetty-ee10-demos/jetty-ee10-demo-embedded/src/main/java/org/eclipse/jetty/ee10/demos/ProxyServer.java
@@ -33,6 +33,8 @@ public class ProxyServer
 
         // Setup proxy handler to handle CONNECT methods
         ConnectHandler proxy = new ConnectHandler();
+        // proxy.getHostIncludeExclude().include("mail.google.com");
+        // proxy.getHostIncludeExclude().include("www.google.com");
         server.setHandler(proxy);
 
         // Setup proxy servlet

--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
@@ -48,6 +48,8 @@ import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.AsciiLowerCaseSet;
+import org.eclipse.jetty.util.IncludeExclude;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -95,8 +97,7 @@ public abstract class AbstractProxyServlet extends HttpServlet
         "upgrade"
     );
 
-    private final Set<String> _whiteList = new HashSet<>();
-    private final Set<String> _blackList = new HashSet<>();
+    private final IncludeExclude<String> _hosts = new IncludeExclude<>(AsciiLowerCaseSet.class);
     protected Logger _log;
     private boolean _preserveHost;
     private String _hostHeader;
@@ -128,11 +129,11 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
             String whiteList = config.getInitParameter("whiteList");
             if (whiteList != null)
-                getWhiteListHosts().addAll(parseList(whiteList));
+                parseList(whiteList).forEach(hostPort -> getHostIncludeExclude().include(hostPort));
 
             String blackList = config.getInitParameter("blackList");
             if (blackList != null)
-                getBlackListHosts().addAll(parseList(blackList));
+                parseList(blackList).forEach(hostPort -> getHostIncludeExclude().exclude(hostPort));
         }
         catch (Exception e)
         {
@@ -186,14 +187,38 @@ public abstract class AbstractProxyServlet extends HttpServlet
         this._timeout = timeout;
     }
 
-    public Set<String> getWhiteListHosts()
+    /**
+     * Get the {@link IncludeExclude} used for host whitelists and blacklists
+     *
+     * @return the {@link IncludeExclude} used for host matching
+     */
+    public IncludeExclude<String> getHostIncludeExclude()
     {
-        return _whiteList;
+        return _hosts;
     }
 
+    /**
+     * The set of whitelisted hosts.
+     *
+     * @return the set of whitelisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#include(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
+    public Set<String> getWhiteListHosts()
+    {
+        return _hosts.getIncluded();
+    }
+
+    /**
+     * The set of blacklisted hosts.
+     *
+     * @return the set of blacklisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#exclude(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
     public Set<String> getBlackListHosts()
     {
-        return _blackList;
+        return _hosts.getExcluded();
     }
 
     /**
@@ -418,25 +443,10 @@ public abstract class AbstractProxyServlet extends HttpServlet
     public boolean validateDestination(String host, int port)
     {
         String hostPort = host + ":" + port;
-        if (!_whiteList.isEmpty())
-        {
-            if (!_whiteList.contains(hostPort))
-            {
-                if (_log.isDebugEnabled())
-                    _log.debug("Host {}:{} not whitelisted", host, port);
-                return false;
-            }
-        }
-        if (!_blackList.isEmpty())
-        {
-            if (_blackList.contains(hostPort))
-            {
-                if (_log.isDebugEnabled())
-                    _log.debug("Host {}:{} blacklisted", host, port);
-                return false;
-            }
-        }
-        return true;
+        boolean allowed = _hosts.test(hostPort);
+        if (_log.isDebugEnabled())
+            _log.debug("Host {} is {}", hostPort, allowed ? "allowed" : "denied");
+        return allowed;
     }
 
     protected String rewriteTarget(HttpServletRequest clientRequest)

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServer.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServer.java
@@ -30,8 +30,8 @@ public class ProxyServer
 
         // Setup proxy handler to handle CONNECT methods
         ConnectHandler proxy = new ConnectHandler();
-//        proxy.setWhite(new String[]{"mail.google.com"});
-//        proxy.addWhitelistHost("www.google.com");
+        // proxy.getHostIncludeExclude().include("mail.google.com");
+        // proxy.getHostIncludeExclude().include("www.google.com");
         server.setHandler(proxy);
 
         // Setup proxy servlet

--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
@@ -123,7 +123,7 @@ public class DoSFilter implements Filter
     private static final Pattern IPv4_PATTERN = Pattern.compile(IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP);
     private static final String IPv6_GROUP = "(\\p{XDigit}{1,4})";
     private static final Pattern IPv6_PATTERN = Pattern.compile(IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP);
-    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private static final String __TRACKER = "DoSFilter.Tracker";
     private static final String __THROTTLED = "DoSFilter.Throttled";
@@ -585,7 +585,7 @@ public class DoSFilter implements Filter
             }
             else
             {
-                if (address.equals(candidate))
+                if (address.equalsIgnoreCase(candidate))
                     return true;
             }
         }

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
@@ -48,6 +48,8 @@ import org.eclipse.jetty.http.HttpHeaderValue;
 import org.eclipse.jetty.http.HttpScheme;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.io.ClientConnector;
+import org.eclipse.jetty.util.AsciiLowerCaseSet;
+import org.eclipse.jetty.util.IncludeExclude;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
@@ -96,8 +98,7 @@ public abstract class AbstractProxyServlet extends HttpServlet
         "upgrade"
     );
 
-    private final Set<String> _whiteList = new HashSet<>();
-    private final Set<String> _blackList = new HashSet<>();
+    private final IncludeExclude<String> _hosts = new IncludeExclude<>(AsciiLowerCaseSet.class);
     protected Logger _log;
     private boolean _preserveHost;
     private String _hostHeader;
@@ -129,11 +130,11 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
             String whiteList = config.getInitParameter("whiteList");
             if (whiteList != null)
-                getWhiteListHosts().addAll(parseList(whiteList));
+                parseList(whiteList).forEach(hostPort -> getHostIncludeExclude().include(hostPort));
 
             String blackList = config.getInitParameter("blackList");
             if (blackList != null)
-                getBlackListHosts().addAll(parseList(blackList));
+                parseList(blackList).forEach(hostPort -> getHostIncludeExclude().exclude(hostPort));
         }
         catch (Exception e)
         {
@@ -189,14 +190,38 @@ public abstract class AbstractProxyServlet extends HttpServlet
         this._timeout = timeout;
     }
 
-    public Set<String> getWhiteListHosts()
+    /**
+     * Get the {@link IncludeExclude} used for host whitelists and blacklists
+     *
+     * @return the {@link IncludeExclude} used for host matching
+     */
+    public IncludeExclude<String> getHostIncludeExclude()
     {
-        return _whiteList;
+        return _hosts;
     }
 
+    /**
+     * The set of whitelisted hosts.
+     *
+     * @return the set of whitelisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#include(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
+    public Set<String> getWhiteListHosts()
+    {
+        return _hosts.getIncluded();
+    }
+
+    /**
+     * The set of blacklisted hosts.
+     *
+     * @return the set of blacklisted hosts.
+     * @deprecated use {@link #getHostIncludeExclude()} and its {@link IncludeExclude#exclude(Object)} method instead.
+     */
+    @Deprecated(since = "12.0.39", forRemoval = true)
     public Set<String> getBlackListHosts()
     {
-        return _blackList;
+        return _hosts.getExcluded();
     }
 
     /**
@@ -404,7 +429,7 @@ public abstract class AbstractProxyServlet extends HttpServlet
         for (String host : hosts)
         {
             host = host.trim();
-            if (host.length() == 0)
+            if (host.isEmpty())
                 continue;
             result.add(host);
         }
@@ -421,25 +446,10 @@ public abstract class AbstractProxyServlet extends HttpServlet
     public boolean validateDestination(String host, int port)
     {
         String hostPort = host + ":" + port;
-        if (!_whiteList.isEmpty())
-        {
-            if (!_whiteList.contains(hostPort))
-            {
-                if (_log.isDebugEnabled())
-                    _log.debug("Host {}:{} not whitelisted", host, port);
-                return false;
-            }
-        }
-        if (!_blackList.isEmpty())
-        {
-            if (_blackList.contains(hostPort))
-            {
-                if (_log.isDebugEnabled())
-                    _log.debug("Host {}:{} blacklisted", host, port);
-                return false;
-            }
-        }
-        return true;
+        boolean allowed = _hosts.test(hostPort);
+        if (_log.isDebugEnabled())
+            _log.debug("Host {} is {}", hostPort, allowed ? "allowed" : "denied");
+        return allowed;
     }
 
     protected String rewriteTarget(HttpServletRequest clientRequest)

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServer.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServer.java
@@ -30,15 +30,15 @@ public class ProxyServer
 
         // Setup proxy handler to handle CONNECT methods
         ConnectHandler proxy = new ConnectHandler();
-//        proxy.setWhite(new String[]{"mail.google.com"});
-//        proxy.addWhitelistHost("www.google.com");
+        // proxy.getHostIncludeExclude().include("mail.google.com");
+        // proxy.getHostIncludeExclude().include("www.google.com");
         server.setHandler(proxy);
 
         // Setup proxy servlet
         ServletContextHandler context = new ServletContextHandler(proxy, "/", ServletContextHandler.SESSIONS);
         ServletHolder proxyServlet = new ServletHolder(ProxyServlet.class);
-//        proxyServlet.setInitParameter("whiteList", "google.com, www.eclipse.org, localhost");
-//        proxyServlet.setInitParameter("blackList", "google.com/calendar/*, www.eclipse.org/committers/");
+        // proxyServlet.setInitParameter("whiteList", "google.com, www.eclipse.org, localhost");
+        // proxyServlet.setInitParameter("blackList", "google.com/calendar/*, www.eclipse.org/committers/");
         context.addServlet(proxyServlet, "/*");
 
         server.start();

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
@@ -123,7 +123,7 @@ public class DoSFilter implements Filter
     private static final Pattern IPv4_PATTERN = Pattern.compile(IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP);
     private static final String IPv6_GROUP = "(\\p{XDigit}{1,4})";
     private static final Pattern IPv6_PATTERN = Pattern.compile(IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP);
-    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private static final String __TRACKER = "DoSFilter.Tracker";
     private static final String __THROTTLED = "DoSFilter.Throttled";
@@ -585,7 +585,7 @@ public class DoSFilter implements Filter
             }
             else
             {
-                if (address.equals(candidate))
+                if (address.equalsIgnoreCase(candidate))
                     return true;
             }
         }


### PR DESCRIPTION
This is a backport of https://github.com/jetty/jetty.project/pull/15495 to `jetty-12.0.x`