### PR TITLE
Fix incorrect eager aborting of H2 channels during graceful shutdown

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/HttpClientTransportOverHTTP2.java
@@ -143,7 +143,7 @@ public class HttpClientTransportOverHTTP2 extends AbstractHttpClientTransport
 
     protected void onClose(Connection connection, GoAwayFrame frame)
     {
-        connection.close();
+        ((HttpConnectionOverHTTP2)connection).upwardClose();
     }
 
     private class SessionListenerPromise extends HTTPSessionListenerPromise

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -130,6 +130,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
     @Override
     public void release()
     {
+        Stream stream = getStream();
         setStream(null);
         connection.release(this);
         if (LOG.isDebugEnabled())

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -300,28 +300,51 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
     {
         boolean removed;
         boolean destroy;
+        boolean runZeroChannelAction;
         try (AutoLock ignored = lock.lock())
         {
             removed = activeChannels.remove(channel);
-            destroy = closed || !removed || channel.isFailed();
-            // Recycle only non-failed channels.
-            if (isRecycleHttpChannels() && !destroy)
-                idleChannels.offer(channel);
+            if (activeChannels.isEmpty())
+            {
+                destroy = false;
+                runZeroChannelAction = true;
+            }
+            else
+            {
+                runZeroChannelAction = false;
+                destroy = closed || !removed || channel.isFailed();
+                // Recycle only non-failed channels.
+                if (isRecycleHttpChannels() && !destroy)
+                    idleChannels.offer(channel);
+            }
         }
         if (LOG.isDebugEnabled())
-            LOG.debug("released={} destroy={} {}", removed, destroy, channel);
-        if (destroy)
-            channel.destroy();
-        getHttpDestination().release(this);
+            LOG.debug("released={} destroy={} runZeroChannelAction={} {}", removed, destroy, runZeroChannelAction, channel);
+
+        if (runZeroChannelAction)
+        {
+            zeroChannelAction();
+        }
+        else
+        {
+            if (destroy)
+                channel.destroy();
+            getHttpDestination().release(this);
+        }
     }
 
     private void destroyHttpChannel(HttpChannelOverHTTP2 channel)
     {
+        boolean runZeroChannelAction;
         try (AutoLock ignored = lock.lock())
         {
             activeChannels.remove(channel);
+            runZeroChannelAction = activeChannels.isEmpty();
         }
-        channel.destroy();
+        if (runZeroChannelAction)
+            zeroChannelAction();
+        else
+            channel.destroy();
     }
 
     void remove()
@@ -335,9 +358,28 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             LOG.debug("Failure {}", this, failure);
         if (ensureClosedOrAbortActiveChannels(() -> failure))
             return;
+        zeroChannelAction();
+        callback.succeeded();
+    }
+
+    public void upwardClose()
+    {
+        boolean runZeroChannelAction;
+        try (AutoLock ignored = lock.lock())
+        {
+            if (closed)
+                return;
+            closed = true;
+            runZeroChannelAction = activeChannels.isEmpty();
+        }
+        if (runZeroChannelAction)
+            zeroChannelAction();
+    }
+
+    private void zeroChannelAction()
+    {
         remove();
         destroy();
-        callback.succeeded();
     }
 
     @Override
@@ -347,11 +389,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             LOG.debug("Close {}", this);
         if (ensureClosedOrAbortActiveChannels(ClosedChannelException::new))
             return;
