### PR TITLE
Making CIDR pattern matching case insensitive

### DIFF
--- a/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
+++ b/jetty-ee10/jetty-ee10-servlets/src/main/java/org/eclipse/jetty/ee10/servlets/DoSFilter.java
@@ -124,7 +124,7 @@ public class DoSFilter implements Filter
     private static final Pattern IPv4_PATTERN = Pattern.compile(IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP);
     private static final String IPv6_GROUP = "(\\p{XDigit}{1,4})";
     private static final Pattern IPv6_PATTERN = Pattern.compile(IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP);
-    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private static final String __TRACKER = "DoSFilter.Tracker";
     private static final String __THROTTLED = "DoSFilter.Throttled";

--- a/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
+++ b/jetty-ee11/jetty-ee11-servlets/src/main/java/org/eclipse/jetty/ee11/servlets/DoSFilter.java
@@ -124,7 +124,7 @@ public class DoSFilter implements Filter
     private static final Pattern IPv4_PATTERN = Pattern.compile(IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP);
     private static final String IPv6_GROUP = "(\\p{XDigit}{1,4})";
     private static final Pattern IPv6_PATTERN = Pattern.compile(IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP);
-    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private static final String __TRACKER = "DoSFilter.Tracker";
     private static final String __THROTTLED = "DoSFilter.Throttled";

--- a/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
+++ b/jetty-ee9/jetty-ee9-servlets/src/main/java/org/eclipse/jetty/ee9/servlets/DoSFilter.java
@@ -123,7 +123,7 @@ public class DoSFilter implements Filter
     private static final Pattern IPv4_PATTERN = Pattern.compile(IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP + "\\." + IPv4_GROUP);
     private static final String IPv6_GROUP = "(\\p{XDigit}{1,4})";
     private static final Pattern IPv6_PATTERN = Pattern.compile(IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP + ":" + IPv6_GROUP);
-    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)");
+    private static final Pattern CIDR_PATTERN = Pattern.compile("([^/]+)/(\\d+)", Pattern.CASE_INSENSITIVE);
 
     private static final String __TRACKER = "DoSFilter.Tracker";
     private static final String __THROTTLED = "DoSFilter.Throttled";


### PR DESCRIPTION
Simple tweak to CIDR_PATTERN to make it case insensitive.
This will have no impact on IPv4, but can improve configuration gotchas on IPv6. 