### PR TITLE
[12.0.x EE8] Update OSGi compatibility enforcer rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1912,7 +1912,7 @@
                   <version>[17,)</version>
                   <message>[ERROR] OLD JDK [${java.version}] in use. Jetty ${project.version} requires JDK 17 or newer</message>
                 </requireJavaVersion>
-                <versionOsgiRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireOsgiCompatibleVersionRule"/>
+                <requireCompatibleVersionOSGI/>
                 <!-- do not support alphax as a version number -->
                 <!--
                             <versionRedhatRule implementation="org.eclipse.jetty.toolchain.enforcer.rules.RequireRedhatCompatibleVersionRule" />


### PR DESCRIPTION
Completes #15655 by using the OSGi compatibility rule name exported by the
upgraded Jetty toolchain. The previous implementation class is no longer
available in build-support 1.6.0, which made Enforcer fall back to an invalid
rule instantiation.

This changes only the rule binding; the OSGi-compatible version check remains
enabled.

Verification (JDK 17):

- `mvn -N validate -Dcheckstyle.skip=true` — passed
- `git diff --check` — passed

Development assistance: prepared in Codex with the maintainer-intent,
fast-execution, and diff-review skills from
[JAIPilot](https://github.com/JAIPilot/jaipilot). Execution profile: `gpt-5.6-sol · xhigh · fast`. Execution was local.
