### PR TITLE
Issue #15667 - HTTP/2/3 client discards response on abrupt connection close

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpChannelOverHTTP2.java
@@ -42,7 +42,7 @@ public class HttpChannelOverHTTP2 extends HttpChannel
 {
     private static final Logger LOG = LoggerFactory.getLogger(HttpChannelOverHTTP2.class);
 
-    private final Stream.Listener listener = new Listener();
+    private final Listener listener = new Listener();
     private final HttpConnectionOverHTTP2 connection;
     private final Session session;
     private final HttpSenderOverHTTP2 sender;
@@ -71,6 +71,15 @@ public class HttpChannelOverHTTP2 extends HttpChannel
     public Stream.Listener getStreamListener()
     {
         return listener;
+    }
+
+    /**
+     * Aborts the exchange, serialized with other stream events so that an
+     * already-received response is delivered before the exchange is aborted.
+     */
+    void abort(Throwable failure)
+    {
+        listener.abort(failure);
     }
 
     @Override
@@ -250,6 +259,18 @@ public class HttpChannelOverHTTP2 extends HttpChannel
             Runnable task = channel.onFailure(failure, callback);
             if (LOG.isDebugEnabled())
                 LOG.debug("executing failure task {} {}", stream, task);
+            ThreadPool.executeImmediately(connection.getHttpClient().getExecutor(), invoker.offer(task));
+        }
+
+        private void abort(Throwable failure)
+        {
+            // Serialize with other stream events so an already-received response is delivered first.
+            Runnable task = () ->
+            {
+                HttpExchange exchange = getHttpExchange();
+                if (exchange != null)
+                    exchange.getRequest().abort(failure);
+            };
             ThreadPool.executeImmediately(connection.getHttpClient().getExecutor(), invoker.offer(task));
         }
     }

--- a/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
+++ b/jetty-core/jetty-http2/jetty-http2-client-transport/src/main/java/org/eclipse/jetty/http2/client/transport/internal/HttpConnectionOverHTTP2.java
@@ -369,11 +369,9 @@ public class HttpConnectionOverHTTP2 extends HttpConnection implements Sweeper.S
             activeChannels.clear();
         }
         Throwable failure = failureSupplier.get();
-        for (HttpChannel channel : channels)
+        for (HttpChannelOverHTTP2 channel : channels)
         {
-            HttpExchange exchange = channel.getHttpExchange();
-            if (exchange != null)
-                exchange.getRequest().abort(failure);
+            channel.abort(failure);
         }
         return false;
     }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpChannelOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpChannelOverHTTP3.java
@@ -30,7 +30,7 @@ import org.eclipse.jetty.util.thread.ThreadPool;
 
 public class HttpChannelOverHTTP3 extends HttpChannel
 {
-    private final Stream.Client.Listener listener = new Listener();
+    private final Listener listener = new Listener();
     private final HttpConnectionOverHTTP3 connection;
     private final HTTP3SessionClient session;
     private final HttpSenderOverHTTP3 sender;
@@ -59,6 +59,15 @@ public class HttpChannelOverHTTP3 extends HttpChannel
     public Stream.Client.Listener getStreamListener()
     {
         return listener;
+    }
+
+    /**
+     * Aborts the exchange, serialized with other stream events so that an
+     * already-received response is delivered before the exchange is aborted.
+     */
+    void abort(Throwable failure)
+    {
+        listener.abort(failure);
     }
 
     @Override
@@ -170,6 +179,18 @@ public class HttpChannelOverHTTP3 extends HttpChannel
         public void onFailure(Stream.Client stream, long error, Throwable failure)
         {
             Runnable task = receiver.onFailure(failure);
+            ThreadPool.executeImmediately(session.getProtocolSession().getExecutor(), invoker.offer(task));
+        }
+
+        private void abort(Throwable failure)
+        {
+            // Serialize with other stream events so an already-received response is delivered first.
+            Runnable task = () ->
+            {
+                HttpExchange exchange = getHttpExchange();
+                if (exchange != null)
+                    exchange.getRequest().abort(failure);
+            };
             ThreadPool.executeImmediately(session.getProtocolSession().getExecutor(), invoker.offer(task));
         }
     }

--- a/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
+++ b/jetty-core/jetty-http3/jetty-http3-client-transport/src/main/java/org/eclipse/jetty/http3/client/transport/internal/HttpConnectionOverHTTP3.java
@@ -208,11 +208,9 @@ public class HttpConnectionOverHTTP3 extends HttpConnection implements Connectio
             channels = Set.copyOf(activeChannels);
             activeChannels.clear();
         }
-        for (HttpChannel channel : channels)
+        for (HttpChannelOverHTTP3 channel : channels)
         {
-            HttpExchange exchange = channel.getHttpExchange();
-            if (exchange != null)
-                exchange.getRequest().abort(failure);
+            channel.abort(failure);
         }
         return false;
     }


### PR DESCRIPTION
## Fixes #15667

In the test `HttpClientStreamTest#testDownloadWithFailure` the server sends half of the response then abruptly closes the TCP connection.

However since the HEADERS/DATA frames are delivered asynchronously using the channels `SerializedInvoker`, the abort is racing against the processing of the headers frame.

This PR sends the abort through the same `SerializedInvoker`, so it is serialized behind any events already received.