### PR TITLE
Issue #14904 - Stabilize virtual thread tracking dump test

### DIFF
--- a/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
+++ b/jetty-core/jetty-util/src/test/java/org/eclipse/jetty/util/thread/VirtualThreadPoolTest.java
@@ -116,38 +116,39 @@ public class VirtualThreadPoolTest
         TrackingExecutor trackingExecutor = (TrackingExecutor)vtp.getVirtualThreadsExecutor();
         assertThat(trackingExecutor.size(), is(0));
 
-        CountDownLatch running = new CountDownLatch(4);
-        Waiter waiter = new Waiter(running, false);
-        Waiter spinner = new Waiter(running, true);
+        CountDownLatch waiterRunning = new CountDownLatch(1);
+        CountDownLatch spinnerRunning = new CountDownLatch(1);
+        CountDownLatch release = new CountDownLatch(1);
+        Waiter waiter = new Waiter(waiterRunning, release, false);
+        Waiter spinner = new Waiter(spinnerRunning, release, true);
         try
         {
             vtp.execute(waiter);
-            vtp.execute(spinner);
-            vtp.execute(waiter);
-            vtp.execute(spinner);
+            assertTrue(waiterRunning.await(5, TimeUnit.SECONDS));
+            await().atMost(5, TimeUnit.SECONDS).until(waiter.getThread()::getState, is(Thread.State.WAITING));
 
-            assertTrue(running.await(5, TimeUnit.SECONDS));
-            assertThat(trackingExecutor.size(), is(4));
+            vtp.execute(spinner);
+            assertTrue(spinnerRunning.await(5, TimeUnit.SECONDS));
+            assertThat(trackingExecutor.size(), is(2));
 
             vtp.setDetailedDump(false);
             String dump = vtp.dump();
-            assertThat(count(dump, "VirtualThread[#"), is(4));
-            assertThat(count(dump, "/runnable@"), is(2));
-            assertThat(count(dump, "waiting"), is(2));
+            assertThat(count(dump, "VirtualThread[#"), is(2));
+            assertThat(count(dump, "/runnable@"), is(1));
+            assertThat(count(dump, "waiting"), is(1));
             assertThat(count(dump, "VirtualThreadPoolTest.java"), is(0));
 
             vtp.setDetailedDump(true);
             dump = vtp.dump();
-            assertThat(count(dump, "VirtualThread[#"), is(4));
-            assertThat(count(dump, "/runnable@"), is(2));
-            assertThat(count(dump, "waiting"), is(2));
-            assertThat(count(dump, "VirtualThreadPoolTest.java"), is(4));
-            assertThat(count(dump, "CountDownLatch.await("), is(2));
+            assertThat(count(dump, "VirtualThread[#"), is(2));
+            assertThat(count(dump, "/runnable@"), is(1));
+            assertThat(count(dump, "waiting"), is(1));
+            assertThat(count(dump, "VirtualThreadPoolTest.java"), is(2));
+            assertThat(count(dump, "CountDownLatch.await("), is(1));
         }
         finally
         {
-            waiter.countDown();
-            spinner.countDown();
+            release.countDown();
             vtp.stop();
         }
     }
@@ -209,16 +210,23 @@ public class VirtualThreadPoolTest
         return count;
     }
 
-    private static class Waiter extends CountDownLatch implements Runnable
+    private static class Waiter implements Runnable
     {
         private final CountDownLatch _running;
+        private final CountDownLatch _release;
         private final boolean _spin;
+        private Thread _thread;
 
-        public Waiter(CountDownLatch running, boolean spin)
+        public Waiter(CountDownLatch running, CountDownLatch release, boolean spin)
         {
-            super(1);
             _running = running;
+            _release = release;
             _spin = spin;
+        }
+
+        public Thread getThread()
+        {
+            return _thread;
         }
 
         @Override
@@ -226,11 +234,11 @@ public class VirtualThreadPoolTest
         {
             try
             {
+                _thread = Thread.currentThread();
                 _running.countDown();
-                while (_spin && getCount() > 0)
+                while (_spin && _release.getCount() > 0)
                     Thread.onSpinWait();
-                if (!await(10, TimeUnit.SECONDS))
-                    throw new IllegalStateException();
+                _release.await();
             }
             catch (InterruptedException e)
             {


### PR DESCRIPTION
Fixes #14904.

`testTrackingDump()` signaled task startup before the blocking virtual thread necessarily reached `WAITING`, and its 10-second timeout allowed tracked tasks to finish before both dumps completed.

Use one blocking task and one spinning task. Wait for the blocking task to reach `WAITING` before starting the spinner, and keep both alive until both dumps are complete. This preserves the assertions for waiting and runnable states, carrier information, and detailed stack frames without assuming multiple scheduler carriers.

Tests:

- JDK 21 and 25: `VirtualThreadPoolTest#testTrackingDump`
- JDK 21 and 25: `VirtualThreadPoolTest#testTrackingDump` with `-Djdk.virtualThreadScheduler.parallelism=1`
- JDK 25: `jetty-util` test suite (2963 tests, 0 failures, 0 errors)

### AI disclosure

I used OpenAI GPT-5.6 and Kimi K3 to assist with issue analysis and drafting the implementation and tests. I reviewed and verified the final changes.