### PR TITLE
Fix the use of quickstart with a combined base resource.

### DIFF
--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -109,7 +109,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
         //check that webapp is suitable for quick start - it is not a packed war
         Resource baseResource = context.getBaseResource();
         if (!Resources.isReadableDirectory(baseResource))
-            throw new IllegalStateException("Invalid Quickstart location");
+            throw new IllegalStateException("Invalid Quickstart location, base resource is not a readable directory: " + baseResource);
 
         //look for quickstart-web.xml in WEB-INF of webapp
         Path quickStartWebXml = getQuickStartWebXml(context);

--- a/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/main/java/org/eclipse/jetty/ee10/quickstart/QuickStartConfiguration.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,8 +107,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
         _resourceFactory = ResourceFactory.closeable();
 
         //check that webapp is suitable for quick start - it is not a packed war
-        String war = context.getWar();
-        if (StringUtil.isBlank(war) || !context.getBaseResource().isDirectory())
+        Resource baseResource = context.getBaseResource();
+        if (!Resources.isReadableDirectory(baseResource))
             throw new IllegalStateException("Invalid Quickstart location");
 
         //look for quickstart-web.xml in WEB-INF of webapp

--- a/jetty-ee10/jetty-ee10-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/TestQuickStart.java
+++ b/jetty-ee10/jetty-ee10-quickstart/src/test/java/org/eclipse/jetty/ee10/quickstart/TestQuickStart.java
@@ -14,8 +14,11 @@
 package org.eclipse.jetty.ee10.quickstart;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
+import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.ee10.servlet.FilterHolder;
 import org.eclipse.jetty.ee10.servlet.ListenerHolder;
 import org.eclipse.jetty.ee10.servlet.ServletHolder;
@@ -23,6 +26,8 @@ import org.eclipse.jetty.ee10.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.resource.CombinedResource;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.hamcrest.Matchers;
@@ -284,5 +289,59 @@ public class TestQuickStart
         assertNotNull(listeners);
         assertEquals(1,
             Arrays.stream(listeners).filter(l -> "org.eclipse.jetty.ee10.quickstart.FooContextListener".equals(l.getClassName())).count());
+    }
+
+    @Test
+    public void testQuickStartWithCombinedBaseResource() throws Exception
+    {
+        // Split the web content across two directories, presented to the webapp
+        // as a single combined base resource:
+        //   contentDir - holds the generated WEB-INF/quickstart-web.xml
+        //   overlayDir - holds an extra static resource
+        Path testDir = MavenTestingUtils.getTargetTestingPath("combinedbase");
+        FS.ensureEmpty(testDir);
+        Path contentDir = testDir.resolve("content");
+        Path overlayDir = testDir.resolve("overlay");
+        FS.ensureDirExists(contentDir.resolve("WEB-INF"));
+        FS.ensureDirExists(overlayDir);
+        Files.writeString(overlayDir.resolve("hello.txt"), "Hello");
+
+        // One combined resource used as the base resource for both generation and quickstart.
+        Resource base = ResourceFactory.combine(
+            ResourceFactory.root().newResource(contentDir),
+            ResourceFactory.root().newResource(overlayDir));
+
+        Path quickstartXml = contentDir.resolve("WEB-INF/quickstart-web.xml");
+        assertFalse(Files.exists(quickstartXml));
+
+        // Generate quickstart-web.xml from web.xml; it is written into contentDir/WEB-INF.
+        WebAppContext quickstart = new WebAppContext();
+        quickstart.setBaseResource(base);
+        quickstart.addConfiguration(new QuickStartConfiguration());
+        quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
+        quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
+        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        server.setHandler(quickstart);
+        server.setDryRun(true);
+        server.start();
+        assertTrue(Files.exists(quickstartXml));
+
+        // Run in QUICKSTART mode using the same combined base resource.
+        WebAppContext webapp = new WebAppContext();
+        webapp.setBaseResource(base);
+        webapp.addConfiguration(new QuickStartConfiguration());
+        webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.QUICKSTART);
+        server.setHandler(webapp);
+        server.setDryRun(false);
+        server.start();
+
+        // The base resource is a combined resource.
+        assertThat(webapp.getBaseResource(), Matchers.instanceOf(CombinedResource.class));
+        // The quickstart-web.xml was applied (default-context-path comes from web.xml).
+        assertEquals("/thisIsTheDefault", webapp.getContextPath());
+        // Content from both overlayed directories is visible through the combined base.
+        ServletContext servletContext = webapp.getServletContext();
+        assertNotNull(servletContext.getResource("/WEB-INF/quickstart-web.xml"));
+        assertNotNull(servletContext.getResource("/hello.txt"));
     }
 }

--- a/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/QuickStartConfiguration.java
@@ -109,7 +109,7 @@ public class QuickStartConfiguration extends AbstractConfiguration
         //check that webapp is suitable for quick start - it is not a packed war
         Resource baseResource = context.getBaseResource();
         if (!Resources.isReadableDirectory(baseResource))
