### PR TITLE
[12.0.x] Improve `*AuthenticationProtocolHandler.accept()`

### DIFF
--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/HttpProxy.java
@@ -141,6 +141,17 @@ public class HttpProxy extends ProxyConfiguration.Proxy
         return URI.create(getOrigin().asString());
     }
 
+    /**
+     * <p>Returns whether tunneling is required to reach the given server {@link Origin}.</p>
+     * <p>Returns {@code true} when the server is secure, or when the client-proxy protocol
+     * is different from the proxy-server protocol.
+     * An example of the latter case is sending an HTTP/2 clear-text request to the server
+     * via a proxy that only speaks HTTP/1.1, or an HTTP/1.1 request to a server via a proxy
+     * that only speaks HTTP/2.</p>
+     *
+     * @param serverOrigin the server {@link Origin}
+     * @return true if tunneling is required to reach the server
+     */
     public boolean requiresTunnel(Origin serverOrigin)
     {
         if (HttpScheme.isSecure(serverOrigin.getScheme()))

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyAuthenticationProtocolHandler.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/ProxyAuthenticationProtocolHandler.java
@@ -15,12 +15,13 @@ package org.eclipse.jetty.client;
 
 import java.net.URI;
 
-import org.eclipse.jetty.client.transport.HttpDestination;
+import org.eclipse.jetty.client.internal.TunnelRequest;
+import org.eclipse.jetty.client.transport.HttpRequest;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 
 /**
- * <p>A protocol handler that handles the 401 response code
+ * <p>A protocol handler that handles the {@code 407} response code
  * in association with the {@code Proxy-Authenticate} header.</p>
  *
  * @see WWWAuthenticationProtocolHandler
@@ -49,7 +50,14 @@ public class ProxyAuthenticationProtocolHandler extends AuthenticationProtocolHa
     @Override
     public boolean accept(Request request, Response response)
     {
-        return response.getStatus() == HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407;
+        return response.getStatus() == HttpStatus.PROXY_AUTHENTICATION_REQUIRED_407 && isSentToProxy(request);
+    }
+
+    private boolean isSentToProxy(Request request)
+    {
+        if (request instanceof TunnelRequest)
+            return true;
+        return ((HttpRequest)request).getHttpProxy() != null;
     }
 
     @Override
@@ -67,8 +75,7 @@ public class ProxyAuthenticationProtocolHandler extends AuthenticationProtocolHa
     @Override
     protected URI getAuthenticationURI(Request request)
     {
-        HttpDestination destination = (HttpDestination)getHttpClient().resolveDestination(request);
-        ProxyConfiguration.Proxy proxy = destination.getProxy();
+        HttpProxy proxy = ((HttpRequest)request).getHttpProxy();
         return proxy != null ? proxy.getURI() : request.getURI();
     }
 

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/WWWAuthenticationProtocolHandler.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/WWWAuthenticationProtocolHandler.java
@@ -15,6 +15,7 @@ package org.eclipse.jetty.client;
 
 import java.net.URI;
 
+import org.eclipse.jetty.client.internal.TunnelRequest;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -48,7 +49,7 @@ public class WWWAuthenticationProtocolHandler extends AuthenticationProtocolHand
     @Override
     public boolean accept(Request request, Response response)
     {
-        return response.getStatus() == HttpStatus.UNAUTHORIZED_401;
+        return response.getStatus() == HttpStatus.UNAUTHORIZED_401 && !(request instanceof TunnelRequest);
     }
 
     @Override

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpConnection.java
@@ -160,20 +160,24 @@ public abstract class HttpConnection implements IConnection, Attachable
         if (proxy instanceof HttpProxy httpProxy)
         {
             boolean tunnelled = httpProxy.requiresTunnel(destination.getOrigin());
-
-            // RFC 9112, section 3.2.2: when making a request to a proxy other than CONNECT,
-            // the client must send the target URI in absolute-form as the request target.
-            // In practice, this is only valid for HTTP/1.1 requests that are not tunnelled.
-            if (http1 && !tunnelled)
+            if (!tunnelled)
             {
-                URI uri = request.getURI();
-                if (uri != null)
-                    request.path(uri.toString());
-            }
+                // RFC 9112, section 3.2.2: when making a request to a proxy other than CONNECT,
+                // the client must send the target URI in absolute-form as the request target.
+                // In practice, this is only valid for HTTP/1.1 requests that are not tunnelled.
+                if (http1)
+                {
+                    URI uri = request.getURI();
+                    if (uri != null)
+                        request.path(uri.toString());
+                }
 
-            // Do not send proxy authentication headers when tunnelled,
-            // otherwise proxy credentials arrive to the server.
-            applyProxyAuthentication = !tunnelled;
+                request.httpProxy(httpProxy);
+
+                // Send the proxy credentials only when not tunnelled,
+                // otherwise proxy credentials are leaked to the server.
+                applyProxyAuthentication = true;
+            }
         }
 
         // If we are HTTP 1.1, add the Host header.

--- a/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
+++ b/jetty-core/jetty-client/src/main/java/org/eclipse/jetty/client/transport/HttpRequest.java
@@ -44,6 +44,7 @@ import org.eclipse.jetty.client.Connection;
 import org.eclipse.jetty.client.ContentResponse;
 import org.eclipse.jetty.client.Destination;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpProxy;
 import org.eclipse.jetty.client.Origin;
 import org.eclipse.jetty.client.PathRequestContent;
 import org.eclipse.jetty.client.Request;
@@ -96,6 +97,7 @@ public class HttpRequest implements Request
     private Supplier<HttpFields> trailers;
     private Object tag;
     private boolean normalized;
+    private HttpProxy httpProxy;
 
     public HttpRequest(HttpClient client, HttpConversation conversation, URI uri)
     {
@@ -822,6 +824,16 @@ public class HttpRequest implements Request
         boolean result = normalized;
         normalized = true;
         return result;
+    }
+
+    public HttpProxy getHttpProxy()
+    {
+        return httpProxy;
+    }
+
+    void httpProxy(HttpProxy httpProxy)
+    {
+        this.httpProxy = httpProxy;
     }
 
     private String buildQuery()

--- a/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
+++ b/jetty-core/jetty-client/src/test/java/org/eclipse/jetty/client/HttpClientAuthenticationTest.java
@@ -45,8 +45,6 @@ import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ArgumentsSource;
 
 import static org.eclipse.jetty.client.Authentication.ANY_REALM;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -78,6 +76,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         start(scenario, new DigestAuthenticator(), handler);
     }
 
+    protected int getServerPort()
+    {
+        return connector.getLocalPort();
+    }
+
     private void start(Scenario scenario, Authenticator authenticator, Handler handler) throws Exception
     {
         server = new Server();
@@ -95,66 +98,66 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         start(scenario, securityHandler);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicAuthentication(Scenario scenario) throws Exception
+    @Test
+    public void testBasicAuthentication() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic", "basic"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicEmptyRealm(Scenario scenario) throws Exception
+    @Test
+    public void testBasicEmptyRealm() throws Exception
     {
         realm = "";
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic", "basic"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicAnyRealm(Scenario scenario) throws Exception
+    @Test
+    public void testBasicAnyRealm() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         testAuthentication(scenario, new BasicAuthentication(uri, ANY_REALM, "basic", "basic"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicWithUTF8Password(Scenario scenario) throws Exception
+    @Test
+    public void testBasicWithUTF8Password() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler(), StandardCharsets.UTF_8);
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
         testAuthentication(scenario, new BasicAuthentication(uri, realm, "basic_utf8", "\u20AC"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testDigestAuthentication(Scenario scenario) throws Exception
+    @Test
+    public void testDigestAuthentication() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startDigest(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         testAuthentication(scenario, new DigestAuthentication(uri, realm, "digest", "digest"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testDigestAnyRealm(Scenario scenario) throws Exception
+    @Test
+    public void testDigestAnyRealm() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startDigest(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         testAuthentication(scenario, new DigestAuthentication(uri, ANY_REALM, "digest", "digest"));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testDigestCharset(Scenario scenario) throws Exception
+    @Test
+    public void testDigestCharset() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startDigest(scenario, new EmptyServerHandler());
         URI uri = URI.create(scenario.getScheme() + "://localhost:" + connector.getLocalPort());
         // @checkstyle-disable-check : AvoidEscapedUnicodeCharactersCheck
@@ -177,7 +180,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         client.getRequestListeners().addListener(requestListener);
 
         // Request without Authentication causes a 401
-        Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        Request request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(401, response.getStatus());
@@ -198,7 +201,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         client.getRequestListeners().addListener(requestListener);
 
         // Request with authentication causes a 401 (no previous successful authentication) + 200
-        request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(200, response.getStatus());
@@ -218,7 +221,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
 
         // Further requests do not trigger 401 because there is a previous successful authentication
         // Remove existing header to be sure it's added by the implementation
-        request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(200, response.getStatus());
@@ -226,10 +229,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         client.getRequestListeners().removeListener(requestListener);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicAuthenticationThenRedirect(Scenario scenario) throws Exception
+    @Test
+    public void testBasicAuthenticationThenRedirect() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new Handler.Abstract()
         {
             private final AtomicInteger requests = new AtomicInteger();
@@ -265,7 +268,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+        ContentResponse response = client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .path("/secure")
             .timeout(5, TimeUnit.SECONDS)
@@ -276,10 +279,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         client.getRequestListeners().removeListener(requestListener);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testRedirectThenBasicAuthentication(Scenario scenario) throws Exception
+    @Test
+    public void testRedirectThenBasicAuthentication() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new Handler.Abstract()
         {
             @Override
@@ -312,7 +315,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         };
         client.getRequestListeners().addListener(requestListener);
 
-        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+        ContentResponse response = client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .path("/redirect")
             .timeout(5, TimeUnit.SECONDS)
@@ -323,10 +326,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         client.getRequestListeners().removeListener(requestListener);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicAuthenticationWithAuthenticationRemoved(Scenario scenario) throws Exception
+    @Test
+    public void testBasicAuthenticationWithAuthenticationRemoved() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
 
         AtomicReference<CountDownLatch> requests = new AtomicReference<>(new CountDownLatch(2));
@@ -345,7 +348,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         BasicAuthentication authentication = new BasicAuthentication(uri, realm, "basic", "basic");
         authenticationStore.addAuthentication(authentication);
 
-        Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        Request request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(200, response.getStatus());
@@ -354,28 +357,28 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         authenticationStore.removeAuthentication(authentication);
 
         requests.set(new CountDownLatch(1));
-        request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(200, response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
 
-        Authentication.Result result = authenticationStore.findAuthenticationResult(request.getURI());
+        Authentication.Result result = authenticationStore.findAuthenticationResult(uri);
         assertNotNull(result);
         authenticationStore.removeAuthenticationResult(result);
 
         requests.set(new CountDownLatch(1));
-        request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(401, response.getStatus());
         assertTrue(requests.get().await(5, TimeUnit.SECONDS));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testBasicAuthenticationWithWrongPassword(Scenario scenario) throws Exception
+    @Test
+    public void testBasicAuthenticationWithWrongPassword() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
@@ -383,7 +386,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         BasicAuthentication authentication = new BasicAuthentication(uri, realm, "basic", "wrong");
         authenticationStore.addAuthentication(authentication);
 
-        Request request = client.newRequest("localhost", connector.getLocalPort()).scheme(scenario.getScheme()).path("/secure");
+        Request request = client.newRequest("localhost", getServerPort()).scheme(scenario.getScheme()).path("/secure");
         ContentResponse response = request.timeout(5, TimeUnit.SECONDS).send();
         assertNotNull(response);
         assertEquals(401, response.getStatus());
@@ -392,10 +395,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertNull(authenticationResult);
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testAuthenticationThrowsException(Scenario scenario) throws Exception
+    @Test
+    public void testAuthenticationThrowsException() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
 
         // Request without Authentication would cause a 401,
@@ -418,7 +421,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         });
 
         CountDownLatch latch = new CountDownLatch(1);
-        client.newRequest("localhost", connector.getLocalPort())
+        client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .path("/secure")
             .timeout(5, TimeUnit.SECONDS)
@@ -432,10 +435,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertTrue(latch.await(5, TimeUnit.SECONDS));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testPreemptedAuthentication(Scenario scenario) throws Exception
+    @Test
+    public void testPreemptedAuthentication() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
@@ -452,7 +455,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             }
         });
 
-        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+        ContentResponse response = client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .path("/secure")
             .timeout(5, TimeUnit.SECONDS)
@@ -462,10 +465,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertEquals(1, requests.get());
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testNonReproducibleContent(Scenario scenario) throws Exception
+    @Test
+    public void testNonReproducibleContent() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new EmptyServerHandler());
 
         AuthenticationStore authenticationStore = client.getAuthenticationStore();
@@ -490,10 +493,10 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testRequestFailsAfterResponse(Scenario scenario) throws Exception
+    @Test
+    public void testRequestFailsAfterResponse() throws Exception
     {
+        Scenario scenario = new NormalScenario();
         startBasic(scenario, new Handler.Abstract()
         {
             @Override
@@ -573,7 +576,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             }
         });
         CountDownLatch resultLatch = new CountDownLatch(1);
-        client.newRequest("localhost", connector.getLocalPort())
+        client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .path("/secure")
             .body(content)
@@ -587,11 +590,11 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
         assertTrue(resultLatch.await(5, TimeUnit.SECONDS));
     }
 
-    @ParameterizedTest
-    @ArgumentsSource(ScenarioProvider.class)
-    public void testInfiniteAuthentication(Scenario scenario) throws Exception
+    @Test
+    public void testInfiniteAuthentication() throws Exception
     {
         String authType = "Authenticate";
+        Scenario scenario = new NormalScenario();
         start(scenario, new Handler.Abstract()
         {
             @Override
@@ -635,7 +638,7 @@ public class HttpClientAuthenticationTest extends AbstractHttpClientServerTest
             }
         });
 
-        ContentResponse response = client.newRequest("localhost", connector.getLocalPort())
+        ContentResponse response = client.newRequest("localhost", getServerPort())
             .scheme(scenario.getScheme())
             .send();
 


### PR DESCRIPTION
Made `*AuthenticationProtocolHandler.accept()` more precise, as they are exclusive: when one accepts the other should not.

12.0.x backport of https://github.com/jetty/jetty.project/pull/15629