### PR TITLE
[12.0.x] Reuses URIUtil.canonicalPath() for URI matching.

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractAuthentication.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/AbstractAuthentication.java
@@ -15,6 +15,8 @@ package org.eclipse.jetty.client;
 
 import java.net.URI;
 
+import org.eclipse.jetty.util.URIUtil;
+
 /**
  * <p>Abstract base class for authentication implementations.
  * Provides common functionality for URI and realm matching.</p>
@@ -69,20 +71,36 @@ public abstract class AbstractAuthentication implements Authentication
     public static boolean matchesURI(URI uri1, URI uri2)
     {
         String scheme = uri1.getScheme();
-        if (scheme.equalsIgnoreCase(uri2.getScheme()))
-        {
-            if (uri1.getHost().equalsIgnoreCase(uri2.getHost()))
-            {
-                // Handle default HTTP ports.
-                int thisPort = HttpClient.normalizePort(scheme, uri1.getPort());
-                int thatPort = HttpClient.normalizePort(scheme, uri2.getPort());
-                if (thisPort == thatPort)
-                {
-                    // Use decoded URI paths.
-                    return uri2.getPath().startsWith(uri1.getPath());
-                }
-            }
-        }
-        return false;
+        if (scheme == null || !scheme.equalsIgnoreCase(uri2.getScheme()))
+            return false;
+
+        String host = uri1.getHost();
+        if (host == null || !host.equalsIgnoreCase(uri2.getHost()))
+            return false;
+
+        // Handle default HTTP ports.
+        if (HttpClient.normalizePort(scheme, uri1.getPort()) != HttpClient.normalizePort(scheme, uri2.getPort()))
+            return false;
+
+        // Compare canonical paths.
+        String path1 = URIUtil.canonicalPath(uri1.getRawPath());
+        String path2 = URIUtil.canonicalPath(uri2.getRawPath());
+        if (path1 == null || path2 == null)
+            return false;
+
+        if (path1.endsWith("/"))
+            path1 = path1.substring(0, path1.length() - 1);
+
+        if (path1.isEmpty())
+            return true;
+
+        if (!path2.startsWith(path1))
+            return false;
+
+        if (path2.length() == path1.length())
+            return true;
+
+        // Must match at a segment boundary.
+        return path2.charAt(path1.length()) == '/';
     }
 }

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpAuthenticationStoreTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpAuthenticationStoreTest.java
@@ -17,8 +17,11 @@ import java.net.URI;
 
 import org.eclipse.jetty.client.internal.HttpAuthenticationStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class HttpAuthenticationStoreTest
 {
@@ -43,6 +46,59 @@ public class HttpAuthenticationStoreTest
         store.addAuthentication(new DigestAuthentication(uri1, realm, "user", "password"));
         result = store.findAuthentication("Digest", uri2, realm);
         assertNotNull(result);
+    }
+
+    @ParameterizedTest
+    @CsvSource(useHeadersInDisplayName = true, textBlock = """
+        registered,            requested,                matches
+        http://host,           http://host/any,          true
+        http://host/,          http://host/any,          true
+        http://host/,          http://HOST/any,          true
+        http://host/,          http://host:80/any,       true
+        http://host/ctx/,      http://host/ctx/,         true
+        http://host/ctx/,      http://host/ctx,          true
+        http://host/ctx,       http://host/ctx,          true
+        http://host/ctx,       http://host/ctx/,         true
+        http://host/ctx,       http://host/ctx/;j=1,     true
+        http://host/ctx,       http://host/ctx?q=1,      true
+        http://host/ctx,       http://host/ctx/?q=1,     true
+        http://host/ctx,       http://host/ctx/path,     true
+        http://host/ctx,       http://host/ctx//path,    true
+        http://host/ctx,       http://host/c/../ctx/p,   true
+        http://host/ctx,       http://host/ctx/p/../s,   true
+        http://host/ctx,       http://host/ctx/./path,   true
+        http://host/ctx/~user, http://host/ctx/~user,    true
+        http://host/ctx/~user, http://host/ctx/%7Euser,  true
+        http://host/ctx%2Fp,   http://host/ctx%2fp,      true
+        http://host/ctx%2Fp,   http://host/ctx/p,        false
+        http://host/ctx,       http://host/ctx2,         false
+        http://host/ctx/,      http://host/ctx2,         false
+        http://host/ctx,       http://host/ctx2/path,    false
+        http://host/ctx,       http://host/c,            false
+        http://host/ctx,       http://host/CTX,          false
+        http://host/ctx,       http://host/ctx%2Fpath,   false
+        http://host/ctx,       http://host/ctx/..,       false
+        http://host/ctx,       http://host/ctx/../path,  false
+        http://host/ctx,       http://host/ctx/..;/path, false
+        http://host/ctx/path,  http://host/ctx,          false
+        http://host/ctx/path,  http://host/ctx/,         false
+        """)
+    public void testFindAuthenticationWithURI(String registered, String requested, boolean matches)
+    {
+        AuthenticationStore store = new HttpAuthenticationStore();
+
+        URI uri1 = URI.create(registered);
+        String realm = "realm";
+        store.addAuthentication(new BasicAuthentication(uri1, realm, "user", "password"));
+
+        URI uri2 = URI.create(requested);
+        Authentication result = store.findAuthentication("Basic", uri2, realm);
+        if (matches)
+            assertNotNull(result);
+        else
+            assertNull(result);
+
+        store.clearAuthentications();
     }
 
     @Test


### PR DESCRIPTION
12.0.x backport of https://github.com/jetty/jetty.project/pull/15612