### PR TITLE
Fixes race for HTTP3StreamConnection release of Chunk

### DIFF
--- a/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
+++ b/jetty-core/jetty-http3/jetty-http3-common/src/main/java/org/eclipse/jetty/http3/HTTP3StreamConnection.java
@@ -27,11 +27,13 @@ import org.eclipse.jetty.http3.parser.MessageParser;
 import org.eclipse.jetty.http3.parser.ParserListener;
 import org.eclipse.jetty.io.AbstractConnection;
 import org.eclipse.jetty.io.Content;
+import org.eclipse.jetty.io.EofException;
 import org.eclipse.jetty.quic.common.StreamEndPoint;
 import org.eclipse.jetty.util.Callback;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.Promise;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.thread.AutoLock;
 import org.eclipse.jetty.util.thread.Invocable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +42,7 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
 {
     private static final Logger LOG = LoggerFactory.getLogger(HTTP3StreamConnection.class);
 
+    private final AutoLock lock = new AutoLock();
     private final Callback fillableCallback = new FillableCallback();
     private final AtomicReference<FrameAction> frameAction = new AtomicReference<>();
     private final MessageParser parser;
@@ -260,30 +263,44 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
                 case FRAME ->
                 {
                     FrameAction action = frameAction.getAndSet(null);
-                    action.task().run();
-
-                    Frame frame = action.frame();
-                    if (frame instanceof DataFrame dataFrame)
+                    // Retain because the DATA frame bytes reference the QUIC chunk.
+                    Content.Chunk quicChunk = retainData();
+                    try
                     {
-                        if (dataFrame.isLast() && !dataFrame.getByteBuffer().hasRemaining())
-                        {
-                            tryReleaseData(true);
-                            yield Content.Chunk.EOF;
-                        }
-                        else
-                        {
-                            // Retain because multiple frames can be parsed from the same QUIC chunk.
-                            quicChunk.retain();
-                            Content.Chunk h3Chunk = Content.Chunk.asChunk(dataFrame.getByteBuffer(), dataFrame.isLast(), quicChunk);
-                            if (h3Chunk.isLast())
-                                tryReleaseData(true);
-                            yield h3Chunk;
-                        }
-                    }
+                        action.task().run();
 
-                    // It is a trailer HEADERS frame.
-                    tryReleaseData(true);
-                    yield Content.Chunk.EOF;
+                        Frame frame = action.frame();
+                        if (frame instanceof DataFrame dataFrame)
+                        {
+                            // A concurrent release invalidated the frame bytes.
+                            if (quicChunk == null)
+                                throw new EofException("stream closed while reading");
+
+                            if (dataFrame.isLast() && !dataFrame.getByteBuffer().hasRemaining())
+                            {
+                                tryReleaseData(true);
+                                yield Content.Chunk.EOF;
+                            }
+                            else
+                            {
+                                Content.Chunk h3Chunk = Content.Chunk.asChunk(dataFrame.getByteBuffer(), dataFrame.isLast(), quicChunk);
+                                // The retain above is now owned by h3Chunk.
+                                quicChunk = null;
+                                if (h3Chunk.isLast())
+                                    tryReleaseData(true);
+                                yield h3Chunk;
+                            }
+                        }
+
+                        // It is a trailer HEADERS frame.
+                        tryReleaseData(true);
+                        yield Content.Chunk.EOF;
+                    }
+                    finally
+                    {
+                        if (quicChunk != null)
+                            quicChunk.release();
+                    }
                 }
                 case EOF ->
                 {
@@ -314,35 +331,51 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
 
             while (true)
             {
-                if (quicChunk != null)
+                // Retain so that a concurrent release does not recycle the buffer being parsed.
+                Content.Chunk chunk = retainData();
+                if (chunk != null)
                 {
-                    MessageParser.Result result = parser.parse(quicChunk.getByteBuffer(), quicChunk.isLast());
-                    if (LOG.isDebugEnabled())
-                        LOG.debug("parsed {} from {} on {}", result, quicChunk, this);
+                    try
+                    {
+                        MessageParser.Result result = parser.parse(chunk.getByteBuffer(), chunk.isLast());
+                        if (LOG.isDebugEnabled())
+                            LOG.debug("parsed {} from {} on {}", result, chunk, this);
 
-                    if (result == MessageParser.Result.FRAME)
-                        return ParseResult.FRAME;
-                    if (result == MessageParser.Result.BLOCKED_FRAME)
-                        return ParseResult.BLOCKED_FRAME;
+                        if (result == MessageParser.Result.FRAME)
+                            return ParseResult.FRAME;
+                        if (result == MessageParser.Result.BLOCKED_FRAME)
+                            return ParseResult.BLOCKED_FRAME;
+                    }
+                    finally
+                    {
+                        chunk.release();
+                    }
 
                     tryReleaseData(true);
                 }
 
-                quicChunk = getEndPoint().fill();
+                Content.Chunk filled = getEndPoint().fill();
                 if (LOG.isDebugEnabled())
-                    LOG.debug("filled {} on {}", quicChunk, this);
+                    LOG.debug("filled {} on {}", filled, this);
 
-                if (quicChunk == null)
+                if (filled == null)
                     return ParseResult.NO_FRAME;
 
-                if (quicChunk.hasRemaining())
+                if (filled.hasRemaining())
+                {
+                    storeData(filled);
                     continue;
+                }
 
-                if (Content.Chunk.isFailure(quicChunk))
-                    throw new UncheckedIOException(IO.rethrow(quicChunk.getFailure()));
+                // Not stored, so nothing else can observe it; release it here.
+                if (Content.Chunk.isFailure(filled))
+                {
+                    filled.release();
+                    throw new UncheckedIOException(IO.rethrow(filled.getFailure()));
+                }
 
-                ParseResult result = quicChunk.isLast() ? ParseResult.EOF : ParseResult.NO_FRAME;
-                tryReleaseData(true);
+                ParseResult result = filled.isLast() ? ParseResult.EOF : ParseResult.NO_FRAME;
+                filled.release();
                 return result;
             }
         }
