### PR TITLE
Fixes #15548 - Replace/drop filtered proxy response headers

### DIFF
--- a/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/main/java/org/eclipse/jetty/ee10/proxy/AbstractProxyServlet.java
@@ -750,7 +750,14 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected HttpField filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, HttpField field)
     {
-        return field.withValue(filterServerResponseHeader(clientRequest, serverResponse, field.getName(), field.getValue()));
+        // HttpField.withValue() appends; replace or drop the value instead.
+        String existingValue = field.getValue();
+        String filteredValue = filterServerResponseHeader(clientRequest, serverResponse, field.getName(), existingValue);
+        if (filteredValue == null)
+            return null;
+        if (filteredValue.equals(existingValue))
+            return field;
+        return new HttpField(field.getHeader(), field.getName(), filteredValue);
     }
 
     /**

--- a/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
+++ b/jetty-ee10/jetty-ee10-proxy/src/test/java/org/eclipse/jetty/ee10/proxy/ProxyServletTest.java
@@ -114,6 +114,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1879,5 +1881,109 @@ public class ProxyServletTest
             .map(HttpField::getValue)
             .toList();
         assertEquals(List.of("resp1", "resp2"), responseValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("impls")
+    public void testFilterServerResponseHeaderReplacesAndDrops(Class<? extends ProxyServlet> proxyServletClass) throws Exception
+    {
+        // Override of the deprecated String filter must replace (not append) and honor null (see #15548).
+        final String originalLocation = "http://backend.example/redirect";
+        final String filteredLocation = "http://localhost/proxy";
+        final String keepHeader = "X-Keep";
+        final String keepValue = "keep-me";
+
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(HttpServletResponse.SC_FOUND);
+                resp.setHeader(HttpHeader.LOCATION.asString(), originalLocation);
+                resp.setHeader(HttpHeader.DATE.asString(), "Wed, 01 Jan 2020 00:00:00 GMT");
+                resp.setHeader(keepHeader, keepValue);
+            }
+        });
+        startProxy(newFilteringProxyServlet(proxyServletClass, filteredLocation), new HashMap<>());
+        startClient();
+        client.setFollowRedirects(false);
+
+        ContentResponse response = client.newRequest("localhost", serverConnector.getLocalPort())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.FOUND_302, response.getStatus());
+        assertEquals(List.of(filteredLocation), response.getHeaders().getValuesList(HttpHeader.LOCATION));
+        assertFalse(response.getHeaders().contains(HttpHeader.DATE));
+        assertEquals(keepValue, response.getHeaders().get(keepHeader));
+    }
+
+    @Test
+    public void testFilterServerResponseHeaderHttpFieldOverload()
+    {
+        final String filteredLocation = "http://localhost/proxy";
+        AbstractProxyServlet servlet = newFilteringProxyServlet(ProxyServlet.class, filteredLocation);
+
+        HttpField location = new HttpField(HttpHeader.LOCATION, "http://backend.example/redirect");
+        HttpField filtered = servlet.filterServerResponseHeader(null, null, location);
+        assertEquals(filteredLocation, filtered.getValue());
+        assertEquals(List.of(filteredLocation), filtered.getValueList());
+
+        HttpField date = new HttpField(HttpHeader.DATE, "Wed, 01 Jan 2020 00:00:00 GMT");
+        assertNull(servlet.filterServerResponseHeader(null, null, date));
+
+        HttpField keep = new HttpField("X-Keep", "keep-me");
+        assertSame(keep, servlet.filterServerResponseHeader(null, null, keep));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static AbstractProxyServlet newFilteringProxyServlet(Class<?> proxyServletClass, String filteredLocation)
+    {
+        if (proxyServletClass == ProxyServlet.class)
+        {
+            return new ProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncProxyServlet.class)
+        {
+            return new AsyncProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncMiddleManServlet.class)
+        {
+            return new AsyncMiddleManServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        throw new IllegalArgumentException(proxyServletClass.getName());
     }
 }

--- a/jetty-ee11/jetty-ee11-proxy/src/main/java/org/eclipse/jetty/ee11/proxy/AbstractProxyServlet.java
+++ b/jetty-ee11/jetty-ee11-proxy/src/main/java/org/eclipse/jetty/ee11/proxy/AbstractProxyServlet.java
@@ -750,7 +750,14 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected HttpField filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, HttpField field)
     {
-        return field.withValue(filterServerResponseHeader(clientRequest, serverResponse, field.getName(), field.getValue()));
+        // HttpField.withValue() appends; replace or drop the value instead.
+        String existingValue = field.getValue();
+        String filteredValue = filterServerResponseHeader(clientRequest, serverResponse, field.getName(), existingValue);
+        if (filteredValue == null)
+            return null;
+        if (filteredValue.equals(existingValue))
+            return field;
+        return new HttpField(field.getHeader(), field.getName(), filteredValue);
     }
 
     /**

--- a/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/ProxyServletTest.java
+++ b/jetty-ee11/jetty-ee11-proxy/src/test/java/org/eclipse/jetty/ee11/proxy/ProxyServletTest.java
@@ -115,6 +115,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1880,5 +1882,109 @@ public class ProxyServletTest
             .map(HttpField::getValue)
             .toList();
         assertEquals(List.of("resp1", "resp2"), responseValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("impls")
+    public void testFilterServerResponseHeaderReplacesAndDrops(Class<? extends ProxyServlet> proxyServletClass) throws Exception
+    {
+        // Override of the deprecated String filter must replace (not append) and honor null (see #15548).
+        final String originalLocation = "http://backend.example/redirect";
+        final String filteredLocation = "http://localhost/proxy";
+        final String keepHeader = "X-Keep";
+        final String keepValue = "keep-me";
+
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(HttpServletResponse.SC_FOUND);
+                resp.setHeader(HttpHeader.LOCATION.asString(), originalLocation);
+                resp.setHeader(HttpHeader.DATE.asString(), "Wed, 01 Jan 2020 00:00:00 GMT");
+                resp.setHeader(keepHeader, keepValue);
+            }
+        });
+        startProxy(newFilteringProxyServlet(proxyServletClass, filteredLocation), new HashMap<>());
+        startClient();
+        client.setFollowRedirects(false);
+
+        ContentResponse response = client.newRequest("localhost", serverConnector.getLocalPort())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.FOUND_302, response.getStatus());
+        assertEquals(List.of(filteredLocation), response.getHeaders().getValuesList(HttpHeader.LOCATION));
+        assertFalse(response.getHeaders().contains(HttpHeader.DATE));
+        assertEquals(keepValue, response.getHeaders().get(keepHeader));
+    }
+
+    @Test
+    public void testFilterServerResponseHeaderHttpFieldOverload()
+    {
+        final String filteredLocation = "http://localhost/proxy";
+        AbstractProxyServlet servlet = newFilteringProxyServlet(ProxyServlet.class, filteredLocation);
+
+        HttpField location = new HttpField(HttpHeader.LOCATION, "http://backend.example/redirect");
+        HttpField filtered = servlet.filterServerResponseHeader(null, null, location);
+        assertEquals(filteredLocation, filtered.getValue());
+        assertEquals(List.of(filteredLocation), filtered.getValueList());
+
+        HttpField date = new HttpField(HttpHeader.DATE, "Wed, 01 Jan 2020 00:00:00 GMT");
+        assertNull(servlet.filterServerResponseHeader(null, null, date));
+
+        HttpField keep = new HttpField("X-Keep", "keep-me");
+        assertSame(keep, servlet.filterServerResponseHeader(null, null, keep));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static AbstractProxyServlet newFilteringProxyServlet(Class<?> proxyServletClass, String filteredLocation)
+    {
+        if (proxyServletClass == ProxyServlet.class)
+        {
+            return new ProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncProxyServlet.class)
+        {
+            return new AsyncProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncMiddleManServlet.class)
+        {
+            return new AsyncMiddleManServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        throw new IllegalArgumentException(proxyServletClass.getName());
     }
 }

--- a/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/main/java/org/eclipse/jetty/ee9/proxy/AbstractProxyServlet.java
@@ -733,7 +733,14 @@ public abstract class AbstractProxyServlet extends HttpServlet
 
     protected HttpField filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, HttpField field)
     {
-        return field.withValue(filterServerResponseHeader(clientRequest, serverResponse, field.getName(), field.getValue()));
+        // HttpField.withValue() appends; replace or drop the value instead.
+        String existingValue = field.getValue();
+        String filteredValue = filterServerResponseHeader(clientRequest, serverResponse, field.getName(), existingValue);
+        if (filteredValue == null)
+            return null;
+        if (filteredValue.equals(existingValue))
+            return field;
+        return new HttpField(field.getHeader(), field.getName(), filteredValue);
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
+++ b/jetty-ee9/jetty-ee9-proxy/src/test/java/org/eclipse/jetty/ee9/proxy/ProxyServletTest.java
@@ -113,6 +113,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -1821,5 +1823,109 @@ public class ProxyServletTest
             .map(HttpField::getValue)
             .toList();
         assertEquals(List.of("resp1", "resp2"), responseValues);
+    }
+
+    @ParameterizedTest
+    @MethodSource("impls")
+    public void testFilterServerResponseHeaderReplacesAndDrops(Class<? extends ProxyServlet> proxyServletClass) throws Exception
+    {
+        // Override of the deprecated String filter must replace (not append) and honor null (see #15548).
+        final String originalLocation = "http://backend.example/redirect";
+        final String filteredLocation = "http://localhost/proxy";
+        final String keepHeader = "X-Keep";
+        final String keepValue = "keep-me";
+
+        startServer(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(HttpServletResponse.SC_FOUND);
+                resp.setHeader(HttpHeader.LOCATION.asString(), originalLocation);
+                resp.setHeader(HttpHeader.DATE.asString(), "Wed, 01 Jan 2020 00:00:00 GMT");
+                resp.setHeader(keepHeader, keepValue);
+            }
+        });
+        startProxy(newFilteringProxyServlet(proxyServletClass, filteredLocation), new HashMap<>());
+        startClient();
+        client.setFollowRedirects(false);
+
+        ContentResponse response = client.newRequest("localhost", serverConnector.getLocalPort())
+            .timeout(5, TimeUnit.SECONDS)
+            .send();
+
+        assertEquals(HttpStatus.FOUND_302, response.getStatus());
+        assertEquals(List.of(filteredLocation), response.getHeaders().getValuesList(HttpHeader.LOCATION));
+        assertFalse(response.getHeaders().contains(HttpHeader.DATE));
+        assertEquals(keepValue, response.getHeaders().get(keepHeader));
+    }
+
+    @Test
+    public void testFilterServerResponseHeaderHttpFieldOverload()
+    {
+        final String filteredLocation = "http://localhost/proxy";
+        AbstractProxyServlet servlet = newFilteringProxyServlet(ProxyServlet.class, filteredLocation);
+
+        HttpField location = new HttpField(HttpHeader.LOCATION, "http://backend.example/redirect");
+        HttpField filtered = servlet.filterServerResponseHeader(null, null, location);
+        assertEquals(filteredLocation, filtered.getValue());
+        assertEquals(List.of(filteredLocation), filtered.getValueList());
+
+        HttpField date = new HttpField(HttpHeader.DATE, "Wed, 01 Jan 2020 00:00:00 GMT");
+        assertNull(servlet.filterServerResponseHeader(null, null, date));
+
+        HttpField keep = new HttpField("X-Keep", "keep-me");
+        assertSame(keep, servlet.filterServerResponseHeader(null, null, keep));
+    }
+
+    @SuppressWarnings("deprecation")
+    private static AbstractProxyServlet newFilteringProxyServlet(Class<?> proxyServletClass, String filteredLocation)
+    {
+        if (proxyServletClass == ProxyServlet.class)
+        {
+            return new ProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncProxyServlet.class)
+        {
+            return new AsyncProxyServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        if (proxyServletClass == AsyncMiddleManServlet.class)
+        {
+            return new AsyncMiddleManServlet()
+            {
+                @Override
+                protected String filterServerResponseHeader(HttpServletRequest clientRequest, Response serverResponse, String headerName, String headerValue)
+                {
+                    if (HttpHeader.LOCATION.is(headerName))
+                        return filteredLocation;
+                    if (HttpHeader.DATE.is(headerName))
+                        return null;
+                    return super.filterServerResponseHeader(clientRequest, serverResponse, headerName, headerValue);
+                }
+            };
+        }
+        throw new IllegalArgumentException(proxyServletClass.getName());
     }
 }


### PR DESCRIPTION
## Fixes

Fixes #15548

## Problem

In Jetty 12.1.12, `AbstractProxyServlet.filterServerResponseHeader(... HttpField)` was added and implemented as:

```java
return field.withValue(filterServerResponseHeader(..., field.getValue()));
```

`HttpField.withValue()` **appends** a value (CSV-style) rather than replacing it. When subclasses override the deprecated `String` filter to change a header (e.g. `Location`) or return `null` (drop the header), the client sees the original value plus the filtered value (or a literal `"null"`), instead of a single replaced/dropped header.

## Fix

In ee9 / ee10 / ee11 `AbstractProxyServlet`, call the string filter and:

- return `null` when the filtered value is `null` (drop header)
- return the original field when unchanged
- otherwise return a new `HttpField` with the filtered value (replace)

This matches the first suggested implementation in the issue.

## Tests

- Unit: `testFilterServerResponseHeaderHttpFieldOverload` — replace / null / unchanged
- Integration: `testFilterServerResponseHeaderReplacesAndDrops` — parameterized over `ProxyServlet`, `AsyncProxyServlet`, `AsyncMiddleManServlet`

Verified locally (Temurin 21):

```
mvn -pl jetty-ee11/jetty-ee11-proxy test -Dtest=ProxyServletTest#testFilterServerResponseHeader*
mvn -pl jetty-ee10/jetty-ee10-proxy test -Dtest=ProxyServletTest#testFilterServerResponseHeader*
mvn -pl jetty-ee9/jetty-ee9-proxy  test -Dtest=ProxyServletTest#testFilterServerResponseHeader*
```

All: Tests run: 4, Failures: 0 for each module.

## Notes

- Eclipse ECA: contributor will complete/sign as required for merge.
- Signed-off-by present on commit.