### PR TITLE
General cleanup of modules, with focus on [lib] section mistakes.

### DIFF
--- a/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
+++ b/jetty-ee10/jetty-ee10-apache-jsp/pom.xml
@@ -17,6 +17,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>jakarta.el</groupId>
+      <artifactId>jakarta.el-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
@@ -11,5 +11,5 @@ ee10-apache-jsp
 
 # The prefix is necessary because Glassfish jars do not have JPMS metadata, see #9301.
 [lib]
-lib/ee10-glassfish-jstl/@jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api@
-lib/ee10-glassfish-jstl/@org.glassfish.web:jakarta.servlet.jsp.jstl@
+lib/ee10-glassfish-jstl/jakarta.servlet.jsp.jstl.@jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api@
+lib/ee10-glassfish-jstl/org.glassfish.web.@org.glassfish.web:jakarta.servlet.jsp.jstl@

--- a/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
+++ b/jetty-ee10/jetty-ee10-glassfish-jstl/src/main/config/modules/ee10-glassfish-jstl.mod
@@ -11,5 +11,5 @@ ee10-apache-jsp
 
 # The prefix is necessary because Glassfish jars do not have JPMS metadata, see #9301.
 [lib]
-lib/ee10-glassfish-jstl/jakarta.servlet.jsp.jstl.@jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api@
-lib/ee10-glassfish-jstl/org.glassfish.web.@org.glassfish.web:jakarta.servlet.jsp.jstl@
+lib/ee10-glassfish-jstl/@jakarta.servlet.jsp.jstl:jakarta.servlet.jsp.jstl-api@
+lib/ee10-glassfish-jstl/@org.glassfish.web:jakarta.servlet.jsp.jstl@

--- a/jetty-ee10/jetty-ee10-webapp/src/main/config/modules/ee10-environment.mod
+++ b/jetty-ee10/jetty-ee10-webapp/src/main/config/modules/ee10-environment.mod
@@ -3,6 +3,9 @@
 [description]
 Template configuration file to apply to all web applications deployed in the EE10 environment.
 
+[environment]
+ee10
+
 [tags]
 deployment
 

--- a/jetty-ee11/jetty-ee11-apache-jsp/pom.xml
+++ b/jetty-ee11/jetty-ee11-apache-jsp/pom.xml
@@ -25,6 +25,10 @@
       <artifactId>jakarta.servlet-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.servlet.jsp</groupId>
+      <artifactId>jakarta.servlet.jsp-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-util</artifactId>
     </dependency>

--- a/jetty-ee11/jetty-ee11-plus/pom.xml
+++ b/jetty-ee11/jetty-ee11-plus/pom.xml
@@ -30,6 +30,10 @@
       <artifactId>jakarta.enterprise.lang-model</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.interceptor</groupId>
       <artifactId>jakarta.interceptor-api</artifactId>
     </dependency>

--- a/jetty-ee11/jetty-ee11-webapp/src/main/config/modules/ee11-environment.mod
+++ b/jetty-ee11/jetty-ee11-webapp/src/main/config/modules/ee11-environment.mod
@@ -3,6 +3,9 @@
 [description]
 Template configuration file to apply to all web applications deployed in the EE11 environment.
 
+[environment]
+ee11
+
 [tags]
 deployment
 

--- a/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-server/pom.xml
+++ b/jetty-ee11/jetty-ee11-websocket/jetty-ee11-websocket-jakarta-server/pom.xml
@@ -20,6 +20,10 @@
       <artifactId>jakarta.websocket-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.websocket</groupId>
+      <artifactId>jakarta.websocket-client-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee11</groupId>
       <artifactId>jetty-ee11-annotations</artifactId>
     </dependency>

--- a/jetty-ee8/jetty-ee8-webapp/src/main/config/modules/ee8-environment.mod
+++ b/jetty-ee8/jetty-ee8-webapp/src/main/config/modules/ee8-environment.mod
@@ -3,6 +3,9 @@
 [description]
 Template configuration file to apply to all web applications deployed in the EE8 environment.
 
+[environment]
+ee8
+
 [tags]
 deployment
 

--- a/jetty-ee9/jetty-ee9-jaspi/src/main/config/modules/ee9-jaspi.mod
+++ b/jetty-ee9/jetty-ee9-jaspi/src/main/config/modules/ee9-jaspi.mod
@@ -3,6 +3,9 @@
 [description]
 Enables JASPI authentication for deployed web applications.
 
+[environment]
+ee9
+
 [tags]
 security
 

--- a/jetty-ee9/jetty-ee9-plus/pom.xml
+++ b/jetty-ee9/jetty-ee9-plus/pom.xml
@@ -32,6 +32,10 @@
       <artifactId>jakarta.inject-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>jakarta.interceptor</groupId>
+      <artifactId>jakarta.interceptor-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>jakarta.transaction</groupId>
       <artifactId>jakarta.transaction-api</artifactId>
     </dependency>

--- a/jetty-ee9/jetty-ee9-webapp/src/main/config/modules/ee9-environment.mod
+++ b/jetty-ee9/jetty-ee9-webapp/src/main/config/modules/ee9-environment.mod
@@ -3,6 +3,9 @@
 [description]
 Template configuration file to apply to all web applications deployed in the EE9 environment.
 
+[environment]
+ee9
+
 [tags]
 deployment
 


### PR DESCRIPTION
Went through the jetty-home/start modules with a more strict eye on behavior.
I found a few bad flaws, and a bunch of cases where the resolution of the artifact would fail sometimes.

The bad flaws:

* Some modules that are ee# specific were missing their `[environment]` section.
* Some modules with libs that use the `@groupId:artifactId@` syntax would prefix/suffix that with extra stuff that rendered the output broken.