@@ -402,17 +435,58 @@ public abstract class HTTP3StreamConnection extends AbstractConnection
         getEndPoint().disconnect(appErrorCode, failure, true, promise);
     }
 
+    /**
+     * <p>Retains the QUIC chunk, so that it is not recycled while in use.</p>
+     *
+     * @return the retained QUIC chunk that the caller must release,
+     * or {@code null} if it was already released
+     */
+    private Content.Chunk retainData()
+    {
+        try (AutoLock ignored = lock.lock())
+        {
+            // A non-null quicChunk is still referenced by this connection, because
+            // tryReleaseData() nulls it before releasing, so this cannot race to zero.
+            if (quicChunk != null)
+                quicChunk.retain();
+            return quicChunk;
+        }
+    }
+
+    /**
+     * <p>Stores the QUIC chunk just filled, taking ownership of its reference.</p>
+     *
+     * @param chunk the QUIC chunk to store
+     */
+    private void storeData(Content.Chunk chunk)
+    {
+        try (AutoLock ignored = lock.lock())
+        {
+            assert quicChunk == null;
+            quicChunk = chunk;
+        }
+    }
+
+    /**
+     * <p>Releases the QUIC chunk reference owned by this connection; the references
+     * taken by {@link #retainData()} are released by their callers.</p>
+     *
+     * @param force whether to release even if the chunk has bytes left to parse
+     */
     private void tryReleaseData(boolean force)
     {
-        if (LOG.isDebugEnabled())
-            LOG.debug("releasing force={} {} on {}", force, quicChunk, this);
-        if (quicChunk == null)
-            return;
-        if (force || !quicChunk.hasRemaining())
+        Content.Chunk chunk;
+        try (AutoLock ignored = lock.lock())
         {
-            quicChunk.release();
+            chunk = quicChunk;
+            if (chunk == null || (!force && chunk.hasRemaining()))
+                return;
+            // Claim the chunk so it is released at most once, even if called concurrently.
             quicChunk = null;
         }
+        if (LOG.isDebugEnabled())
+            LOG.debug("releasing force={} {} on {}", force, chunk, this);
+        chunk.release();
     }
 
     @Override


### PR DESCRIPTION
Fixes some stacktraces I found when running tests.

`HTTP3StreamConnection` parses the QUIC chunk held in quicChunk on whichever thread consumes the content, usually an application thread. It releases that same chunk from unrelated threads: a stream idle timeout on the scheduler thread, and a stream reset or abrupt connection close dispatched onto the protocol session's executor, bypassing the serializer that orders normal stream events. The field was read, written and released without any coordination.                                                                                                                           
                                                                                                                                                                                                                      
Two threads on a release path could therefore both call release() on the same chunk, throwing IllegalStateException: already released. A release arriving mid-parse returned the pooled buffer while it was still in use, letting the connection parse memory already handed out elsewhere. This change routes every access to quicChunk through a lock and has the read path hold a reference while it uses the chunk. A concurrent release can still take the chunk away, but not the buffer from under a reader; the read then fails with EOF, which is correct since the stream is being reset or closed.                                            
                             
