### PR TITLE
Backport of update to `amazoncorretto:17.0.20-al2023` image for testing

### DIFF
--- a/jetty-home/src/main/resources/bin/jetty.sh
+++ b/jetty-home/src/main/resources/bin/jetty.sh
@@ -490,7 +490,7 @@ fi
 ##################################################
 if [ -z "$JAVA" ]
 then
-  JAVA=$(which java)
+  JAVA=$(type -p java)
 fi
 
 if [ -z "$JAVA" ]

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto17.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/ImageOSAmazonCorretto17.java
@@ -15,10 +15,10 @@ package org.eclipse.jetty.tests.distribution.jettysh;
 
 /**
  * An OS Image of linux specific for running on Amazon AWS.
- * This is based on Amazon Linux 2 (which is based on Alpine 3).
+ * This is based on Amazon Linux 2023.
  * Amazon Corretto JDK 17 is installed.
  * This image does NOT come with start-stop-daemon installed.
- * Instead of apt, it uses yum (the redhat package manager)
+ * Instead of apt, it uses dnf (the redhat package manager)
  */
 public class ImageOSAmazonCorretto17 extends ImageOS
 {
@@ -27,16 +27,24 @@ public class ImageOSAmazonCorretto17 extends ImageOS
         super("amazoncorretto-jdk17-jetty12",
             builder ->
                 builder
-                    .from("amazoncorretto:17")
-                    .run("yum update -y ; " +
-                        "yum install -y curl tar gzip vim shadow-utils net-tools")
+                    .from("amazoncorretto:17.0.20-al2023")
+                    // Notes: amazoncorretto now uses dnf, not yum
+                    .run("dnf update -y ; " +
+                        // Notes:
+                        // `curl-minimal` ships with `amazoncorretto:17-al2023`.
+                        // `findutils` provides `xargs`, which is needed by `jetty.sh`.
+                        // `tar` and `gzip` needed by this Dockerfile for managing the jetty-home tarball.
+                        // `shadow-utils` is needed for `useradd` (done by ImageUserChange)
+                        "dnf install -y findutils tar gzip shadow-utils")
                     .env("TEST_DIR", "/var/test")
                     .env("JETTY_HOME", "$TEST_DIR/jetty-home")
                     .env("JETTY_BASE", "$TEST_DIR/jetty-base")
                     .env("PATH", "$PATH:${JETTY_HOME}/bin/")
                     .user("root")
                     // Configure /etc/default/jetty
-                    .run("echo \"JETTY_HOME=${JETTY_HOME}\" > /etc/default/jetty ; " +
+                    .run(
+                        "mkdir /etc/default ; " +
+                        "echo \"JETTY_HOME=${JETTY_HOME}\" > /etc/default/jetty ; " +
                         "echo \"JETTY_BASE=${JETTY_BASE}\" >> /etc/default/jetty ; " +
                         "echo \"JETTY_RUN=${JETTY_BASE}\" >> /etc/default/jetty ")
                     // setup Jetty Home

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/jettysh/JettyShStartTest.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.nio.channels.AsynchronousCloseException;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Stack;
@@ -37,6 +38,7 @@ import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.startupcheck.IsRunningStartupCheckStrategy;
 import org.testcontainers.containers.wait.strategy.ShellStrategy;
+import org.testcontainers.images.ImagePullPolicy;
 import org.testcontainers.images.PullPolicy;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -55,6 +57,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 public class JettyShStartTest extends AbstractJettyHomeTest
 {
     private static final Logger LOG = LoggerFactory.getLogger(JettyShStartTest.class);
+    // Establish a 3 month expiration for older pulled image
+    private static final ImagePullPolicy DEFAULT_PULL_POLICY = PullPolicy.ageBased(Duration.of(30 * 3, ChronoUnit.DAYS));
 
     public static Stream<Arguments> jettyImages()
     {
@@ -113,7 +117,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
         try (GenericContainer<?> genericContainer = new GenericContainer<>(jettyImage))
         {
-            genericContainer.withImagePullPolicy(PullPolicy.defaultPolicy());
+            genericContainer.withImagePullPolicy(DEFAULT_PULL_POLICY);
             genericContainer.setWaitStrategy(new ShellStrategy().withCommand("id"));
 
             genericContainer.withExposedPorts(80, 8080) // jetty
@@ -126,7 +130,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh start ==");
             Container.ExecResult result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "start");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh start"), result.getExitCode(), is(0));
             /*
              * Example successful output
              * ----
@@ -153,13 +157,13 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh status (should be running) ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "status");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh status"), result.getExitCode(), is(0));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 containsString("Jetty running pid"));
 
             System.err.println("== jetty.sh stop ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "stop");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh stop"), result.getExitCode(), is(0));
             /* Looking for output from jetty.sh indicating a stopped jetty.
              * STDOUT Example 1
              * ----
@@ -176,7 +180,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh status (should be stopped) ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "status");
-            assertThat(result.getExitCode(), is(1));
+            assertThat(asReason(result, "jetty.sh status"), result.getExitCode(), is(1));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 containsString("Jetty NOT running"));
 
@@ -199,7 +203,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
         try (GenericContainer<?> genericContainer = new GenericContainer<>(jettyImage))
         {
-            genericContainer.withImagePullPolicy(PullPolicy.defaultPolicy());
+            genericContainer.withImagePullPolicy(DEFAULT_PULL_POLICY);
             genericContainer.setWaitStrategy(new ShellStrategy().withCommand("id"));
 
             genericContainer.withExposedPorts(80, 8080) // jetty
@@ -212,7 +216,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh start ==");
             Container.ExecResult result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "start");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh start"), result.getExitCode(), is(0));
             /*
              * Example successful output
              * ----
@@ -239,13 +243,13 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh status (should be running) ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "status");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh status"), result.getExitCode(), is(0));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 containsString("Jetty running pid"));
 
             System.err.println("== jetty.sh restart ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "restart");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh restart"), result.getExitCode(), is(0));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 allOf(
                     containsString("Starting Jetty:"),
@@ -259,13 +263,13 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh status (should be running) ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "status");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh status"), result.getExitCode(), is(0));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 containsString("Jetty running pid"));
 
             System.err.println("== jetty.sh stop ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "stop");
-            assertThat(result.getExitCode(), is(0));
+            assertThat(asReason(result, "jetty.sh stop"), result.getExitCode(), is(0));
             /* Looking for output from jetty.sh indicating a stopped jetty.
              * STDOUT Example 1
              * ----
@@ -282,7 +286,7 @@ public class JettyShStartTest extends AbstractJettyHomeTest
 
             System.err.println("== jetty.sh status (should be stopped) ==");
             result = genericContainer.execInContainer("/var/test/jetty-home/bin/jetty.sh", "status");
-            assertThat(result.getExitCode(), is(1));
+            assertThat(asReason(result, "jetty.sh status"), result.getExitCode(), is(1));
             Awaitility.await().atMost(Duration.ofSeconds(5)).until(result::getStdout,
                 containsString("Jetty NOT running"));
 
@@ -321,7 +325,14 @@ public class JettyShStartTest extends AbstractJettyHomeTest
         LOG.debug("Create Image: {}", image.getDockerImageName());
         try (GenericContainer<?> container = new GenericContainer<>(image))
         {
-            container.start();
+            container
+                .withImagePullPolicy(DEFAULT_PULL_POLICY)
+                .start();
         }
+    }
+
+    private String asReason(Container.ExecResult result, String reason)
+    {
+        return String.format("%s%n--STDERR-%n%s--STDOUT--%s", reason, result.getStderr(), result.getStdout());
     }
 }

--- a/tests/test-distribution/test-distribution-common/src/test/resources/jetty-logging.properties
+++ b/tests/test-distribution/test-distribution-common/src/test/resources/jetty-logging.properties
@@ -3,7 +3,11 @@ org.eclipse.jetty.logging.appender.MESSAGE_ESCAPE=false
 org.eclipse.jetty.logging.appender.NAME_CONDENSE=false
 org.eclipse.jetty.LEVEL=INFO
 org.testcontainers.LEVEL=INFO
+# Uncomment this to see the as-built Dockerfile that testcontainers generates
+#org.testcontainers.images.builder.dockerfile.LEVEL=DEBUG
 #org.testcontainers.LEVEL=DEBUG
+#com.github.dockerjava.LEVEL=DEBUG
+#com.github.dockerjava.zerodep.LEVEL=WARN
 #org.eclipse.jetty.LEVEL=DEBUG
 #org.eclipse.jetty.tests.distribution.LEVEL=DEBUG
 # uncomment to get output of forked jetty process in the logs


### PR DESCRIPTION
* Updating `amazoncorretto:17` to `amazoncorretto:17.0.20-al2023` to prevent issues with latest image having some OS changes

Backport of #15554 for `jetty-12.0.x` branch.