### PR TITLE
12.1.x Use k8s pods with dind, improve Maven cache

### DIFF
--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -34,6 +34,11 @@
       <excludes>
         <exclude glob="*Jenkinsfile*" />
         <exclude glob="./idea/*" />
+        <!-- The invoker plugin points localRepositoryPath and cloneProjectsTo at these, and the
+             scanner follows path-valued plugin config, so whatever happens to be sitting there
+             ends up in the checksum. They are build output, never input. -->
+        <exclude>target/local-repo</exclude>
+        <exclude>target/it</exclude>
       </excludes>
     </global>
     <plugins>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -50,14 +50,13 @@
             <excludeProperty>filterProperties</excludeProperty>
           </excludeProperties>
         </effectivePom>
-        <!-- javaHome is ${java.home}, so the scanner walks the whole JDK and hashes every file in
-             it. Jenkins unpacks a fresh JDK per agent, so that alone gives a new checksum
-             on every run and the module can never hit the cache. The
-             others point at build output for the same reason. -->
+        <!-- The scanner hashes anything that looks like a path, and these all move between
+             runs: a fresh JDK per agent, a random temp settings file, build output. -->
         <dirScan>
           <excludes>
             <exclude tagName="javaHome"/>
             <exclude tagName="environmentVariables"/>
+            <exclude tagName="settingsFile"/>
             <exclude tagName="localRepositoryPath"/>
             <exclude tagName="cloneProjectsTo"/>
           </excludes>
@@ -80,6 +79,13 @@
             <excludeProperty>systemPropertyVariables</excludeProperty>
           </excludeProperties>
         </effectivePom>
+        <!-- Same story: the osgi tests pass a settings file path through here, and Jenkins
+             gives that file a random name on every run. -->
+        <dirScan>
+          <excludes>
+            <exclude tagName="systemPropertyVariables"/>
+          </excludes>
+        </dirScan>
       </plugin>
       <plugin artifactId="asciidoctor-maven-plugin" groupId="org.asciidoctor">
         <effectivePom>

--- a/.mvn/maven-build-cache-config.xml
+++ b/.mvn/maven-build-cache-config.xml
@@ -50,6 +50,18 @@
             <excludeProperty>filterProperties</excludeProperty>
           </excludeProperties>
         </effectivePom>
