### PR TITLE
Add additional configuration for SessionAuthentication persistence (12.1)

### DIFF
--- a/jetty-core/jetty-security/pom.xml
+++ b/jetty-core/jetty-security/pom.xml
@@ -111,6 +111,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-http-tools</artifactId>
       <scope>test</scope>

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/AbstractLoginService.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/AbstractLoginService.java
@@ -117,19 +117,16 @@ public abstract class AbstractLoginService extends ContainerLifeCycle implements
     public boolean validate(UserIdentity user)
     {
         if (!isFullValidate())
-            return true; //if we have a user identity it must be valid
+            return true; // If we have a user identity it must be valid.
 
-        //Do a full validation back against the user store     
+        // Do a full validation back against the user store.
         UserPrincipal fresh = loadUserInfo(user.getUserPrincipal().getName());
         if (fresh == null)
-            return false; //user no longer exists
+            return false; // User no longer exists.
 
-        if (user.getUserPrincipal() instanceof UserPrincipal)
-        {
-            return fresh.authenticate(((UserPrincipal)user.getUserPrincipal()));
-        }
-
-        throw new IllegalStateException("UserPrincipal not known"); //can't validate
+        if (user.getUserPrincipal() instanceof UserPrincipal userPrincipal)
+            return fresh.authenticate(userPrincipal);
+        return false; // Unable to validate credentials without a UserPrincipal.
     }
 
     @Override

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/Authenticator.java
@@ -150,6 +150,11 @@ public interface Authenticator
          */
         int getSessionMaxInactiveIntervalOnAuthentication();
 
+        default boolean isPersistAuthenticationCredentials()
+        {
+            return false;
+        }
+
         class Wrapper implements Configuration
         {
             private final Configuration _configuration;
@@ -205,6 +210,12 @@ public interface Authenticator
             public int getSessionMaxInactiveIntervalOnAuthentication()
             {
                 return _configuration.getSessionMaxInactiveIntervalOnAuthentication();
+            }
+
+            @Override
+            public boolean isPersistAuthenticationCredentials()
+            {
+                return _configuration.isPersistAuthenticationCredentials();
             }
         }
     }

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/NamePrincipal.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/NamePrincipal.java
@@ -1,0 +1,38 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.security;
+
+import java.security.Principal;
+
+public class NamePrincipal implements Principal
+{
+    private final String _name;
+
+    public NamePrincipal(String name)
+    {
+        _name = name;
+    }
+
+    @Override
+    public String getName()
+    {
+        return _name;
+    }
+
+    @Override
+    public String toString()
+    {
+        return String.format("%s[%s]@%x", getClass().getSimpleName(), getName(), hashCode());
+    }
+}

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/RoleDelegateUserIdentity.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/RoleDelegateUserIdentity.java
@@ -50,6 +50,8 @@ public class RoleDelegateUserIdentity implements UserIdentity
     @Override
     public String[] getRoles()
     {
+        if (_roleDelegate == null)
+            return new String[0];
         return _roleDelegate.getRoles();
     }
 

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/RoleDelegateUserIdentity.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/RoleDelegateUserIdentity.java
@@ -47,6 +47,12 @@ public class RoleDelegateUserIdentity implements UserIdentity
         return _roleDelegate != null && _roleDelegate.isUserInRole(role);
     }
 
