### PR TITLE
Issue #14906 - Serialize test archive extraction

### DIFF
--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -264,7 +264,7 @@ public class JettyHomeTester
         }
     }
 
-    public static void unzip(Path archive, Path outputDir) throws IOException
+    public static synchronized void unzip(Path archive, Path outputDir) throws IOException
     {
         if (Files.notExists(outputDir))
             throw new FileNotFoundException("Directory does not exist: " + outputDir);

--- a/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
+++ b/tests/jetty-testers/src/main/java/org/eclipse/jetty/tests/testers/JettyHomeTester.java
@@ -264,6 +264,7 @@ public class JettyHomeTester
         }
     }
 
+    // Serialize unzips to avoid FileSystemAlreadyExistsException when unzips are executed concurrently.
     public static synchronized void unzip(Path archive, Path outputDir) throws IOException
     {
         if (Files.notExists(outputDir))


### PR DESCRIPTION
Fixes #14906.

`RedispatchTests` and `RedispatchPlansTests` can initialize separate Jetty test bases in parallel while extracting the same WAR. The second ZipFS mount in `JettyHomeTester.unzip()` can throw `FileSystemAlreadyExistsException`, and the existing concurrency fallback then returns before the affected test's exploded webapp is populated.

Serialize `JettyHomeTester.unzip()` through extraction and ZipFS close so each test base is fully populated before setup continues.

Tests:

```text
mvn -q -B -V -Dmaven.build.cache.enabled=false \
  -pl tests/test-cross-context-dispatch/ccd-tests \
  -Dtest=RedispatchTests,RedispatchPlansTests \
  -DfailIfNoTests=false test
```

The target tests pass with the existing parallel execution (`RedispatchTests` 1/1 and `RedispatchPlansTests` 15/15).
