### PR TITLE
Fixes #15657: deregister tunnel streams from the HTTP/2 session on close

### DIFF
--- a/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
+++ b/jetty-core/jetty-http2/jetty-http2-common/src/main/java/org/eclipse/jetty/http2/HTTP2StreamEndPoint.java
@@ -159,6 +159,7 @@ public abstract class HTTP2StreamEndPoint implements EndPoint, Invocable
                 data.release();
             shutdownOutput();
             stream.close();
+            stream.getSession().removeStream(stream);
             connection.onClose(cause);
             onClose(cause);
         }


### PR DESCRIPTION
## Summary
Fixes #15657. An HTTP/2 stream upgraded to a tunnel (WebSocket over HTTP/2, RFC 8441
extended CONNECT) remained registered in its `HTTP2Session` forever after the tunnel
connection closed. `HTTP2StreamEndPoint.close(Throwable)` called `stream.close()` but
never removed the stream from the session, so the session's pending-stream count never
reached zero and `HTTP2Session.shutdown()` never completed — hanging graceful shutdown.

## Root cause
`HTTP2StreamEndPoint.close(Throwable)` (used for upgraded/tunnel streams) deregistered the
stream from the session only indirectly. For a normal stream the removal happens on the
end-stream path (`readData`/`onHeaders`); for a tunnel stream the data flows through the
upgraded endpoint, so nothing ever called `HTTP2Session.removeStream(stream)`. Before
12.1.10 `HTTP2Stream.onReset` unconditionally removed the stream, which masked this
orphaning whenever a peer RST_STREAM arrived.

## Fix
Deregister the stream from its session when the tunnel endpoint closes. `removeStream` is
idempotent (returns false if the stream is already removed), so it is safe if the stream
was reclaimed by a concurrent RST_STREAM/FailureFrame path.

```java
shutdownOutput();
stream.close();
stream.getSession().removeStream(stream);
connection.onClose(cause);
onClose(cause);
```

## Verification
The regression tests from the issue (`testClosedTunnelStreamIsRemovedFromSession`,
`testResetOfClosedTunnelStreamAllowsGracefulShutdown`) assert exactly this invariant.

Signed-off-by: waterWang <waterWang@users.noreply.github.com>