+        <!-- javaHome is ${java.home}, so the scanner walks the whole JDK and hashes every file in
+             it. Jenkins unpacks a fresh JDK per agent, so that alone gives a new checksum
+             on every run and the module can never hit the cache. The
+             others point at build output for the same reason. -->
+        <dirScan>
+          <excludes>
+            <exclude tagName="javaHome"/>
+            <exclude tagName="environmentVariables"/>
+            <exclude tagName="localRepositoryPath"/>
+            <exclude tagName="cloneProjectsTo"/>
+          </excludes>
+        </dirScan>
       </plugin>
       <!-- this one points at the whole build/ dir, which the scanner walks recursively -->
       <plugin groupId="org.apache.maven.plugins" artifactId="maven-resources-plugin">

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
           }
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
-          sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
+          sh "mvn -T3 $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     stage("Parallel Stage") {
       parallel {
         stage("Build / Test - JDK21") {
-          agent { node { label 'linux' } }
+          agent { node { label 'linux-dind' } }
           steps {
             timeout( time: 210, unit: 'MINUTES' ) {
               script{
@@ -30,7 +30,7 @@ pipeline {
         }
 
         stage("Build / Test - JDK25") {
-          agent { node { label 'linux' } }
+          agent { node { label 'linux-dind' } }
           steps {
             timeout( time: 210, unit: 'MINUTES' ) {
               checkout scm
@@ -41,7 +41,7 @@ pipeline {
         }
 
         stage("Build / Test - JDK26") {
-          agent { node { label 'linux' } }
+          agent { node { label 'linux-dind' } }
           steps {
             timeout( time: 210, unit: 'MINUTES' ) {
               checkout scm
@@ -71,7 +71,7 @@ pipeline {
         }
 
         stage("Build / Test - JDK17") {
-          agent { node { label 'linux' } }
+          agent { node { label 'linux-dind' } }
           steps {
             timeout( time: 210, unit: 'MINUTES' ) {
               checkout scm

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -175,6 +175,15 @@ def mavenBuild(jdk, cmdline, mvnName) {
     finally
     {
       junit testResults: '**/target/surefire-reports/TEST**.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
+      // A handful of modules get a fresh build cache checksum on every run and so never hit the
+      // cache. Each buildinfo.xml lists the inputs that went into a checksum, so keeping them
+      // lets us diff two runs and see which input moved. Drop this once the cause is found.
+      sh """
+        rm -rf cache-debug
+        mkdir -p cache-debug/${jdk}
+        find build-cache -name buildinfo.xml -print 2>/dev/null | grep -E '(maven-plugin|osgi|test-distribution-common|jetty-slf4j-impl)' | while read -r f; do cp --parents "\$f" cache-debug/${jdk}/ || true; done
+      """
+      archiveArtifacts artifacts: 'cache-debug/**/buildinfo.xml', allowEmptyArchive: true, onlyIfSuccessful: false
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -163,9 +163,12 @@ def mavenBuild(jdk, cmdline, mvnName) {
           if(useEclipseDash()) {
             dashProfile = " -Peclipse-dash "
           }
+          // Pull the gcloud emulator image through the local Nexus proxy instead of gcr.io. A
+          // registry mirror cannot do this: dockerd only consults a mirror for Docker Hub.
+          def gcloudImage = " -Dgcloud.docker.image.name=nexus-service.nexus.svc.cluster.local:8082/google.com/cloudsdktool/cloud-sdk "
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
-          sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
+          sh "mvn $extraArgs $dashProfile $gcloudImage -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -184,7 +184,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
       sh """
         rm -rf cache-debug
         mkdir -p cache-debug/${jdk}
-        find build-cache -name buildinfo.xml -print 2>/dev/null | grep -E '(maven-plugin|osgi|test-distribution-common|jetty-slf4j-impl)' | while read -r f; do cp --parents "\$f" cache-debug/${jdk}/ || true; done
+        find build-cache -name buildinfo.xml -print 2>/dev/null | grep -E '(maven-plugin|osgi|test-distribution-common|jetty-slf4j-impl|jetty-util|jetty-server)' | while read -r f; do cp --parents "\$f" cache-debug/${jdk}/ || true; done
       """
       archiveArtifacts artifacts: 'cache-debug/**/buildinfo.xml', allowEmptyArchive: true, onlyIfSuccessful: false
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -165,7 +165,7 @@ def mavenBuild(jdk, cmdline, mvnName) {
           }
           sh "mkdir ~/.mimir"
           sh "cp jenkins-mimir-daemon.properties ~/.mimir/daemon.properties"
-          sh "mvn -T3 $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
+          sh "mvn $extraArgs $dashProfile -s $GLOBAL_MVN_SETTINGS -Dsettings.path=$GLOBAL_MVN_SETTINGS -DsettingsPath=$GLOBAL_MVN_SETTINGS -Dmaven.repo.uri=http://nexus-service.nexus.svc.cluster.local:8081/repository/maven-public/ -ntp -Dmaven.repo.local=.repository -Pci -V -B -e -U $cmdline"
           if(saveHome()) {
             archiveArtifacts artifacts: ".repository/org/eclipse/jetty/jetty-home/**/jetty-home-*", allowEmptyArchive: true, onlyIfSuccessful: false
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,15 +178,6 @@ def mavenBuild(jdk, cmdline, mvnName) {
     finally
     {
       junit testResults: '**/target/surefire-reports/TEST**.xml,**/target/invoker-reports/TEST*.xml', allowEmptyResults: true
-      // A handful of modules get a fresh build cache checksum on every run and so never hit the
-      // cache. Each buildinfo.xml lists the inputs that went into a checksum, so keeping them
-      // lets us diff two runs and see which input moved. Drop this once the cause is found.
-      sh """
-        rm -rf cache-debug
-        mkdir -p cache-debug/${jdk}
-        find build-cache -name buildinfo.xml -print 2>/dev/null | grep -E '(maven-plugin|osgi|test-distribution-common|jetty-slf4j-impl|jetty-util|jetty-server)' | while read -r f; do cp --parents "\$f" cache-debug/${jdk}/ || true; done
-      """
-      archiveArtifacts artifacts: 'cache-debug/**/buildinfo.xml', allowEmptyArchive: true, onlyIfSuccessful: false
     }
   }
 }

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/GCloudSessionTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/GCloudSessionTestSupport.java
@@ -70,7 +70,7 @@ public class GCloudSessionTestSupport
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.gcloud.session.gcloudLogs");
 
     public static DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:447.0.0-emulators")
+            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-emulators")
     ).withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
             .withFlags("--consistency=1.0");
 

--- a/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/GCloudSessionTestSupport.java
+++ b/tests/jetty-test-session-common/src/main/java/org/eclipse/jetty/session/test/tools/GCloudSessionTestSupport.java
@@ -69,8 +69,16 @@ public class GCloudSessionTestSupport
     private static final Logger LOGGER = LoggerFactory.getLogger(GCloudSessionTestSupport.class);
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.gcloud.session.gcloudLogs");
 
+    // Point the name at a registry that proxies gcr.io to keep the pull local.
+    private static final String GCLOUD_IMAGE_NAME =
+            System.getProperty("gcloud.docker.image.name", "gcr.io/google.com/cloudsdktool/cloud-sdk");
+    private static final String GCLOUD_IMAGE_VERSION =
+            System.getProperty("gcloud.docker.image.version", "583.0.0-emulators");
+
     public static DatastoreEmulatorContainer emulator = new DatastoreEmulatorContainer(
-            DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-emulators")
+            // The container only knows the gcr.io names, so a proxied one needs a stand-in.
+            DockerImageName.parse(GCLOUD_IMAGE_NAME + ":" + GCLOUD_IMAGE_VERSION)
+                    .asCompatibleSubstituteFor("gcr.io/google.com/cloudsdktool/cloud-sdk")
     ).withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
             .withFlags("--consistency=1.0");
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
@@ -34,8 +34,17 @@ public class GCloudSessionDistributionTests extends AbstractSessionDistributionT
     private static final Logger LOGGER = LoggerFactory.getLogger(GCloudSessionDistributionTests.class);
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.tests.distribution.session.gcloud.logs");
 
+    // Point the name at a registry proxying gcr.io to keep the pull inside the build network.
+    private static final String GCLOUD_IMAGE_NAME =
+            System.getProperty("gcloud.docker.image.name", "gcr.io/google.com/cloudsdktool/cloud-sdk");
+    private static final String GCLOUD_IMAGE_VERSION =
+            System.getProperty("gcloud.docker.image.version", "583.0.0-emulators");
+
     public DatastoreEmulatorContainer emulator =
-            new DatastoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-emulators"))
+            new DatastoreEmulatorContainer(DockerImageName.parse(GCLOUD_IMAGE_NAME + ":" + GCLOUD_IMAGE_VERSION)
+                    // DatastoreEmulatorContainer only accepts the two gcr.io names, so a proxied
+                    // name has to be declared a stand-in for the one it knows.
+                    .asCompatibleSubstituteFor("gcr.io/google.com/cloudsdktool/cloud-sdk"))
                     .withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
                     .withFlags("--consistency=1.0");
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
@@ -35,7 +35,7 @@ public class GCloudSessionDistributionTests extends AbstractSessionDistributionT
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.tests.distribution.session.gcloud.logs");
 
     public DatastoreEmulatorContainer emulator =
-            new DatastoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:316.0.0-emulators"))
+            new DatastoreEmulatorContainer(DockerImageName.parse("gcr.io/google.com/cloudsdktool/cloud-sdk:583.0.0-emulators"))
                     .withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
                     .withFlags("--consistency=1.0");
 

--- a/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
+++ b/tests/test-distribution/test-distribution-common/src/test/java/org/eclipse/jetty/tests/distribution/session/GCloudSessionDistributionTests.java
@@ -34,7 +34,7 @@ public class GCloudSessionDistributionTests extends AbstractSessionDistributionT
     private static final Logger LOGGER = LoggerFactory.getLogger(GCloudSessionDistributionTests.class);
     private static final Logger GCLOUD_LOG = LoggerFactory.getLogger("org.eclipse.jetty.tests.distribution.session.gcloud.logs");
 
-    // Point the name at a registry proxying gcr.io to keep the pull inside the build network.
+    // Point the name at a registry that proxies gcr.io to keep the pull local.
     private static final String GCLOUD_IMAGE_NAME =
             System.getProperty("gcloud.docker.image.name", "gcr.io/google.com/cloudsdktool/cloud-sdk");
     private static final String GCLOUD_IMAGE_VERSION =
@@ -42,8 +42,7 @@ public class GCloudSessionDistributionTests extends AbstractSessionDistributionT
 
     public DatastoreEmulatorContainer emulator =
             new DatastoreEmulatorContainer(DockerImageName.parse(GCLOUD_IMAGE_NAME + ":" + GCLOUD_IMAGE_VERSION)
-                    // DatastoreEmulatorContainer only accepts the two gcr.io names, so a proxied
-                    // name has to be declared a stand-in for the one it knows.
+                    // The container only knows the gcr.io names, so a proxied one needs a stand-in.
                     .asCompatibleSubstituteFor("gcr.io/google.com/cloudsdktool/cloud-sdk"))
                     .withLogConsumer(new Slf4jLogConsumer(GCLOUD_LOG))
                     .withFlags("--consistency=1.0");


### PR DESCRIPTION
-  Use linux-dind, the new k8s pod is now using our internal nexus to cache docker images
- bump google cloud emulator images and cofigure them to use local mirror
- Skip some directories to get scan by the cache
-  Maven plugin cache efficiency changes