Original failure log from tests:
```
Running org.eclipse.jetty.test.client.transport.HttpClientStreamTest.testInputStreamContentProviderThrowingWhileReading([5] H3_QUICHE)
Running HttpClientStreamTest.testInputStreamContentProviderThrowingWhileReading() [5] H3_QUICHE
2026-08-26 03:18:25.109:INFO :oejqqs.AbstractQuicheServerConnectionFactory:ForkJoinPool-1-worker-5: HTTP/3+QUIC support is experimental and not suited for production use.
2026-08-26 03:18:25.168:INFO :oejh3c.HTTP3Client:ForkJoinPool-1-worker-5: HTTP/3+QUIC support is experimental and not suited for production use.
2026-08-26 03:18:25.169:WARN :oejusS.config:ForkJoinPool-1-worker-5: Trusting all certificates configured for oejus.SslContextFactory<span>Client@7e2bd14[provider=null,keyStore=null,trustStore=null] 2026-08-26 03:18:25.169:WARN :oejusS.config:ForkJoinPool-1-worker-5: No Client EndPointIdentificationAlgorithm configured for oejus.SslContextFactory</span>Client@7e2bd14[provider=null,keyStore=null,trustStore=null]
2026-08-26 03:18:25.196:WARN :oejut.SerializedInvoker:client-18463: Serialized invocation error
java.lang.IllegalStateException: client-18463 over-released oeji.ArrayByteBufferPool<span>Tracking</span>TrackedBuffer@3f4535a8[0/4096,d=true,@24dc57a1,rc=1]
at org.eclipse.jetty.io.ArrayByteBufferPool<span>Tracking</span>TrackedBuffer.release(ArrayByteBufferPool.java:1140)
at org.eclipse.jetty.quic.quiche.QuicheStream.tryReleaseInputBuffer(QuicheStream.java:246)
at org.eclipse.jetty.quic.quiche.QuicheStream.disconnect(QuicheStream.java:446)
at org.eclipse.jetty.quic.quiche.QuicheStream.disconnect(QuicheStream.java:423)
at org.eclipse.jetty.quic.common.StreamEndPoint.disconnect(StreamEndPoint.java:207)
at org.eclipse.jetty.http3.HTTP3StreamConnection.disconnect(HTTP3StreamConnection.java:402)
at org.eclipse.jetty.http3.HTTP3Stream.disconnect(HTTP3Stream.java:435)
at org.eclipse.jetty.http3.HTTP3Stream.disconnect(HTTP3Stream.java:414)
at org.eclipse.jetty.http3.client.transport.internal.HttpChannelOverHTTP3.exchangeTerminated(HttpChannelOverHTTP3.java:105)
at org.eclipse.jetty.client.transport.HttpReceiver.terminateResponse(HttpReceiver.java:451)
at org.eclipse.jetty.client.transport.HttpReceiver.terminateResponse(HttpReceiver.java:436)
at org.eclipse.jetty.client.transport.HttpReceiver.lambda<span>abort</span>0(HttpReceiver.java:534)
at org.eclipse.jetty.util.thread.SerializedInvoker<span>Link.run(SerializedInvoker.java:274) at org.eclipse.jetty.util.thread.SerializedInvoker.run(SerializedInvoker.java:174) at org.eclipse.jetty.client.transport.HttpReceiver.abort(HttpReceiver.java:508) at org.eclipse.jetty.client.transport.HttpChannel.abortResponse(HttpChannel.java:179) at org.eclipse.jetty.client.transport.HttpSender.terminateRequest(HttpSender.java:270) at org.eclipse.jetty.client.transport.HttpSender.abortRequest(HttpSender.java:252) at org.eclipse.jetty.client.transport.HttpSender.internalAbort(HttpSender.java:401) at org.eclipse.jetty.client.transport.HttpSender</span>ContentSender.onFailure(HttpSender.java:633)
at org.eclipse.jetty.util.ExceptionUtil.callAndThen(ExceptionUtil.java:452)
at org.eclipse.jetty.util.IteratingCallback.doOnFailureOnCompleted(IteratingCallback.java:286)
at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:520)
at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:351)
at org.eclipse.jetty.client.transport.HttpSender.send(HttpSender.java:86)
at org.eclipse.jetty.http3.client.transport.internal.HttpChannelOverHTTP3.send(HttpChannelOverHTTP3.java:95)
at org.eclipse.jetty.client.transport.HttpChannel.send(HttpChannel.java:148)
at org.eclipse.jetty.client.transport.HttpConnection.send(HttpConnection.java:119)
at org.eclipse.jetty.http3.client.transport.internal.HttpConnectionOverHTTP3.send(HttpConnectionOverHTTP3.java:144)
at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:454)
at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:415)
at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:369)
at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:352)
at org.eclipse.jetty.client.transport.HttpDestination.succeeded(HttpDestination.java:284)
at org.eclipse.jetty.client.AbstractConnectionPool.proceed(AbstractConnectionPool.java:314)
at org.eclipse.jetty.client.AbstractConnectionPool<span>FutureConnection.succeeded(AbstractConnectionPool.java:576) at org.eclipse.jetty.client.AbstractConnectionPool</span>FutureConnection.succeeded(AbstractConnectionPool.java:555)
at org.eclipse.jetty.util.Promise<span>Wrapper.succeeded(Promise.java:210) at org.eclipse.jetty.http3.client.transport.internal.SessionClientListener.lambda</span>onSettings<span>0(SessionClientListener.java:59) at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:1009) at org.eclipse.jetty.util.thread.QueuedThreadPool</span>Runner.doRunJob(QueuedThreadPool.java:1240)
at org.eclipse.jetty.util.thread.QueuedThreadPool<span>Runner.run(QueuedThreadPool.java:1194) at java.base/java.lang.Thread.run(Thread.java:1516) Suppressed: |java.lang.Throwable: Released by client-18461 | at org.eclipse.jetty.io.ArrayByteBufferPool</span>Tracking<span>TrackedBuffer.release(ArrayByteBufferPool.java:1133) | at org.eclipse.jetty.io.internal.ByteBufferChunk</span>WithRetainable.release(ByteBufferChunk.java:173)
| at org.eclipse.jetty.http3.HTTP3StreamConnection.tryReleaseData(HTTP3StreamConnection.java:413)
| at org.eclipse.jetty.http3.HTTP3StreamConnection.processFrames(HTTP3StreamConnection.java:162)
| at org.eclipse.jetty.http3.HTTP3StreamConnection.onFillable(HTTP3StreamConnection.java:107)
| at org.eclipse.jetty.http3.HTTP3StreamConnection<span>FillableCallback.succeeded(HTTP3StreamConnection.java:473) | at org.eclipse.jetty.quic.common.StreamEndPoint.fillable(StreamEndPoint.java:584) | at org.eclipse.jetty.quic.common.ProtocolStreamListener.onDataAvailable(ProtocolStreamListener.java:30) | at org.eclipse.jetty.quic.quiche.QuicheStream.notifyDataAvailable(QuicheStream.java:544) | at org.eclipse.jetty.quic.quiche.QuicheStream.readable(QuicheStream.java:109) | at org.eclipse.jetty.quic.quiche.QuicheSession</span>StreamsProducer.produce(QuicheSession.java:635)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.produceTask(AdaptiveExecutionStrategy.java:509)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:251)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.produce(AdaptiveExecutionStrategy.java:196)
| at org.eclipse.jetty.quic.quiche.QuicheSession.produce(QuicheSession.java:335)
| at org.eclipse.jetty.quic.quiche.client.internal.ClientQuicheConnection.onFillable(ClientQuicheConnection.java:221)
| at org.eclipse.jetty.quic.quiche.QuicheConnection<span>FillableCallback.succeeded(QuicheConnection.java:81) | at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105) | at org.eclipse.jetty.io.SelectableChannelEndPoint</span>1.run(SelectableChannelEndPoint.java:54)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.runTask(AdaptiveExecutionStrategy.java:492)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.epcRunTask(AdaptiveExecutionStrategy.java:428)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.consumeTask(AdaptiveExecutionStrategy.java:401)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.tryProduce(AdaptiveExecutionStrategy.java:255)
| at org.eclipse.jetty.util.thread.strategy.AdaptiveExecutionStrategy.run(AdaptiveExecutionStrategy.java:204)
| at org.eclipse.jetty.util.thread.ReservedThreadExecutor<span>ReservedThread.run(ReservedThreadExecutor.java:317) | at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:1009) | at org.eclipse.jetty.util.thread.QueuedThreadPool</span>Runner.doRunJob(QueuedThreadPool.java:1240)
| at org.eclipse.jetty.util.thread.QueuedThreadPool<span>Runner.run(QueuedThreadPool.java:1194) | at java.base/java.lang.Thread.run(Thread.java:1516) Suppressed: |java.lang.Throwable: Released by client-18463 | at org.eclipse.jetty.io.ArrayByteBufferPool</span>Tracking<span>TrackedBuffer.release(ArrayByteBufferPool.java:1133) | at org.eclipse.jetty.io.internal.ByteBufferChunk</span>WithRetainable.release(ByteBufferChunk.java:173)
| at org.eclipse.jetty.http3.HTTP3StreamConnection.tryReleaseData(HTTP3StreamConnection.java:413)
| at org.eclipse.jetty.http3.HTTP3StreamConnection.disconnect(HTTP3StreamConnection.java:400)
| at org.eclipse.jetty.http3.HTTP3Stream.disconnect(HTTP3Stream.java:435)
| at org.eclipse.jetty.http3.HTTP3Stream.disconnect(HTTP3Stream.java:414)
| at org.eclipse.jetty.http3.client.transport.internal.HttpChannelOverHTTP3.exchangeTerminated(HttpChannelOverHTTP3.java:105)
| at org.eclipse.jetty.client.transport.HttpReceiver.terminateResponse(HttpReceiver.java:451)
| at org.eclipse.jetty.client.transport.HttpReceiver.terminateResponse(HttpReceiver.java:436)
| at org.eclipse.jetty.client.transport.HttpReceiver.lambda<span>abort</span>0(HttpReceiver.java:534)
| at org.eclipse.jetty.util.thread.SerializedInvoker<span>Link.run(SerializedInvoker.java:274) | at org.eclipse.jetty.util.thread.SerializedInvoker.run(SerializedInvoker.java:174) | at org.eclipse.jetty.client.transport.HttpReceiver.abort(HttpReceiver.java:508) | at org.eclipse.jetty.client.transport.HttpChannel.abortResponse(HttpChannel.java:179) | at org.eclipse.jetty.client.transport.HttpSender.terminateRequest(HttpSender.java:270) | at org.eclipse.jetty.client.transport.HttpSender.abortRequest(HttpSender.java:252) | at org.eclipse.jetty.client.transport.HttpSender.internalAbort(HttpSender.java:401) | at org.eclipse.jetty.client.transport.HttpSender</span>ContentSender.onFailure(HttpSender.java:633)
| at org.eclipse.jetty.util.ExceptionUtil.callAndThen(ExceptionUtil.java:452)
| at org.eclipse.jetty.util.IteratingCallback.doOnFailureOnCompleted(IteratingCallback.java:286)
| at org.eclipse.jetty.util.IteratingCallback.processing(IteratingCallback.java:520)
| at org.eclipse.jetty.util.IteratingCallback.iterate(IteratingCallback.java:351)
| at org.eclipse.jetty.client.transport.HttpSender.send(HttpSender.java:86)
| at org.eclipse.jetty.http3.client.transport.internal.HttpChannelOverHTTP3.send(HttpChannelOverHTTP3.java:95)
| at org.eclipse.jetty.client.transport.HttpChannel.send(HttpChannel.java:148)
| at org.eclipse.jetty.client.transport.HttpConnection.send(HttpConnection.java:119)
| at org.eclipse.jetty.http3.client.transport.internal.HttpConnectionOverHTTP3.send(HttpConnectionOverHTTP3.java:144)
| at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:454)
| at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:415)
| at org.eclipse.jetty.client.transport.HttpDestination.process(HttpDestination.java:369)
| at org.eclipse.jetty.client.transport.HttpDestination.send(HttpDestination.java:352)
| at org.eclipse.jetty.client.transport.HttpDestination.succeeded(HttpDestination.java:284)
| at org.eclipse.jetty.client.AbstractConnectionPool.proceed(AbstractConnectionPool.java:314)
| at org.eclipse.jetty.client.AbstractConnectionPool<span>FutureConnection.succeeded(AbstractConnectionPool.java:576) | at org.eclipse.jetty.client.AbstractConnectionPool</span>FutureConnection.succeeded(AbstractConnectionPool.java:555)
| at org.eclipse.jetty.util.Promise<span>Wrapper.succeeded(Promise.java:210) | at org.eclipse.jetty.http3.client.transport.internal.SessionClientListener.lambda</span>onSettings<span>0(SessionClientListener.java:59) | at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:1009) | at org.eclipse.jetty.util.thread.QueuedThreadPool</span>Runner.doRunJob(QueuedThreadPool.java:1240)
| at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1194)
| at java.base/java.lang.Thread.run(Thread.java:1516)
```