-            throw new IllegalStateException("Invalid Quickstart location");
+            throw new IllegalStateException("Invalid Quickstart location, base resource is not a readable directory: " + baseResource);
 
         //look for quickstart-web.xml in WEB-INF of webapp
         Path quickStartWebXml = getQuickStartWebXml(context);

--- a/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/QuickStartConfiguration.java
+++ b/jetty-ee11/jetty-ee11-quickstart/src/main/java/org/eclipse/jetty/ee11/quickstart/QuickStartConfiguration.java
@@ -32,6 +32,7 @@ import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
+import org.eclipse.jetty.util.resource.Resources;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,8 +107,8 @@ public class QuickStartConfiguration extends AbstractConfiguration
         _resourceFactory = ResourceFactory.closeable();
 
         //check that webapp is suitable for quick start - it is not a packed war
-        String war = context.getWar();
-        if (StringUtil.isBlank(war) || !context.getBaseResource().isDirectory())
+        Resource baseResource = context.getBaseResource();
+        if (!Resources.isReadableDirectory(baseResource))
             throw new IllegalStateException("Invalid Quickstart location");
 
         //look for quickstart-web.xml in WEB-INF of webapp

--- a/jetty-ee11/jetty-ee11-quickstart/src/test/java/org/eclipse/jetty/ee11/quickstart/TestQuickStart.java
+++ b/jetty-ee11/jetty-ee11-quickstart/src/test/java/org/eclipse/jetty/ee11/quickstart/TestQuickStart.java
@@ -14,8 +14,11 @@
 package org.eclipse.jetty.ee11.quickstart;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
+import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.ee11.servlet.FilterHolder;
 import org.eclipse.jetty.ee11.servlet.ListenerHolder;
 import org.eclipse.jetty.ee11.servlet.ServletHolder;
@@ -23,6 +26,8 @@ import org.eclipse.jetty.ee11.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.resource.CombinedResource;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.hamcrest.Matchers;
@@ -285,5 +290,59 @@ public class TestQuickStart
         assertNotNull(listeners);
         assertEquals(1,
             Arrays.stream(listeners).filter(l -> "org.eclipse.jetty.ee11.quickstart.FooContextListener".equals(l.getClassName())).count());
+    }
+
+    @Test
+    public void testQuickStartWithCombinedBaseResource() throws Exception
+    {
+        // Split the web content across two directories, presented to the webapp
+        // as a single combined base resource:
+        //   contentDir - holds the generated WEB-INF/quickstart-web.xml
+        //   overlayDir - holds an extra static resource
+        Path testDir = MavenTestingUtils.getTargetTestingPath("combinedbase");
+        FS.ensureEmpty(testDir);
+        Path contentDir = testDir.resolve("content");
+        Path overlayDir = testDir.resolve("overlay");
+        FS.ensureDirExists(contentDir.resolve("WEB-INF"));
+        FS.ensureDirExists(overlayDir);
+        Files.writeString(overlayDir.resolve("hello.txt"), "Hello");
+
+        // One combined resource used as the base resource for both generation and quickstart.
+        Resource base = ResourceFactory.combine(
+            ResourceFactory.root().newResource(contentDir),
+            ResourceFactory.root().newResource(overlayDir));
+
+        Path quickstartXml = contentDir.resolve("WEB-INF/quickstart-web.xml");
+        assertFalse(Files.exists(quickstartXml));
+
+        // Generate quickstart-web.xml from web.xml; it is written into contentDir/WEB-INF.
+        WebAppContext quickstart = new WebAppContext();
+        quickstart.setBaseResource(base);
+        quickstart.addConfiguration(new QuickStartConfiguration());
+        quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
+        quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
+        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        server.setHandler(quickstart);
+        server.setDryRun(true);
+        server.start();
+        assertTrue(Files.exists(quickstartXml));
+
+        // Run in QUICKSTART mode using the same combined base resource.
+        WebAppContext webapp = new WebAppContext();
+        webapp.setBaseResource(base);
+        webapp.addConfiguration(new QuickStartConfiguration());
+        webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.QUICKSTART);
+        server.setHandler(webapp);
+        server.setDryRun(false);
+        server.start();
+
+        // The base resource is a combined resource.
+        assertThat(webapp.getBaseResource(), Matchers.instanceOf(CombinedResource.class));
+        // The quickstart-web.xml was applied (default-context-path comes from web.xml).
+        assertEquals("/thisIsTheDefault", webapp.getContextPath());
+        // Content from both overlayed directories is visible through the combined base.
+        ServletContext servletContext = webapp.getServletContext();
+        assertNotNull(servletContext.getResource("/WEB-INF/quickstart-web.xml"));
+        assertNotNull(servletContext.getResource("/hello.txt"));
     }
 }