+    @Override
+    public String[] getRoles()
+    {
+        return _roleDelegate.getRoles();
+    }
+
     public boolean isEstablished()
     {
         return _roleDelegate != null;

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/SecurityHandler.java
@@ -68,6 +68,7 @@ import org.slf4j.LoggerFactory;
 public abstract class SecurityHandler extends Handler.Wrapper implements Configuration
 {
     public static String SESSION_AUTHENTICATED_ATTRIBUTE = "org.eclipse.jetty.security.sessionAuthenticated";
+    public static final String KNOWN_ROLES_ATTRIBUTE = "org.eclipse.jetty.security.knownRoles";
 
     private static final Logger LOG = LoggerFactory.getLogger(SecurityHandler.class);
     private static final List<Authenticator.Factory> __knownAuthenticatorFactories = new ArrayList<>();
@@ -82,6 +83,7 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
     private boolean _renewSessionOnAuthentication = true;
     private int _sessionMaxInactiveIntervalOnAuthentication = 0;
     private AuthenticationState.Deferred _deferred;
+    private boolean _persistAuthenticationCredentials;
 
     static
     {
@@ -697,6 +699,19 @@ public abstract class SecurityHandler extends Handler.Wrapper implements Configu
     protected Set<String> getKnownRoles()
     {
         return Collections.emptySet();
+    }
+
+    @Override
+    public boolean isPersistAuthenticationCredentials()
+    {
+        return _persistAuthenticationCredentials;
+    }
+
+    public void setPersistAuthenticationCredentials(boolean persistAuthenticationCredentials)
+    {
+        if (isStarted())
+            throw new IllegalStateException("Started");
+        _persistAuthenticationCredentials = persistAuthenticationCredentials;
     }
 
     private static int compareMappedResources(MappedResource<?> mr1, MappedResource<?> mr2)

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/UserIdentity.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/UserIdentity.java
@@ -14,9 +14,12 @@
 package org.eclipse.jetty.security;
 
 import java.security.Principal;
+import java.util.Collection;
+import java.util.HashSet;
 import javax.security.auth.Subject;
 
 import org.eclipse.jetty.security.internal.DefaultUserIdentity;
+import org.eclipse.jetty.server.handler.ContextHandler;
 
 /**
  * User object that encapsulates user identity and operations such as run-as-role actions,
@@ -46,6 +49,57 @@ public interface UserIdentity
      * @return True if the user can act in that role.
      */
     boolean isUserInRole(String role);
+
+    default String[] getRoles()
+    {
+        HashSet<String> roles = new HashSet<>();
+
+        // Extract any RolePrincipal names from the Subject.
+        for (Principal principal : getSubject().getPrincipals())
+        {
+            if (principal instanceof RolePrincipal && isUserInRole(principal.getName()))
+                roles.add(principal.getName());
+        }
+
+        // Run through the list of known roles and verify with isUserInRole.
+        SecurityHandler securityHandler = SecurityHandler.getCurrentSecurityHandler();
+        if (securityHandler != null)
+        {
+            // Check any roles known by the SecurityHandler.
+            for (String role : securityHandler.getKnownRoles())
+            {
+                if (isUserInRole(role))
+                    roles.add(role);
+            }
+        }
+        else
+        {
+            // This may be EE8/EE9 which does not have a jetty-core SecurityHandler so check this ContextHandler attribute.
+            ContextHandler contextHandler = ContextHandler.getCurrentContextHandler();
+            if (contextHandler != null)
+            {
+                Object attribute = contextHandler.getAttribute(SecurityHandler.KNOWN_ROLES_ATTRIBUTE);
+                if (attribute instanceof String[] knownRoles)
+                {
+                    for (String role : knownRoles)
+                    {
+                        if (isUserInRole(role))
+                            roles.add(role);
+                    }
+                }
+                else if (attribute instanceof Collection<?> knownRoles)
+                {
+                    for (Object role : knownRoles)
+                    {
+                        if (isUserInRole(role.toString()))
+                            roles.add(role.toString());
+                    }
+                }
+            }
+        }
+
+        return roles.toArray(new String[0]);
+    }
 
     static UserIdentity from(Subject subject, Principal userPrincipal, String... roles)
     {

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/FormAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/FormAuthenticator.java
@@ -164,7 +164,7 @@ public class FormAuthenticator extends LoginAuthenticator
         if (user != null)
         {
             Session session = request.getSession(true);
-            AuthenticationState cached = new SessionAuthentication(getAuthenticationType(), user, password);
+            AuthenticationState cached = newSessionAuthentication(getAuthenticationType(), user, password);
             session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, cached);
         }
         return user;

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/LoginAuthenticator.java
@@ -42,6 +42,7 @@ public abstract class LoginAuthenticator implements Authenticator
     private boolean _sessionRenewedOnAuthentication;
     private int _sessionMaxInactiveIntervalOnAuthentication;
     private boolean _proxy;
+    private boolean _persistAuthenticationCredentials;
 
     protected LoginAuthenticator()
     {
@@ -160,6 +161,12 @@ public abstract class LoginAuthenticator implements Authenticator
             throw new IllegalStateException("No IdentityService for " + this + " in " + configuration);
         _sessionRenewedOnAuthentication = configuration.isSessionRenewedOnAuthentication();
         _sessionMaxInactiveIntervalOnAuthentication = configuration.getSessionMaxInactiveIntervalOnAuthentication();
+        _persistAuthenticationCredentials = configuration.isPersistAuthenticationCredentials();
+    }
+
+    public boolean isPersistAuthenticationCredentials()
+    {
+        return _persistAuthenticationCredentials;
     }
 
     public LoginService getLoginService()
@@ -170,6 +177,11 @@ public abstract class LoginAuthenticator implements Authenticator
     public void setLoginService(LoginService loginService)
     {
         _loginService = loginService;
+    }
+
+    public SessionAuthentication newSessionAuthentication(String method, UserIdentity userIdentity, Object credentials)
+    {
+        return new SessionAuthentication(method, userIdentity, credentials, isPersistAuthenticationCredentials());
     }
 
     /**
@@ -251,17 +263,17 @@ public abstract class LoginAuthenticator implements Authenticator
             {
                 LoginService loginService = security.getLoginService();
                 if (loginService != null)
-                    loginService.logout(((Succeeded)this).getUserIdentity());
+                    loginService.logout(getUserIdentity());
                 IdentityService identityService = security.getIdentityService();
                 if (identityService != null)
-                    identityService.onLogout(((Succeeded)this).getUserIdentity());
+                    identityService.onLogout(getUserIdentity());
 
                 Authenticator authenticator = security.getAuthenticator();
 
                 AuthenticationState authenticationState = null;
                 if (authenticator instanceof LoginAuthenticator loginAuthenticator)
                 {
-                    ((LoginAuthenticator)authenticator).logout(request, response);
+                    loginAuthenticator.logout(request, response);
                     authenticationState = new LoginAuthenticator.LoggedOutAuthentication(loginAuthenticator);
                 }
                 AuthenticationState.setAuthenticationState(request, authenticationState);

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/authentication/SessionAuthentication.java
@@ -15,11 +15,16 @@ package org.eclipse.jetty.security.authentication;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
+import javax.security.auth.Subject;
 
 import org.eclipse.jetty.security.Authenticator;
+import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.NamePrincipal;
+import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.SecurityHandler;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.server.Session;
@@ -42,15 +47,24 @@ public class SessionAuthentication extends LoginAuthenticator.UserAuthentication
 
     public static final String AUTHENTICATED_ATTRIBUTE = "org.eclipse.jetty.security.UserIdentity";
 
+    private transient Session _session;
+    private transient boolean _persistAuthenticationCredentials;
     private final String _name;
     private final Object _credentials;
-    private transient Session _session;
+    private final String[] _roles;
 
     public SessionAuthentication(String method, UserIdentity userIdentity, Object credentials)
     {
+        this(method, userIdentity, credentials, false);
+    }
+
+    public SessionAuthentication(String method, UserIdentity userIdentity, Object credentials, boolean serializeCredentials)
+    {
         super(method, userIdentity);
         _name = userIdentity.getUserPrincipal().getName();
+        _roles = userIdentity.getRoles();
         _credentials = credentials;
+        _persistAuthenticationCredentials = serializeCredentials;
     }
 
     @Override
@@ -67,8 +81,8 @@ public class SessionAuthentication extends LoginAuthenticator.UserAuthentication
     {
         stream.defaultReadObject();
 
-        SecurityHandler security = SecurityHandler.getCurrentSecurityHandler();
-        if (security == null)
+        SecurityHandler securityHandler = SecurityHandler.getCurrentSecurityHandler();
+        if (securityHandler == null)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("!SecurityHandler");
@@ -76,22 +90,81 @@ public class SessionAuthentication extends LoginAuthenticator.UserAuthentication
         }
 
         LoginService loginService;
-        Authenticator authenticator = security.getAuthenticator();
-        if (authenticator instanceof LoginAuthenticator)
-            loginService = ((LoginAuthenticator)authenticator).getLoginService();
-        else
-            loginService = security.getLoginService();
-
-        if (loginService == null)
+        Authenticator authenticator = securityHandler.getAuthenticator();
+        if (authenticator instanceof LoginAuthenticator loginAuthenticator)
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("!LoginService");
-            return;
+            loginService = loginAuthenticator.getLoginService();
+            _persistAuthenticationCredentials = loginAuthenticator.isPersistAuthenticationCredentials();
+        }
+        else
+        {
+            loginService = securityHandler.getLoginService();
+            _persistAuthenticationCredentials = securityHandler.isPersistAuthenticationCredentials();
         }
 
-        _userIdentity = loginService.login(_name, _credentials, null, null);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Deserialized and relogged in {}", this);
+        // If _persistAuthenticationCredentials is true we must always try to re-login with the loginService.
+        // If _roles is null, it is an old SessionAuthentication, and we should re-login with the LoginService.
+        if (_persistAuthenticationCredentials || _roles == null)
+        {
+            if (loginService == null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("!LoginService");
+                return;
+            }
+
+            _userIdentity = loginService.login(_name, _credentials, null, null);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Deserialized and relogged in {}", this);
+        }
+        else
+        {
+            IdentityService identityService = (loginService == null) ? securityHandler.getIdentityService() : loginService.getIdentityService();
+            if (identityService == null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("!IdentityService");
+                return;
+            }
+
+            Subject subject = new Subject();
+            NamePrincipal principal = new NamePrincipal(_name);
+            subject.getPrincipals().add(principal);
+            for (String role : _roles)
+            {
+                if (role != null)
+                    subject.getPrincipals().add(new RolePrincipal(role));
+            }
+            subject.setReadOnly();
+
+            _userIdentity = identityService.newUserIdentity(subject, principal, _roles);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Deserialized {}", this);
+        }
+    }
+
+    @Serial
+    protected Object readResolve()
+    {
+        // A SessionAuthentication without a UserIdentity is invalid, and should be deserialized as null instead
+        // of throwing ISE when getUserIdentity() is called, which would result in a 500 response.
+        if (_userIdentity == null)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Dropping unrestorable authentication for {}", _name);
+            return null;
+        }
+        return this;
+    }
+
+    @Serial
+    private void writeObject(ObjectOutputStream out) throws IOException
+    {
+        ObjectOutputStream.PutField fields = out.putFields();
+        fields.put("_name", _name);
+        fields.put("_credentials", _persistAuthenticationCredentials ? _credentials : null);
+        fields.put("_roles", _roles);
+        out.writeFields();
     }
 
     @Override

--- a/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/internal/DefaultUserIdentity.java
+++ b/jetty-core/jetty-security/src/main/java/org/eclipse/jetty/security/internal/DefaultUserIdentity.java
@@ -14,6 +14,7 @@
 package org.eclipse.jetty.security.internal;
 
 import java.security.Principal;
+import java.util.Objects;
 import javax.security.auth.Subject;
 
 import org.eclipse.jetty.security.DefaultIdentityService;
@@ -32,7 +33,7 @@ public class DefaultUserIdentity implements UserIdentity
     {
         _subject = subject;
         _userPrincipal = userPrincipal;
-        _roles = roles;
+        _roles = Objects.requireNonNull(roles);
     }
 
     @Override
@@ -62,6 +63,12 @@ public class DefaultUserIdentity implements UserIdentity
                 return true;
         }
         return false;
+    }
+
+    @Override
+    public String[] getRoles()
+    {
+        return _roles.clone();
     }
 
     @Override

--- a/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/PersistAuthenticationCredentialsTest.java
+++ b/jetty-core/jetty-security/src/test/java/org/eclipse/jetty/security/PersistAuthenticationCredentialsTest.java
@@ -1,0 +1,285 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.security;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.security.authentication.SessionAuthentication;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.Session;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.session.FileSessionDataStoreFactory;
+import org.eclipse.jetty.session.NullSessionCacheFactory;
+import org.eclipse.jetty.session.SessionHandler;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.security.Credential;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class PersistAuthenticationCredentialsTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(PersistAuthenticationCredentialsTest.class);
+
+    @TempDir
+    private File _tempDir;
+    private LocalConnector _localConnector;
+    private Server _server;
+    private SecurityHandler.PathMapped _securityHandler;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        _server = new Server();
+        _localConnector = new LocalConnector(_server);
+        _server.addConnector(_localConnector);
+        _securityHandler = new SecurityHandler.PathMapped();
+        _securityHandler.put("/*", Constraint.ANY_USER);
+        HashLoginService loginService = new HashLoginService();
+        UserStore userStore = new UserStore();
+        userStore.addUser("foo", Credential.getCredential("bar"), new String[]{"admin"});
+        loginService.setUserStore(userStore);
+        _securityHandler.setLoginService(loginService);
+
+        _securityHandler.setAuthenticator(new LoginAuthenticator()
+        {
+            @Override
+            public String getAuthenticationType()
+            {
+                return "TEST";
+            }
+
+            @Override
+            public UserIdentity login(String username, Object password, Request request, Response response)
+            {
+                UserIdentity user = super.login(username, password, request, response);
+                if (user != null)
+                {
+                    Session session = request.getSession(true);
+                    AuthenticationState cached = newSessionAuthentication(getAuthenticationType(), user, password);
+                    session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, cached);
+                }
+                return user;
+            }
+
+            @Override
+            public AuthenticationState validateRequest(Request request, Response response, Callback callback) throws ServerAuthException
+            {
+                // Look for cached authentication
+                Session session = request.getSession(false);
+                AuthenticationState authenticationState = session == null ? null : (AuthenticationState)session.getAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("auth {}", authenticationState);
+                // Has authentication been revoked?
+                if (authenticationState instanceof AuthenticationState.Succeeded succeeded && _loginService != null && !_loginService.validate(succeeded.getUserIdentity()))
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth revoked {}", authenticationState);
+                    session.removeAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE);
+                    authenticationState = null;
+                }
+
+                if (authenticationState != null)
+                {
+                    response.getHeaders().add("source", "session");
+                    return authenticationState;
+                }
+
+                response.getHeaders().add("source", "login");
+                UserIdentity userIdentity = login("foo", "bar", request, response);
+                return new LoginAuthenticator.UserAuthenticationSucceeded("TEST", userIdentity);
+            }
+        });
+        FileSessionDataStoreFactory sessionDataStoreFactory = new FileSessionDataStoreFactory();
+        sessionDataStoreFactory.setStoreDir(_tempDir);
+        _server.addBean(sessionDataStoreFactory);
+        _server.addBean(new NullSessionCacheFactory());
+        SessionHandler sessionHandler = new SessionHandler();
+        sessionHandler.setHandler(_securityHandler);
+        _securityHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                response.setStatus(200);
+                callback.succeeded();
+                return true;
+            }
+        });
+
+        _server.setHandler(new ContextHandler(sessionHandler, "/"));
+    }
+
+    @AfterEach
+    public void shutdown() throws Exception
+    {
+        _server.stop();
+    }
+
+    private File[] listFiles()
+    {
+        File[] files = _tempDir.listFiles();
+        if (files == null)
+            return new File[0];
+        return files;
+    }
+
+    private String getSessionData() throws IOException
+    {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> listFiles().length > 0);
+        File[] files = listFiles();
+        if (files.length != 1)
+            throw new IllegalStateException("Expected exactly one session file, but found: " + Arrays.toString(files));
+        return new String(Files.readAllBytes(files[0].toPath()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPersistAuthenticationCredentials(boolean persistAuthenticationCredentials) throws Exception
+    {
+        if (persistAuthenticationCredentials)
+            _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // Check session data on disk to ensure "bar" password is not in it
+        if (persistAuthenticationCredentials)
+            assertThat(getSessionData(), containsString("bar"));
+        else
+            assertThat(getSessionData(), not(containsString("bar")));
+
+        // Verify that we can load it from disk again.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("session"));
+    }
+
+    @Test
+    public void testLegacySessionCredentialsCompatibility() throws Exception
+    {
+        _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // Check session data on disk to ensure "bar" password is in it
+        assertThat(getSessionData(), containsString("bar"));
+
+        // Restart the server with the mode to not save credentials to verify we can still read it.
+        _server.stop();
+        _securityHandler.setPersistAuthenticationCredentials(false);
+        _server.start();
+
+        // Verify that we can load it from disk again.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("session"));
+
+        // The credential is no longer stored in the SessionData.
+        assertThat(getSessionData(), not(containsString("bar")));
+    }
+
+    @Test
+    public void testEnablePersistCredentials() throws Exception
+    {
+        _securityHandler.setPersistAuthenticationCredentials(false);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // The credential is not stored in the SessionData.
+        assertThat(getSessionData(), not(containsString("bar")));
+
+        // Restart the server with the setting to persist the credential.
+        _server.stop();
+        _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        // The persisted authentication has no credentials, and credentials are now required to
+        // re-login, so the cached authentication cannot be restored. Rather than failing the
+        // request, it is treated as unauthenticated and the user must authenticate.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+
+        // Now that persistence is enabled the re-login persists the credential.
+        assertThat(getSessionData(), containsString("bar"));
+    }
+}

--- a/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee10/jetty-ee10-jaspi/src/main/java/org/eclipse/jetty/ee10/security/jaspi/JaspiAuthenticator.java
@@ -144,7 +144,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             HttpSession session = ((HttpServletRequest)request).getSession(true);
             if (session != null)
             {
-                SessionAuthentication sessionAuth = new SessionAuthentication(getAuthenticationType(), user, password);
+                SessionAuthentication sessionAuth = newSessionAuthentication(getAuthenticationType(), user, password);
                 session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, sessionAuth);
             }
         }

--- a/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee11/jetty-ee11-jaspi/src/main/java/org/eclipse/jetty/ee11/security/jaspi/JaspiAuthenticator.java
@@ -144,7 +144,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             HttpSession session = ((HttpServletRequest)request).getSession(true);
             if (session != null)
             {
-                SessionAuthentication sessionAuth = new SessionAuthentication(getAuthenticationType(), user, password);
+                SessionAuthentication sessionAuth = newSessionAuthentication(getAuthenticationType(), user, password);
                 session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, sessionAuth);
             }
         }

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/java/org/eclipse/jetty/ee9/security/jaspi/JaspiAuthenticator.java
@@ -150,7 +150,7 @@ public class JaspiAuthenticator extends LoginAuthenticator
             HttpSession session = ((HttpServletRequest)request).getSession(true);
             if (session != null)
             {
-                SessionAuthentication sessionAuth = new SessionAuthentication(getAuthMethod(), user, password);
+                SessionAuthentication sessionAuth = newSessionAuthentication(getAuthMethod(), user, password);
                 session.setAttribute(SessionAuthentication.__J_AUTHENTICATED, sessionAuth);
             }
         }

--- a/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-openid/src/main/java/org/eclipse/jetty/ee9/security/openid/OpenIdAuthenticator.java
@@ -18,6 +18,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -40,10 +41,12 @@ import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.RoleDelegateUserIdentity;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.security.openid.OpenIdConfiguration;
 import org.eclipse.jetty.security.openid.OpenIdCredentials;
 import org.eclipse.jetty.security.openid.OpenIdLoginService;
+import org.eclipse.jetty.security.openid.OpenIdUserPrincipal;
 import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
@@ -235,7 +238,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
         if (user != null)
         {
             HttpSession session = ((HttpServletRequest)request).getSession();
-            Authentication cached = new SessionAuthentication(getAuthMethod(), user, credentials);
+            Authentication cached = newSessionAuthentication(getAuthMethod(), user, credentials);
             synchronized (session)
             {
                 session.setAttribute(SessionAuthentication.__J_AUTHENTICATED, cached);
@@ -516,9 +519,32 @@ public class OpenIdAuthenticator extends LoginAuthenticator
             Authentication authentication = (Authentication)session.getAttribute(SessionAuthentication.__J_AUTHENTICATED);
             if (authentication != null)
             {
+                boolean isUserIdentityValid = false;
+                if (authentication instanceof Authentication.User userAuthentication && _loginService != null)
+                {
+                    UserIdentity userIdentity = userAuthentication.getUserIdentity();
+                    Principal principal = userIdentity.getUserPrincipal();
+                    if (principal instanceof OpenIdUserPrincipal)
+                    {
+                        isUserIdentityValid = _loginService.validate(userIdentity);
+                    }
+                    else
+                    {
+                        // We need to reconstruct the OpenIdUserPrincipal.
+                        @SuppressWarnings("unchecked")
+                        Map<String, Object> claims = (Map<String, Object>)session.getAttribute(CLAIMS);
+                        if (claims != null)
+                        {
+                            OpenIdCredentials openIdCredentials = new OpenIdCredentials(claims);
+                            OpenIdUserPrincipal openIdUserPrincipal = new OpenIdUserPrincipal(openIdCredentials);
+                            userIdentity = new RoleDelegateUserIdentity(userIdentity.getSubject(), openIdUserPrincipal, userIdentity);
+                            isUserIdentityValid = _loginService.validate(userIdentity);
+                        }
+                    }
+                }
+
                 // Has authentication been revoked?
-                if (authentication instanceof Authentication.User && _loginService != null &&
-                    !_loginService.validate(((Authentication.User)authentication).getUserIdentity()))
+                if (!isUserIdentityValid)
                 {
                     if (LOG.isDebugEnabled())
                         LOG.debug("auth revoked {}", authentication);
@@ -568,7 +594,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
                 return Authentication.UNAUTHENTICATED;
             }
 
-            // Send the the challenge.
+            // Send the challenge.
             String challengeUri = getChallengeUri(baseRequest);
             if (LOG.isDebugEnabled())
                 LOG.debug("challenge {}->{}", session.getId(), challengeUri);

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/Authenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/Authenticator.java
@@ -142,6 +142,11 @@ public interface Authenticator
          *         session never timeout after authentication.
          */
         int getSessionMaxInactiveIntervalOnAuthentication();
+
+        default boolean isPersistAuthenticationCredentials()
+        {
+            return false;
+        }
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/ConstraintSecurityHandler.java
@@ -50,6 +50,8 @@ import org.eclipse.jetty.util.component.DumpableCollection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.eclipse.jetty.security.SecurityHandler.KNOWN_ROLES_ATTRIBUTE;
+
 /**
  * ConstraintSecurityHandler
  * <p>
@@ -419,6 +421,12 @@ public class ConstraintSecurityHandler extends SecurityHandler implements Constr
         rebuildMappings();
 
         super.doStart();
+
+        // Set the known roles as an attribute on the jetty-core context handler to make it externally available.
+        // This is used to implement the default UserIdentity.getRoles() in jetty-core.
+        ContextHandler contextHandler = ContextHandler.getCurrentContextHandler();
+        if (contextHandler != null)
+            contextHandler.getCoreContextHandler().setAttribute(KNOWN_ROLES_ATTRIBUTE, _roles);
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/SecurityHandler.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/SecurityHandler.java
@@ -72,6 +72,7 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
     private IdentityService _identityService;
     private boolean _renewSessionOnAuthentication = true;
     private int _sessionMaxInactiveIntervalOnAuthentication = 0;
+    private boolean _persistAuthenticationCredentials;
 
     static
     {
@@ -469,6 +470,19 @@ public abstract class SecurityHandler extends HandlerWrapper implements Authenti
     public void setSessionMaxInactiveIntervalOnAuthentication(int seconds)
     {
         _sessionMaxInactiveIntervalOnAuthentication = seconds;
+    }
+
+    @Override
+    public boolean isPersistAuthenticationCredentials()
+    {
+        return _persistAuthenticationCredentials;
+    }
+
+    public void setPersistAuthenticationCredentials(boolean persistAuthenticationCredentials)
+    {
+        if (isStarted())
+            throw new IllegalStateException("Started");
+        _persistAuthenticationCredentials = persistAuthenticationCredentials;
     }
 
     /*

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/WrappedAuthConfiguration.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/WrappedAuthConfiguration.java
@@ -79,4 +79,10 @@ public class WrappedAuthConfiguration implements AuthConfiguration
     {
         return _configuration.getSessionMaxInactiveIntervalOnAuthentication();
     }
+
+    @Override
+    public boolean isPersistAuthenticationCredentials()
+    {
+        return _configuration.isPersistAuthenticationCredentials();
+    }
 }

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/FormAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/FormAuthenticator.java
@@ -174,7 +174,7 @@ public class FormAuthenticator extends LoginAuthenticator
         {
 
             HttpSession session = ((HttpServletRequest)request).getSession(true);
-            Authentication cached = new SessionAuthentication(getAuthMethod(), user, password);
+            Authentication cached = newSessionAuthentication(getAuthMethod(), user, password);
             session.setAttribute(SessionAuthentication.__J_AUTHENTICATED, cached);
         }
         return user;

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/LoginAuthenticator.java
@@ -43,6 +43,7 @@ public abstract class LoginAuthenticator implements Authenticator
     private boolean _sessionRenewedOnAuthentication;
     private int _sessionMaxInactiveIntervalOnAuthentication;
     private boolean _proxy;
+    private boolean _persistAuthenticationCredentials;
 
     protected LoginAuthenticator()
     {
@@ -168,11 +169,22 @@ public abstract class LoginAuthenticator implements Authenticator
             throw new IllegalStateException("No IdentityService for " + this + " in " + configuration);
         _sessionRenewedOnAuthentication = configuration.isSessionRenewedOnAuthentication();
         _sessionMaxInactiveIntervalOnAuthentication = configuration.getSessionMaxInactiveIntervalOnAuthentication();
+        _persistAuthenticationCredentials = configuration.isPersistAuthenticationCredentials();
+    }
+
+    public boolean isPersistAuthenticationCredentials()
+    {
+        return _persistAuthenticationCredentials;
     }
 
     public LoginService getLoginService()
     {
         return _loginService;
+    }
+
+    public SessionAuthentication newSessionAuthentication(String method, UserIdentity userIdentity, Object credentials)
+    {
+        return new SessionAuthentication(method, userIdentity, credentials, _persistAuthenticationCredentials);
     }
 
     /**

--- a/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/SessionAuthentication.java
+++ b/jetty-ee9/jetty-ee9-security/src/main/java/org/eclipse/jetty/ee9/security/authentication/SessionAuthentication.java
@@ -15,8 +15,10 @@ package org.eclipse.jetty.ee9.security.authentication;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.io.Serial;
 import java.io.Serializable;
+import javax.security.auth.Subject;
 
 import jakarta.servlet.http.HttpSession;
 import jakarta.servlet.http.HttpSessionActivationListener;
@@ -25,7 +27,10 @@ import jakarta.servlet.http.HttpSessionEvent;
 import org.eclipse.jetty.ee9.security.AbstractUserAuthentication;
 import org.eclipse.jetty.ee9.security.Authenticator;
 import org.eclipse.jetty.ee9.security.SecurityHandler;
+import org.eclipse.jetty.security.IdentityService;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.NamePrincipal;
+import org.eclipse.jetty.security.RolePrincipal;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.util.TypeUtil;
 import org.slf4j.Logger;
@@ -46,15 +51,24 @@ public class SessionAuthentication extends AbstractUserAuthentication
 
     public static final String __J_AUTHENTICATED = "org.eclipse.jetty.security.UserIdentity";
 
+    private transient HttpSession _session;
+    private transient boolean _persistAuthenticationCredentials;
     private final String _name;
     private final Object _credentials;
-    private transient HttpSession _session;
+    private final String[] _roles;
 
     public SessionAuthentication(String method, UserIdentity userIdentity, Object credentials)
     {
+        this(method, userIdentity, credentials, false);
+    }
+
+    public SessionAuthentication(String method, UserIdentity userIdentity, Object credentials, boolean serializeCredentials)
+    {
         super(method, userIdentity);
         _name = userIdentity.getUserPrincipal().getName();
+        _roles = userIdentity.getRoles();
         _credentials = credentials;
+        _persistAuthenticationCredentials = serializeCredentials;
     }
 
     @Override
@@ -71,8 +85,8 @@ public class SessionAuthentication extends AbstractUserAuthentication
     {
         stream.defaultReadObject();
 
-        SecurityHandler security = SecurityHandler.getCurrentSecurityHandler();
-        if (security == null)
+        SecurityHandler securityHandler = SecurityHandler.getCurrentSecurityHandler();
+        if (securityHandler == null)
         {
             if (LOG.isDebugEnabled())
                 LOG.debug("!SecurityHandler");
@@ -80,22 +94,81 @@ public class SessionAuthentication extends AbstractUserAuthentication
         }
 
         LoginService loginService;
-        Authenticator authenticator = security.getAuthenticator();
-        if (authenticator instanceof LoginAuthenticator)
-            loginService = ((LoginAuthenticator)authenticator).getLoginService();
-        else
-            loginService = security.getLoginService();
-
-        if (loginService == null)
+        Authenticator authenticator = securityHandler.getAuthenticator();
+        if (authenticator instanceof LoginAuthenticator loginAuthenticator)
         {
-            if (LOG.isDebugEnabled())
-                LOG.debug("!LoginService");
-            return;
+            loginService = loginAuthenticator.getLoginService();
+            _persistAuthenticationCredentials = loginAuthenticator.isPersistAuthenticationCredentials();
+        }
+        else
+        {
+            loginService = securityHandler.getLoginService();
+            _persistAuthenticationCredentials = securityHandler.isPersistAuthenticationCredentials();
         }
 
-        _userIdentity = loginService.login(_name, _credentials, null, null);
-        if (LOG.isDebugEnabled())
-            LOG.debug("Deserialized and relogged in {}", this);
+        // If _persistAuthenticationCredentials is true we must always try to re-login with the loginService.
+        // If _roles is null, it is an old SessionAuthentication, and we should re-login with the LoginService.
+        if (_persistAuthenticationCredentials || _roles == null)
+        {
+            if (loginService == null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("!LoginService");
+                return;
+            }
+
+            _userIdentity = loginService.login(_name, _credentials, null, null);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Deserialized and relogged in {}", this);
+        }
+        else
+        {
+            IdentityService identityService = (loginService == null) ? securityHandler.getIdentityService() : loginService.getIdentityService();
+            if (identityService == null)
+            {
+                if (LOG.isDebugEnabled())
+                    LOG.debug("!IdentityService");
+                return;
+            }
+
+            Subject subject = new Subject();
+            NamePrincipal principal = new NamePrincipal(_name);
+            subject.getPrincipals().add(principal);
+            for (String role : _roles)
+            {
+                if (role != null)
+                    subject.getPrincipals().add(new RolePrincipal(role));
+            }
+            subject.setReadOnly();
+
+            _userIdentity = identityService.newUserIdentity(subject, principal, _roles);
+            if (LOG.isDebugEnabled())
+                LOG.debug("Deserialized {}", this);
+        }
+    }
+
+    @Serial
+    protected Object readResolve()
+    {
+        // A SessionAuthentication without a UserIdentity is invalid, and should be deserialized as null instead
+        // of throwing ISE when getUserIdentity() is called, which would result in a 500 response.
+        if (_userIdentity == null)
+        {
+            if (LOG.isDebugEnabled())
+                LOG.debug("Dropping unrestorable authentication for {}", _name);
+            return null;
+        }
+        return this;
+    }
+
+    @Serial
+    private void writeObject(ObjectOutputStream out) throws IOException
+    {
+        ObjectOutputStream.PutField fields = out.putFields();
+        fields.put("_name", _name);
+        fields.put("_credentials", _persistAuthenticationCredentials ? _credentials : null);
+        fields.put("_roles", _roles);
+        out.writeFields();
     }
 
     @Override

--- a/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/PersistAuthenticationCredentialsTest.java
+++ b/jetty-ee9/jetty-ee9-tests/jetty-ee9-test-integration/src/test/java/org/eclipse/jetty/ee9/test/PersistAuthenticationCredentialsTest.java
@@ -1,0 +1,317 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.awaitility.Awaitility;
+import org.eclipse.jetty.ee9.nested.Authentication;
+import org.eclipse.jetty.ee9.nested.ServletConstraint;
+import org.eclipse.jetty.ee9.nested.SessionHandler;
+import org.eclipse.jetty.ee9.security.ConstraintMapping;
+import org.eclipse.jetty.ee9.security.ConstraintSecurityHandler;
+import org.eclipse.jetty.ee9.security.ServerAuthException;
+import org.eclipse.jetty.ee9.security.UserAuthentication;
+import org.eclipse.jetty.ee9.security.authentication.LoginAuthenticator;
+import org.eclipse.jetty.ee9.security.authentication.SessionAuthentication;
+import org.eclipse.jetty.ee9.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee9.servlet.ServletHolder;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.security.AuthenticationState;
+import org.eclipse.jetty.security.HashLoginService;
+import org.eclipse.jetty.security.UserIdentity;
+import org.eclipse.jetty.security.UserStore;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.session.FileSessionDataStoreFactory;
+import org.eclipse.jetty.session.NullSessionCacheFactory;
+import org.eclipse.jetty.util.security.Credential;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class PersistAuthenticationCredentialsTest
+{
+    private static final Logger LOG = LoggerFactory.getLogger(PersistAuthenticationCredentialsTest.class);
+
+    @TempDir
+    private File _tempDir;
+    private LocalConnector _localConnector;
+    private Server _server;
+    private ConstraintSecurityHandler _securityHandler;
+
+    @BeforeEach
+    public void setup() throws Exception
+    {
+        _server = new Server();
+        _localConnector = new LocalConnector(_server);
+        _server.addConnector(_localConnector);
+        _securityHandler = new ConstraintSecurityHandler();
+        ConstraintMapping constraintMapping = new ConstraintMapping();
+        constraintMapping.setPathSpec("/*");
+        ServletConstraint servletConstraint = new ServletConstraint();
+        servletConstraint.setAuthenticate(true);
+        servletConstraint.setRoles(new String[]{"**"});
+        constraintMapping.setConstraint(servletConstraint);
+        _securityHandler.addConstraintMapping(constraintMapping);
+        HashLoginService loginService = new HashLoginService();
+        UserStore userStore = new UserStore();
+        userStore.addUser("foo", Credential.getCredential("bar"), new String[]{"admin"});
+        loginService.setUserStore(userStore);
+        _securityHandler.setLoginService(loginService);
+
+        _securityHandler.setAuthenticator(new LoginAuthenticator()
+        {
+            @Override
+            public String getAuthMethod()
+            {
+                return "TEST";
+            }
+
+            @Override
+            public UserIdentity login(String username, Object password, ServletRequest request)
+            {
+
+                UserIdentity user = super.login(username, password, request);
+                if (user != null)
+                {
+
+                    HttpSession session = ((HttpServletRequest)request).getSession(true);
+                    Authentication cached = newSessionAuthentication(getAuthMethod(), user, password);
+                    session.setAttribute(SessionAuthentication.__J_AUTHENTICATED, cached);
+                }
+                return user;
+            }
+
+            @Override
+            public Authentication validateRequest(ServletRequest request, ServletResponse response, boolean mandatory) throws ServerAuthException
+            {
+                HttpServletRequest httpServletRequest = (HttpServletRequest)request;
+                HttpServletResponse httpServletResponse = (HttpServletResponse)response;
+
+                // Look for cached authentication
+                HttpSession session = httpServletRequest.getSession(false);
+                Authentication authenticationState = session == null ? null : (Authentication)session.getAttribute(SessionAuthentication.__J_AUTHENTICATED);
+                if (LOG.isDebugEnabled())
+                    LOG.debug("auth {}", authenticationState);
+                // Has authentication been revoked?
+                if (authenticationState instanceof AuthenticationState.Succeeded succeeded && _loginService != null && !_loginService.validate(succeeded.getUserIdentity()))
+                {
+                    if (LOG.isDebugEnabled())
+                        LOG.debug("auth revoked {}", authenticationState);
+                    session.removeAttribute(SessionAuthentication.__J_AUTHENTICATED);
+                    authenticationState = null;
+                }
+
+                if (authenticationState != null)
+                {
+                    httpServletResponse.setHeader("source", "session");
+                    return authenticationState;
+                }
+
+                httpServletResponse.setHeader("source", "login");
+                UserIdentity userIdentity = login("foo", "bar", request);
+                return new UserAuthentication("TEST", userIdentity);
+            }
+
+            @Override
+            public boolean secureResponse(ServletRequest request, ServletResponse response, boolean mandatory, Authentication.User validatedUser) throws org.eclipse.jetty.ee9.security.ServerAuthException
+            {
+                return false;
+            }
+        });
+        FileSessionDataStoreFactory sessionDataStoreFactory = new FileSessionDataStoreFactory();
+        sessionDataStoreFactory.setStoreDir(_tempDir);
+        _server.addBean(sessionDataStoreFactory);
+        _server.addBean(new NullSessionCacheFactory());
+
+        SessionHandler sessionHandler = new SessionHandler();
+        sessionHandler.setHandler(_securityHandler);
+
+        ServletContextHandler servletContextHandler = new ServletContextHandler();
+        servletContextHandler.setSessionHandler(sessionHandler);
+        servletContextHandler.setSecurityHandler(_securityHandler);
+        _server.setHandler(servletContextHandler);
+
+        servletContextHandler.addServlet(new ServletHolder(new HttpServlet()
+        {
+            @Override
+            protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+            {
+                resp.setStatus(HttpStatus.OK_200);
+            }
+        }), "/");
+    }
+
+    @AfterEach
+    public void shutdown() throws Exception
+    {
+        _server.stop();
+    }
+
+    private File[] listFiles()
+    {
+        File[] files = _tempDir.listFiles();
+        if (files == null)
+            return new File[0];
+        return files;
+    }
+
+    private String getSessionData() throws IOException
+    {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).until(() -> listFiles().length > 0);
+        File[] files = listFiles();
+        if (files.length != 1)
+            throw new IllegalStateException("Expected exactly one session file, but found: " + Arrays.toString(files));
+        return new String(Files.readAllBytes(files[0].toPath()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    public void testPersistAuthenticationCredentials(boolean persistAuthenticationCredentials) throws Exception
+    {
+        if (persistAuthenticationCredentials)
+            _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // Check session data on disk to ensure "bar" password is not in it
+        if (persistAuthenticationCredentials)
+            assertThat(getSessionData(), containsString("bar"));
+        else
+            assertThat(getSessionData(), not(containsString("bar")));
+
+        // Verify that we can load it from disk again.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("session"));
+    }
+
+    @Test
+    public void testLegacySessionCredentialsCompatibility() throws Exception
+    {
+        _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // Check session data on disk to ensure "bar" password is in it
+        assertThat(getSessionData(), containsString("bar"));
+
+        // Restart the server with the mode to not save credentials to verify we can still read it.
+        _server.stop();
+        _securityHandler.setPersistAuthenticationCredentials(false);
+        _server.start();
+
+        // Verify that we can load it from disk again.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("session"));
+
+        // The credential is no longer stored in the SessionData.
+        assertThat(getSessionData(), not(containsString("bar")));
+    }
+
+    @Test
+    public void testEnablePersistCredentials() throws Exception
+    {
+        _securityHandler.setPersistAuthenticationCredentials(false);
+        _server.start();
+
+        HttpTester.Response response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+        String sessionId = response.get(HttpHeader.SET_COOKIE).split("JSESSIONID=")[1].split(";")[0];
+
+        // The credential is not stored in the SessionData.
+        assertThat(getSessionData(), not(containsString("bar")));
+
+        // Restart the server with the setting to persist the credential.
+        _server.stop();
+        _securityHandler.setPersistAuthenticationCredentials(true);
+        _server.start();
+
+        // The persisted authentication has no credentials, and credentials are now required to
+        // re-login, so the cached authentication cannot be restored. Rather than failing the
+        // request, it is treated as unauthenticated and the user must authenticate.
+        response = HttpTester.parseResponse(_localConnector.getResponse("""
+            GET /hello HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            Cookie: JSESSIONID=%s\r
+            \r
+            """.formatted(sessionId)));
+        assertThat(response.getStatus(), equalTo(HttpStatus.OK_200));
+        assertThat(response.get("source"), equalTo("login"));
+
+        // Now that persistence is enabled the re-login persists the credential.
+        assertThat(getSessionData(), containsString("bar"));
+    }
+}

--- a/jetty-integrations/jetty-ethereum/src/main/java/org/eclipse/jetty/security/siwe/EthereumAuthenticator.java
+++ b/jetty-integrations/jetty-ethereum/src/main/java/org/eclipse/jetty/security/siwe/EthereumAuthenticator.java
@@ -307,7 +307,7 @@ public class EthereumAuthenticator extends LoginAuthenticator implements Dumpabl
         if (user != null)
         {
             Session session = request.getSession(true);
-            AuthenticationState cached = new SessionAuthentication(getAuthenticationType(), user, credentials);
+            AuthenticationState cached = newSessionAuthentication(getAuthenticationType(), user, credentials);
             synchronized (session)
             {
                 session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, cached);

--- a/jetty-integrations/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
+++ b/jetty-integrations/jetty-openid/src/main/java/org/eclipse/jetty/security/openid/OpenIdAuthenticator.java
@@ -18,6 +18,7 @@ import java.io.Serial;
 import java.io.Serializable;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
+import java.security.Principal;
 import java.security.SecureRandom;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -35,6 +36,7 @@ import org.eclipse.jetty.security.AuthenticationState;
 import org.eclipse.jetty.security.Authenticator;
 import org.eclipse.jetty.security.Constraint;
 import org.eclipse.jetty.security.LoginService;
+import org.eclipse.jetty.security.RoleDelegateUserIdentity;
 import org.eclipse.jetty.security.ServerAuthException;
 import org.eclipse.jetty.security.UserIdentity;
 import org.eclipse.jetty.security.authentication.LoginAuthenticator;
@@ -237,7 +239,7 @@ public class OpenIdAuthenticator extends LoginAuthenticator
         if (user != null)
         {
             Session session = request.getSession(true);
-            AuthenticationState cached = new SessionAuthentication(getAuthenticationType(), user, credentials);
+            AuthenticationState cached = newSessionAuthentication(getAuthenticationType(), user, credentials);
             synchronized (session)
             {
                 session.setAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE, cached);
@@ -518,9 +520,32 @@ public class OpenIdAuthenticator extends LoginAuthenticator
         AuthenticationState authenticationState = (AuthenticationState)session.getAttribute(SessionAuthentication.AUTHENTICATED_ATTRIBUTE);
         if (authenticationState != null)
         {
+            boolean isUserIdentityValid = false;
+            if (authenticationState instanceof AuthenticationState.Succeeded succeeded && _loginService != null)
+            {
+                UserIdentity userIdentity = succeeded.getUserIdentity();
+                Principal principal = userIdentity.getUserPrincipal();
+                if (principal instanceof OpenIdUserPrincipal)
+                {
+                    isUserIdentityValid = _loginService.validate(userIdentity);
+                }
+                else
+                {
+                    // We need to reconstruct the OpenIdUserPrincipal.
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> claims = (Map<String, Object>)session.getAttribute(CLAIMS);
+                    if (claims != null)
+                    {
+                        OpenIdCredentials openIdCredentials = new OpenIdCredentials(claims);
+                        OpenIdUserPrincipal openIdUserPrincipal = new OpenIdUserPrincipal(openIdCredentials);
+                        userIdentity = new RoleDelegateUserIdentity(userIdentity.getSubject(), openIdUserPrincipal, userIdentity);
+                        isUserIdentityValid = _loginService.validate(userIdentity);
+                    }
+                }
+            }
+
             // Has authentication been revoked?
-            if (authenticationState instanceof AuthenticationState.Succeeded && _loginService != null &&
-                !_loginService.validate(((AuthenticationState.Succeeded)authenticationState).getUserIdentity()))
+            if (!isUserIdentityValid)
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("auth revoked {}", authenticationState);


### PR DESCRIPTION
- additional setters on `SecurityHandler` to switch modes for the `SessionAuthentication` persistence in session attributes.
- Introduce a new method on `UserIdentity` called `getRoles()`, with a default implementation on the interface.
- additional testing