-        session.close(ErrorCode.NO_ERROR.code, "close", Callback.from(() ->
-        {
-            remove();
-            destroy();
-        }));
+        session.close(ErrorCode.NO_ERROR.code, "close", Callback.from(this::zeroChannelAction));
     }
 
     /**

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -304,7 +304,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         try (AutoLock ignored = lock.lock())
         {
             removed = activeChannels.remove(channel);
-            if (activeChannels.isEmpty())
+            if (closed && activeChannels.isEmpty())
             {
                 destroy = false;
                 runZeroChannelAction = true;
@@ -339,7 +339,7 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
         try (AutoLock ignored = lock.lock())
         {
             activeChannels.remove(channel);
-            runZeroChannelAction = activeChannels.isEmpty();
+            runZeroChannelAction = closed && activeChannels.isEmpty();
         }
         if (runZeroChannelAction)
             zeroChannelAction();

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GoAwayTest.java
@@ -13,6 +13,7 @@
 
 package org.eclipse.jetty.http2.tests;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -48,6 +49,7 @@ import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
 import org.eclipse.jetty.http2.frames.ResetFrame;
 import org.eclipse.jetty.http2.frames.SettingsFrame;
+import org.eclipse.jetty.util.Blocker;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.FuturePromise;
@@ -289,6 +291,133 @@ public class GoAwayTest extends AbstractTest
 
         assertFalse(((HTTP2Session)serverSessionRef.get()).getEndPoint().isOpen());
         assertFalse(((HTTP2Session)clientSession).getEndPoint().isOpen());
+    }
+
+    @Test
+    public void testServerSendsGracefulGoAwayAfterLastData() throws Exception
+    {
+        AtomicReference<Stream> serverStream = new AtomicReference<>();
+        AtomicReference<Stream> clientStream = new AtomicReference<>();
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                serverStream.set(stream);
+                if (!frame.isEndStream())
+                    stream.demand();
+
+                stream.headers(new HeadersFrame(stream.getId(), new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY), null, false), Callback.NOOP);
+                stream.data(new DataFrame(stream.getId(), ByteBuffer.allocate(1024), true), Callback.NOOP);
+                return Stream.Listener.AUTO_DISCARD;
+            }
+        });
+
+        Session clientSession = newClientSession(new Session.Listener()
+        {
+            @Override
+            public void onGoAway(Session session, GoAwayFrame frame)
+            {
+                if (!frame.isGraceful())
+                    clientStream.get().demand();
+            }
+        });
+
+        CountDownLatch clientStreamClosedLatch = new CountDownLatch(1);
+        clientSession.newStream(new HeadersFrame(newRequest(HttpMethod.GET.asString(), HttpFields.EMPTY), null, true), new Promise<>()
+        {
+            @Override
+            public void succeeded(Stream result)
+            {
+                clientStream.set(result);
+            }
+        }, new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                // server sends a go away
+                try (Blocker.Callback bcb = Blocker.callback())
+                {
+                    ((HTTP2Session)serverStream.get().getSession()).goAway(GoAwayFrame.GRACEFUL, bcb);
+                    bcb.block();
+                }
+                catch (IOException e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onClosed(Stream stream)
+            {
+                clientStreamClosedLatch.countDown();
+            }
+        });
+
+        assertTrue(clientStreamClosedLatch.await(5, TimeUnit.SECONDS));
+    }
+
+    @Test
+    public void testServerShutdownAfterLastData() throws Exception
+    {
+        AtomicReference<Stream> clientStream = new AtomicReference<>();
+        start(new ServerSessionListener()
+        {
+            @Override
+            public Stream.Listener onNewStream(Stream stream, HeadersFrame frame)
+            {
+                if (!frame.isEndStream())
+                    stream.demand();
+
+                stream.headers(new HeadersFrame(stream.getId(), new MetaData.Response(HttpStatus.OK_200, null, HttpVersion.HTTP_2, HttpFields.EMPTY), null, false), Callback.NOOP);
+                stream.data(new DataFrame(stream.getId(), ByteBuffer.allocate(1024), true), Callback.NOOP);
+                return Stream.Listener.AUTO_DISCARD;
+            }
+        });
+
+        Session clientSession = newClientSession(new Session.Listener()
+        {
+            @Override
+            public void onGoAway(Session session, GoAwayFrame frame)
+            {
+                if (!frame.isGraceful())
+                    clientStream.get().demand();
+            }
+        });
+
+        CountDownLatch clientStreamClosedLatch = new CountDownLatch(1);
+        clientSession.newStream(new HeadersFrame(newRequest(HttpMethod.GET.asString(), HttpFields.EMPTY), null, true), new Promise<>()
+        {
+            @Override
+            public void succeeded(Stream result)
+            {
+                clientStream.set(result);
+            }
+        }, new Stream.Listener()
+        {
+            @Override
+            public void onHeaders(Stream stream, HeadersFrame frame)
+            {
+                // server shuts down
+                try
+                {
+                    server.stop();
+                }
+                catch (Exception e)
+                {
+                    throw new RuntimeException(e);
+                }
+            }
+
+            @Override
+            public void onClosed(Stream stream)
+            {
+                clientStreamClosedLatch.countDown();
+            }
+        });
+
+        assertTrue(clientStreamClosedLatch.await(5, TimeUnit.SECONDS));
     }
 
     @Test

--- a/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
+++ b/jetty-core/jetty-http2/jetty-http2-tests/src/test/java/org/eclipse/jetty/http2/tests/GracefulShutdownTest.java
@@ -13,28 +13,44 @@
 
 package org.eclipse.jetty.http2.tests;
 
+import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
+import org.eclipse.jetty.client.InputStreamResponseListener;
+import org.eclipse.jetty.client.Result;
 import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.http.HttpStatus;
 import org.eclipse.jetty.http.HttpVersion;
 import org.eclipse.jetty.http.MetaData;
+import org.eclipse.jetty.http2.HTTP2Session;
+import org.eclipse.jetty.http2.SessionContainer;
 import org.eclipse.jetty.http2.api.Session;
 import org.eclipse.jetty.http2.api.Stream;
 import org.eclipse.jetty.http2.api.server.ServerSessionListener;
 import org.eclipse.jetty.http2.frames.DataFrame;
+import org.eclipse.jetty.http2.frames.Frame;
 import org.eclipse.jetty.http2.frames.GoAwayFrame;
 import org.eclipse.jetty.http2.frames.HeadersFrame;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.handler.GracefulHandler;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.component.Graceful;
 import org.eclipse.jetty.util.component.LifeCycle;
 import org.junit.jupiter.api.Test;
 
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -239,5 +255,125 @@ public class GracefulShutdownTest extends AbstractTest
         CompletableFuture<Void> completable = serverSession.shutdown();
         // Verify that it is completed.
         assertTrue(completable.isDone());
+    }
+
+    @Test
+    public void testGracefulServerStopUsingInputStreamResponseListener() throws Exception
+    {
+        CountDownLatch serverHandlingLatch = new CountDownLatch(1);
+        GracefulHandler gracefulHandler = new GracefulHandler();
+        gracefulHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request1, Response response, Callback callback)
+            {
+                // Let the client thread start the server's graceful stopping sequence.
+                serverHandlingLatch.countDown();
+
+                // Wait for the server to receive the client's go away frame before succeeding this request.
+                SessionContainer sessionContainer = server.getContainedBeans(SessionContainer.class).stream().findFirst().orElseThrow();
+                Session session = sessionContainer.getSessions().stream().findFirst().orElseThrow();
+                ((HTTP2Session)session).addEventListener(new HTTP2Session.FrameListener()
+                {
+                    @Override
+                    public void onIncomingFrame(Session session, Frame frame)
+                    {
+                        if (frame instanceof GoAwayFrame)
+                            callback.succeeded();
+                    }
+                });
+
+                byte[] bytes = new byte[1024];
+                Arrays.fill(bytes, (byte)'X');
+                response.write(true, ByteBuffer.wrap(bytes), Callback.NOOP);
+                return true;
+            }
+        });
+        start(gracefulHandler);
+        server.setStopTimeout(5_000);
+
+        var request = httpClient.newRequest(server.getURI());
+        InputStreamResponseListener listener = new InputStreamResponseListener();
+        request.send(listener);
+
+        // Wait for the server to start handling before stopping it.
+        assertTrue(serverHandlingLatch.await(5, TimeUnit.SECONDS));
+        new Thread(() -> LifeCycle.stop(server)).start();
+
+        var response = listener.get(5, TimeUnit.SECONDS);
+        String body = new String(listener.getInputStream().readAllBytes());
+
+        assertThat(response.getStatus(), is(200));
+        assertThat("X".repeat(1024), is(body));
+    }
+
+    @Test
+    public void testGracefulServerStop() throws Exception
+    {
+        CountDownLatch serverStoppedLatch = new CountDownLatch(1);
+        CountDownLatch serverHandlingLatch = new CountDownLatch(1);
+        GracefulHandler gracefulHandler = new GracefulHandler();
+        gracefulHandler.setHandler(new Handler.Abstract()
+        {
+            @Override
+            public boolean handle(Request request1, Response response, Callback callback)
+            {
+                // Let the client thread start the server's graceful stopping sequence.
+                serverHandlingLatch.countDown();
+
+                // Wait for the server to receive the client's go away frame before succeeding this request.
+                SessionContainer sessionContainer = server.getContainedBeans(SessionContainer.class).stream().findFirst().orElseThrow();
+                Session session = sessionContainer.getSessions().stream().findFirst().orElseThrow();
+                ((HTTP2Session)session).addEventListener(new HTTP2Session.FrameListener()
+                {
+                    @Override
+                    public void onIncomingFrame(Session session, Frame frame)
+                    {
+                        // Wait until server received the client's go away frame.
+                        if (frame instanceof GoAwayFrame)
+                        {
+                            callback.succeeded();
+                            serverStoppedLatch.countDown();
+                        }
+                    }
+                });
+
+                byte[] bytes = new byte[1024];
+                Arrays.fill(bytes, (byte)'X');
+                response.write(true, ByteBuffer.wrap(bytes), Callback.NOOP);
+                return true;
+            }
+        });
+        start(gracefulHandler);
+        server.setStopTimeout(5_000);
+
+        AtomicReference<Result> clientResultRef = new AtomicReference<>();
+        StringBuffer body = new StringBuffer();
+        var request = httpClient.newRequest(server.getURI());
+        request.send(new org.eclipse.jetty.client.Response.Listener()
+        {
+            @Override
+            public void onContent(org.eclipse.jetty.client.Response response, ByteBuffer content)
+            {
+                body.append(BufferUtil.toString(content));
+            }
+
+            @Override
+            public void onComplete(Result result)
+            {
+                clientResultRef.set(result);
+            }
+        });
+
+        // Wait for the server to start handling before stopping it.
+        assertTrue(serverHandlingLatch.await(5, TimeUnit.SECONDS));
+        new Thread(() -> LifeCycle.stop(server)).start();
+        assertTrue(serverStoppedLatch.await(5, TimeUnit.SECONDS));
+
+        await().atMost(5, TimeUnit.SECONDS).until(clientResultRef::get, notNullValue());
+
+        assertThat(clientResultRef.get().getResponse().getStatus(), is(200));
+        assertThat("X".repeat(1024), is(body.toString()));
+        assertThat(clientResultRef.get().getFailure(), nullValue());
     }
 }


### PR DESCRIPTION
Fix for https://github.com/jetty/jetty.project/issues/15368

Needs to be backported to 12.0.x.