--- a/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
@@ -14,8 +14,11 @@
 package org.eclipse.jetty.ee9.quickstart;
 
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 
+import jakarta.servlet.ServletContext;
 import org.eclipse.jetty.ee9.servlet.FilterHolder;
 import org.eclipse.jetty.ee9.servlet.ListenerHolder;
 import org.eclipse.jetty.ee9.servlet.ServletHolder;
@@ -23,6 +26,8 @@ import org.eclipse.jetty.ee9.webapp.WebAppContext;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.toolchain.test.FS;
 import org.eclipse.jetty.toolchain.test.MavenTestingUtils;
+import org.eclipse.jetty.util.resource.CombinedResource;
+import org.eclipse.jetty.util.resource.Resource;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.eclipse.jetty.xml.XmlConfiguration;
 import org.hamcrest.Matchers;
@@ -284,5 +289,59 @@ public class TestQuickStart
         assertNotNull(listeners);
         assertEquals(1,
             Arrays.stream(listeners).filter(l -> "org.eclipse.jetty.ee9.quickstart.FooContextListener".equals(l.getClassName())).count());
+    }
+
+    @Test
+    public void testQuickStartWithCombinedBaseResource() throws Exception
+    {
+        // Split the web content across two directories, presented to the webapp
+        // as a single combined base resource:
+        //   contentDir - holds the generated WEB-INF/quickstart-web.xml
+        //   overlayDir - holds an extra static resource
+        Path testDir = MavenTestingUtils.getTargetTestingPath("combinedbase");
+        FS.ensureEmpty(testDir);
+        Path contentDir = testDir.resolve("content");
+        Path overlayDir = testDir.resolve("overlay");
+        FS.ensureDirExists(contentDir.resolve("WEB-INF"));
+        FS.ensureDirExists(overlayDir);
+        Files.writeString(overlayDir.resolve("hello.txt"), "Hello");
+
+        // One combined resource used as the base resource for both generation and quickstart.
+        Resource base = ResourceFactory.combine(
+            ResourceFactory.root().newResource(contentDir),
+            ResourceFactory.root().newResource(overlayDir));
+
+        Path quickstartXml = contentDir.resolve("WEB-INF/quickstart-web.xml");
+        assertFalse(Files.exists(quickstartXml));
+
+        // Generate quickstart-web.xml from web.xml; it is written into contentDir/WEB-INF.
+        WebAppContext quickstart = new WebAppContext();
+        quickstart.setBaseResource(base);
+        quickstart.addConfiguration(new QuickStartConfiguration());
+        quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
+        quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
+        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        server.setHandler(quickstart);
+        server.setDryRun(true);
+        server.start();
+        assertTrue(Files.exists(quickstartXml));
+
+        // Run in QUICKSTART mode using the same combined base resource.
+        WebAppContext webapp = new WebAppContext();
+        webapp.setBaseResource(base);
+        webapp.addConfiguration(new QuickStartConfiguration());
+        webapp.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.QUICKSTART);
+        server.setHandler(webapp);
+        server.setDryRun(false);
+        server.start();
+
+        // The base resource is a combined resource.
+        assertThat(webapp.getBaseResource(), Matchers.instanceOf(CombinedResource.class));
+        // The quickstart-web.xml was applied (default-context-path comes from web.xml).
+        assertEquals("/thisIsTheDefault", webapp.getContextPath());
+        // Content from both overlayed directories is visible through the combined base.
+        ServletContext servletContext = webapp.getServletContext();
+        assertNotNull(servletContext.getResource("/WEB-INF/quickstart-web.xml"));
+        assertNotNull(servletContext.getResource("/hello.txt"));
     }
 }

--- a/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
+++ b/jetty-ee9/jetty-ee9-quickstart/src/test/java/org/eclipse/jetty/ee9/quickstart/TestQuickStart.java
@@ -320,7 +320,7 @@ public class TestQuickStart
         quickstart.addConfiguration(new QuickStartConfiguration());
         quickstart.setAttribute(QuickStartConfiguration.MODE, QuickStartConfiguration.Mode.GENERATE);
         quickstart.setAttribute(QuickStartConfiguration.ORIGIN_ATTRIBUTE, "origin");
-        quickstart.setDescriptor(MavenTestingUtils.getTestResourceFile("web.xml").getAbsolutePath());
+        quickstart.setDescriptor(MavenTestingUtils.getTargetPath("test-classes/web.xml").toString());
         server.setHandler(quickstart);
         server.setDryRun(true);
         server.start();


### PR DESCRIPTION
In the case of a `CombinedResource` as the base resource, `context.getWar()` will return null, which was causing this ISE to be thrown.

We should instead test the value of `context.getBaseResource()` due to the fact that `CombinedResource` cannot be converted to `String` by `context.getWar()`.