### PR TITLE
Add missing integration between ServletContextResponse.write() and HttpOutput

### DIFF
--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
@@ -540,6 +540,19 @@ public class Blocker
             }
         }
 
+        public boolean isBlocking()
+        {
+            _lock.lock();
+            try
+            {
+                return _completed != null && _completed != SUCCEEDED;
+            }
+            finally
+            {
+                _lock.unlock();
+            }
+        }
+
         @Override
         public String toString()
         {

--- a/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
+++ b/jetty-core/jetty-util/src/main/java/org/eclipse/jetty/util/Blocker.java
@@ -540,19 +540,6 @@ public class Blocker
             }
         }
 
-        public boolean isBlocking()
-        {
-            _lock.lock();
-            try
-            {
-                return _completed != null && _completed != SUCCEEDED;
-            }
-            finally
-            {
-                _lock.unlock();
-            }
-        }
-
         @Override
         public String toString()
         {

--- a/jetty-ee10/jetty-ee10-servlet/pom.xml
+++ b/jetty-ee10/jetty-ee10-servlet/pom.xml
@@ -68,6 +68,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-zstandard</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee</groupId>
       <artifactId>jetty-ee-test-resources</artifactId>
       <scope>test</scope>

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -243,6 +243,20 @@ public class HttpOutput extends ServletOutputStream
         content.writeTo(_servletChannel.getResponse(), last, callback);
     }
 
+    void lastWriteComplete()
+    {
+        Callback closedCallback;
+        try (AutoLock ignored = _channelState.lock())
+        {
+            _state = State.CLOSED;
+            closedCallback = _closedCallback;
+            _closedCallback = null;
+            lockedReleaseBuffer();
+        }
+        if (closedCallback != null)
+            closedCallback.succeeded();
+    }
+
     private void onWriteComplete(boolean last, Throwable failure)
     {
         String state = null;
@@ -487,11 +501,6 @@ public class HttpOutput extends ServletOutputStream
             _state = State.CLOSED;
             lockedReleaseBuffer();
         }
-    }
-
-    boolean isBlocking()
-    {
-        return _writeBlocker.isBlocking();
     }
 
     @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -1727,6 +1727,15 @@ public class HttpOutput extends ServletOutputStream
                     len += r;
             }
 
+            if (_eof)
+            {
+                // Change the state to signal that this is really the last write.
+                try (AutoLock ignored = _channelState.lock())
+                {
+                    _state = State.CLOSING;
+                }
+            }
+
             // write what we have
             byteBuffer.position(0);
             byteBuffer.limit(len);
@@ -1798,6 +1807,15 @@ public class HttpOutput extends ServletOutputStream
             while (byteBuffer.hasRemaining() && !_eof)
             {
                 _eof = (_in.read(byteBuffer)) < 0;
+            }
+
+            if (_eof)
+            {
+                // Change the state to signal that this is really the last write.
+                try (AutoLock ignored = _channelState.lock())
+                {
+                    _state = State.CLOSING;
+                }
             }
 
             // write what we have

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/HttpOutput.java
@@ -489,6 +489,11 @@ public class HttpOutput extends ServletOutputStream
         }
     }
 
+    boolean isBlocking()
+    {
+        return _writeBlocker.isBlocking();
+    }
+
     @Override
     public void close() throws IOException
     {
@@ -811,7 +816,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + len;
+            long written = lockedGetWritten() + len;
             int space = maximizeAggregateSpace();
 
             // Is this the last write due to content-length?
@@ -848,8 +853,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-
-            _written = written;
 
             // Should we aggregate?
             if (aggregate)
@@ -949,7 +952,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + len;
+            long written = lockedGetWritten() + len;
 
             // Is this the last write due to content-length?
             last = isAllContentWritten(written);
@@ -981,7 +984,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-            _written = written;
         }
 
         if (!flush)
@@ -1031,7 +1033,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + 1;
+            long written = lockedGetWritten() + 1;
             int space = maximizeAggregateSpace();
 
             // Is this the last write due to content-length?
@@ -1063,7 +1065,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-            _written = written;
 
             lockedAcquireBuffer();
             BufferUtil.append(_aggregate.getByteBuffer(), (byte)b);
@@ -1089,6 +1090,12 @@ public class HttpOutput extends ServletOutputStream
                 throw t;
             }
         }
+    }
+
+    private long lockedGetWritten()
+    {
+        assert _channelState.isLockHeldByCurrentThread();
+        return _written + (_aggregate == null ? 0 : _aggregate.remaining());
     }
 
     @Override
@@ -1171,7 +1178,6 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent({})", BufferUtil.toDetailString(content));
 
-        _written += content.remaining();
         channelWrite(content, true);
     }
 
@@ -1216,7 +1222,7 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(buffer={},{})", BufferUtil.toDetailString(content), callback);
 
-        if (prepareSendContent(content.remaining(), callback))
+        if (prepareSendContent(callback))
             channelWrite(content, true,
                 new Callback.Nested(callback)
                 {
@@ -1248,7 +1254,7 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(stream={},{})", in, callback);
 
-        if (prepareSendContent(0, callback))
+        if (prepareSendContent(callback))
             new InputStreamWritingCB(in, callback).iterate();
     }
 
@@ -1264,11 +1270,11 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(channel={},{})", in, callback);
 
-        if (prepareSendContent(0, callback))
+        if (prepareSendContent(callback))
             new ReadableByteChannelWritingCB(in, callback).iterate();
     }
 
-    private boolean prepareSendContent(int len, Callback callback)
+    private boolean prepareSendContent(Callback callback)
     {
         try (AutoLock ignored = _channelState.lock())
         {
@@ -1304,8 +1310,6 @@ public class HttpOutput extends ServletOutputStream
             if (_apiState != ApiState.BLOCKING)
                 throw new IllegalStateException(lockedStateString());
             _apiState = ApiState.PENDING;
-            if (len > 0)
-                _written += len;
             return true;
         }
     }
@@ -1679,7 +1683,6 @@ public class HttpOutput extends ServletOutputStream
         private final InputStream _in;
         private final RetainableByteBuffer _buffer;
         private boolean _eof;
-        private boolean _closed;
 
         private InputStreamWritingCB(InputStream in, Callback callback)
         {
@@ -1699,8 +1702,6 @@ public class HttpOutput extends ServletOutputStream
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("EOF of {}", this);
-                if (!_closed)
-                    _closed = true;
                 return Action.SUCCEEDED;
             }
 
@@ -1720,7 +1721,6 @@ public class HttpOutput extends ServletOutputStream
             // write what we have
             byteBuffer.position(0);
             byteBuffer.limit(len);
-            _written += len;
             channelWrite(byteBuffer, _eof, this);
             return Action.SCHEDULED;
         }
@@ -1730,6 +1730,7 @@ public class HttpOutput extends ServletOutputStream
         {
             _buffer.release();
             IO.close(_in);
+            super.onCompleteSuccess();
         }
 
         @Override
@@ -1759,7 +1760,6 @@ public class HttpOutput extends ServletOutputStream
         private final ReadableByteChannel _in;
         private final RetainableByteBuffer _buffer;
         private boolean _eof;
-        private boolean _closed;
 
         private ReadableByteChannelWritingCB(ReadableByteChannel in, Callback callback)
         {
@@ -1779,8 +1779,6 @@ public class HttpOutput extends ServletOutputStream
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("EOF of {}", this);
-                if (!_closed)
-                    _closed = true;
                 return Action.SUCCEEDED;
             }
 
@@ -1795,7 +1793,6 @@ public class HttpOutput extends ServletOutputStream
 
             // write what we have
             BufferUtil.flipToFlush(byteBuffer, 0);
-            _written += byteBuffer.remaining();
             channelWrite(byteBuffer, _eof, this);
 
             return Action.SCHEDULED;
@@ -1806,6 +1803,7 @@ public class HttpOutput extends ServletOutputStream
         {
             _buffer.release();
             IO.close(_in);
+            super.onCompleteSuccess();
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -223,12 +223,9 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        if (!httpOutput.isClosed())
-        {
-            httpOutput.addBytesWritten(BufferUtil.length(content));
-            if (last)
-                httpOutput.lastWriteComplete();
-        }
+        if (!httpOutput.isClosed() && last)
+            httpOutput.lastWriteComplete();
+        httpOutput.addBytesWritten(BufferUtil.length(content));
         super.write(last, content, callback);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -223,9 +223,12 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        if (last && !httpOutput.isClosed())
-            httpOutput.lastWriteComplete();
-        httpOutput.addBytesWritten(BufferUtil.length(content));
+        if (!httpOutput.isClosed())
+        {
+            httpOutput.addBytesWritten(BufferUtil.length(content));
+            if (last)
+                httpOutput.lastWriteComplete();
+        }
         super.write(last, content, callback);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -37,7 +37,9 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ContextResponse;
 import org.eclipse.jetty.session.ManagedSession;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 
 /**
  * A core response wrapper that carries the servlet related response state,
@@ -221,7 +223,14 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
-        super.write(last, content, callback);
+        // Last writes must trigger a close() on the HttpOutput
+        // which itself will make the last write.
+        boolean httpOutputClosed = getHttpOutput().isClosed();
+        if (!httpOutputClosed && last)
+            callback = Callback.from(() -> IO.close(getHttpOutput()), callback);
+
+        getHttpOutput().addBytesWritten(BufferUtil.length(content));
+        super.write(httpOutputClosed, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -220,20 +220,13 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     }
 
     @Override
-    public void write(boolean requestLast, ByteBuffer content, Callback callback)
+    public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        boolean deferLast = requestLast && !httpOutput.isClosed();
-        if (deferLast)
-        {
-            callback = Callback.from(callback, () ->
-            {
-                httpOutput.lastWriteComplete();
-                super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
-            });
-        }
+        if (last && !httpOutput.isClosed())
+            httpOutput.lastWriteComplete();
         httpOutput.addBytesWritten(BufferUtil.length(content));
-        super.write(requestLast && !deferLast, content, callback);
+        super.write(last, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -225,11 +225,14 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     {
         // Last writes must trigger a close() on the HttpOutput
         // which itself will make the last write.
-        boolean httpOutputClosed = getHttpOutput().isClosed();
-        if (!httpOutputClosed && last)
-            callback = Callback.from(() -> IO.close(getHttpOutput()), callback);
-
-        getHttpOutput().addBytesWritten(BufferUtil.length(content));
+        HttpOutput httpOutput = getHttpOutput();
+        boolean httpOutputClosed = httpOutput.isClosed();
+        if (!httpOutputClosed)
+        {
+            httpOutput.addBytesWritten(BufferUtil.length(content));
+            if (last)
+                callback = Callback.from(() -> IO.close(httpOutput), callback);
+        }
         super.write(httpOutputClosed, content, callback);
     }
 

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -223,8 +223,8 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
-        // Last writes must trigger a close() on the HttpOutput
-        // which itself will make the last write.
+        // Last write must trigger a close() on the HttpOutput
+        // which will call this method again to do the last write.
         HttpOutput httpOutput = getHttpOutput();
         boolean httpOutputClosed = httpOutput.isClosed();
         if (!httpOutputClosed)

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -221,19 +221,41 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     }
 
     @Override
-    public void write(boolean last, ByteBuffer content, Callback callback)
+    public void write(boolean requestLast, ByteBuffer content, Callback callback)
     {
-        // Last write must trigger a close() on the HttpOutput
-        // which will call this method again to do the last write.
+        // When write() is not called from a blocking call, the
+        // last write must trigger a close() on the HttpOutput
+        // which will call this method again to actually do the
+        // last write.
         HttpOutput httpOutput = getHttpOutput();
-        boolean httpOutputClosed = httpOutput.isClosed();
-        if (!httpOutputClosed)
+        boolean forwardLast;
+        if (requestLast)
         {
-            httpOutput.addBytesWritten(BufferUtil.length(content));
-            if (last)
-                callback = Callback.from(() -> IO.close(httpOutput), callback);
+            if (!httpOutput.isClosed())
+            {
+                // The HttpOutput instance can only be blocking if a blocking sendContent()
+                // variant is the caller; in this case, sendContent() closes the httpOutput.
+                if (!httpOutput.isBlocking())
+                {
+                    callback = Callback.from(() -> IO.close(httpOutput), callback);
+                    forwardLast = false;
+                }
+                else
+                {
+                    forwardLast = true;
+                }
+            }
+            else
+            {
+                forwardLast = true;
+            }
         }
-        super.write(httpOutputClosed, content, callback);
+        else
+        {
+            forwardLast = false;
+        }
+        httpOutput.addBytesWritten(BufferUtil.length(content));
+        super.write(forwardLast, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -39,7 +39,6 @@ import org.eclipse.jetty.server.handler.ContextResponse;
 import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.IO;
 
 /**
  * A core response wrapper that carries the servlet related response state,
@@ -235,15 +234,12 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             {
                 // The HttpOutput instance can only be blocking if a blocking sendContent()
                 // variant is the caller; in this case, sendContent() closes the httpOutput.
-                if (!httpOutput.isBlocking())
+                callback = Callback.from(() ->
                 {
-                    callback = Callback.from(() -> IO.close(httpOutput), callback);
-                    forwardLast = false;
-                }
-                else
-                {
-                    forwardLast = true;
-                }
+                    httpOutput.lastWriteComplete();
+                    super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+                }, callback);
+                forwardLast = false;
             }
             else
             {

--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/ServletContextResponse.java
@@ -222,36 +222,18 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean requestLast, ByteBuffer content, Callback callback)
     {
-        // When write() is not called from a blocking call, the
-        // last write must trigger a close() on the HttpOutput
-        // which will call this method again to actually do the
-        // last write.
         HttpOutput httpOutput = getHttpOutput();
-        boolean forwardLast;
-        if (requestLast)
+        boolean deferLast = requestLast && !httpOutput.isClosed();
+        if (deferLast)
         {
-            if (!httpOutput.isClosed())
+            callback = Callback.from(callback, () ->
             {
-                // The HttpOutput instance can only be blocking if a blocking sendContent()
-                // variant is the caller; in this case, sendContent() closes the httpOutput.
-                callback = Callback.from(() ->
-                {
-                    httpOutput.lastWriteComplete();
-                    super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
-                }, callback);
-                forwardLast = false;
-            }
-            else
-            {
-                forwardLast = true;
-            }
-        }
-        else
-        {
-            forwardLast = false;
+                httpOutput.lastWriteComplete();
+                super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+            });
         }
         httpOutput.addBytesWritten(BufferUtil.length(content));
-        super.write(forwardLast, content, callback);
+        super.write(requestLast && !deferLast, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
@@ -266,7 +266,8 @@ public class HttpOutputTest
     {
         _server.start();
         Resource big = ResourceFactory.of(_servletContextHandler).newClassLoaderResource("simple/big.txt", false);
-        _contentServlet._content = IOResources.toRetainableByteBuffer(big, new ByteBufferPool.Sized(ByteBufferPool.NON_POOLING, true, -1)).getByteBuffer();        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        _contentServlet._content = IOResources.toRetainableByteBuffer(big, new ByteBufferPool.Sized(ByteBufferPool.NON_POOLING, true, -1)).getByteBuffer();
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/HttpOutputTest.java
@@ -108,7 +108,7 @@ public class HttpOutputTest
     }
 
     @Test
-    public void testSendContentByteBuffer() throws Exception
+    public void testSendContentInDirectByteBuffer() throws Exception
     {
         _server.start();
         byte[] buffer = new byte[16 * 1024];
@@ -116,6 +116,34 @@ public class HttpOutputTest
         Arrays.fill(buffer, 4 * 1024, 12 * 1024, (byte)0x58);
         Arrays.fill(buffer, 12 * 1024, 16 * 1024, (byte)0x66);
         _contentServlet._content = ByteBuffer.wrap(buffer);
+        _contentServlet._content.limit(12 * 1024);
+        _contentServlet._content.position(4 * 1024);
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("\r\nXXXXXXXXXXXXXXXXXXXXXXXXXXX"));
+
+        for (int i = 0; i < 4 * 1024; i++)
+        {
+            assertEquals((byte)0x99, buffer[i], "i=" + i);
+        }
+        for (int i = 12 * 1024; i < 16 * 1024; i++)
+        {
+            assertEquals((byte)0x66, buffer[i], "i=" + i);
+        }
+    }
+
+    @Test
+    public void testSendContentDirectByteBuffer() throws Exception
+    {
+        _server.start();
+        byte[] buffer = new byte[16 * 1024];
+        Arrays.fill(buffer, 0, 4 * 1024, (byte)0x99);
+        Arrays.fill(buffer, 4 * 1024, 12 * 1024, (byte)0x58);
+        Arrays.fill(buffer, 12 * 1024, 16 * 1024, (byte)0x66);
+        _contentServlet._content = ByteBuffer.allocateDirect(buffer.length);
+        BufferUtil.flipToFill(_contentServlet._content);
+        BufferUtil.append(_contentServlet._content, buffer);
+        BufferUtil.flipToFlush(_contentServlet._content, 0);
         _contentServlet._content.limit(12 * 1024);
         _contentServlet._content.position(4 * 1024);
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
@@ -238,8 +266,7 @@ public class HttpOutputTest
     {
         _server.start();
         Resource big = ResourceFactory.of(_servletContextHandler).newClassLoaderResource("simple/big.txt", false);
-        _contentServlet._content = IOResources.toRetainableByteBuffer(big, ByteBufferPool.SIZED_NON_POOLING).getByteBuffer();
-        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        _contentServlet._content = IOResources.toRetainableByteBuffer(big, new ByteBufferPool.Sized(ByteBufferPool.NON_POOLING, true, -1)).getByteBuffer();        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));
         assertThat(response, endsWith(toUTF8String(big)));

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletCompressionCompleteTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ResourceServletCompressionCompleteTest.java
@@ -1,0 +1,148 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(WorkDirExtension.class)
+public class ResourceServletCompressionCompleteTest
+{
+    public WorkDir workDir;
+    private Server server;
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testCompleteAfterDirectResourceWriteDoesNotFail() throws Exception
+    {
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
+        FS.ensureDirExists(contextDir);
+
+        Path file = contextDir.resolve("big.txt");
+        String generatedContent = generateContent(64 * 1024);
+        Files.writeString(file, generatedContent, StandardCharsets.UTF_8);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/context");
+        context.setBaseResourceAsPath(contextDir);
+        context.addServlet(ResourceServlet.class, "/*");
+
+        CompressionHandler compressionHandler = new CompressionHandler(context);
+        compressionHandler.putCompression(new ZstandardCompression());
+
+        AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
+        Handler.Wrapper failureCapture = new Handler.Wrapper(compressionHandler)
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                Callback wrapped = new Callback()
+                {
+                    @Override
+                    public void succeeded()
+                    {
+                        callback.succeeded();
+                    }
+
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        handlerFailure.set(x);
+                        callback.failed(x);
+                    }
+                };
+                return super.handle(request, response, wrapped);
+            }
+        };
+
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+        server.setHandler(failureCapture);
+        server.start();
+
+        try (HttpClient httpClient = new HttpClient())
+        {
+            httpClient.start();
+
+            // HttpClient transparently decodes zstd content and strips the Content-Encoding
+            // header from the final response, so capture it as it arrives on the wire instead.
+            AtomicReference<String> contentEncoding = new AtomicReference<>();
+            ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+                .path("/context/big.txt")
+                .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "zstd"))
+                .onResponseHeader((r, f) ->
+                {
+                    if (f.getHeader() == HttpHeader.CONTENT_ENCODING)
+                        contentEncoding.set(f.getValue());
+                    return true;
+                })
+                .timeout(15, TimeUnit.SECONDS)
+                .send();
+
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+            assertThat(contentEncoding.get(), is("zstd"));
+            assertThat(response.getContentAsString(), is(generatedContent));
+            assertThat(handlerFailure.get(), nullValue());
+        }
+    }
+
+    private String generateContent(int length)
+    {
+        String sample = """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis felis nunc.
+                Quisque suscipit mauris et ante auctor ornare rhoncus lacus aliquet. Pellentesque
+                habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+                """;
+        StringBuilder result = new StringBuilder();
+        while (result.length() < length)
+        {
+            result.append(sample);
+        }
+        result.setLength(length);
+        return result.toString();
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/pom.xml
+++ b/jetty-ee11/jetty-ee11-servlet/pom.xml
@@ -68,6 +68,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-zstandard</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.jetty.ee</groupId>
       <artifactId>jetty-ee-test-resources</artifactId>
       <scope>test</scope>

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -1740,6 +1740,15 @@ public class HttpOutput extends ServletOutputStream
                     len += r;
             }
 
+            if (_eof)
+            {
+                // Change the state to signal that this is really the last write.
+                try (AutoLock ignored = _channelState.lock())
+                {
+                    _state = State.CLOSING;
+                }
+            }
+
             // write what we have
             byteBuffer.position(0);
             byteBuffer.limit(len);
@@ -1815,6 +1824,14 @@ public class HttpOutput extends ServletOutputStream
 
             // write what we have
             BufferUtil.flipToFlush(byteBuffer, 0);
+            if (_eof)
+            {
+                // Change the state to signal that this is really the last write.
+                try (AutoLock ignored = _channelState.lock())
+                {
+                    _state = State.CLOSING;
+                }
+            }
             channelWrite(byteBuffer, _eof, this);
 
             return Action.SCHEDULED;

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -243,6 +243,20 @@ public class HttpOutput extends ServletOutputStream
         content.writeTo(_servletChannel.getResponse(), last, callback);
     }
 
+    void lastWriteComplete()
+    {
+        Callback closedCallback;
+        try (AutoLock ignored = _channelState.lock())
+        {
+            _state = State.CLOSED;
+            closedCallback = _closedCallback;
+            _closedCallback = null;
+            lockedReleaseBuffer();
+        }
+        if (closedCallback != null)
+            closedCallback.succeeded();
+    }
+
     private void onWriteComplete(boolean last, Throwable failure)
     {
         String state = null;
@@ -500,11 +514,6 @@ public class HttpOutput extends ServletOutputStream
             _state = State.CLOSED;
             lockedReleaseBuffer();
         }
-    }
-
-    boolean isBlocking()
-    {
-        return _writeBlocker.isBlocking();
     }
 
     @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -502,6 +502,11 @@ public class HttpOutput extends ServletOutputStream
         }
     }
 
+    boolean isBlocking()
+    {
+        return _writeBlocker.isBlocking();
+    }
+
     @Override
     public void close() throws IOException
     {
@@ -824,7 +829,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + len;
+            long written = lockedGetWritten() + len;
             int space = maximizeAggregateSpace();
 
             // Is this the last write due to content-length?
@@ -861,8 +866,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-
-            _written = written;
 
             // Should we aggregate?
             if (aggregate)
@@ -962,7 +965,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + len;
+            long written = lockedGetWritten() + len;
 
             // Is this the last write due to content-length?
             last = isAllContentWritten(written);
@@ -994,7 +997,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-            _written = written;
         }
 
         if (!flush)
@@ -1044,7 +1046,7 @@ public class HttpOutput extends ServletOutputStream
         try (AutoLock ignored = _channelState.lock())
         {
             checkWritable();
-            long written = _written + 1;
+            long written = lockedGetWritten() + 1;
             int space = maximizeAggregateSpace();
 
             // Is this the last write due to content-length?
@@ -1076,7 +1078,6 @@ public class HttpOutput extends ServletOutputStream
                 default:
                     throw new IllegalStateException(lockedStateString());
             }
-            _written = written;
 
             lockedAcquireBuffer();
             BufferUtil.append(_aggregate.getByteBuffer(), (byte)b);
@@ -1102,6 +1103,12 @@ public class HttpOutput extends ServletOutputStream
                 throw t;
             }
         }
+    }
+
+    private long lockedGetWritten()
+    {
+        assert _channelState.isLockHeldByCurrentThread();
+        return _written + (_aggregate == null ? 0 : _aggregate.remaining());
     }
 
     @Override
@@ -1184,7 +1191,6 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent({})", BufferUtil.toDetailString(content));
 
-        _written += content.remaining();
         channelWrite(content, true);
     }
 
@@ -1229,7 +1235,7 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(buffer={},{})", BufferUtil.toDetailString(content), callback);
 
-        if (prepareSendContent(content.remaining(), callback))
+        if (prepareSendContent(callback))
             channelWrite(content, true,
                 new Callback.Nested(callback)
                 {
@@ -1261,7 +1267,7 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(stream={},{})", in, callback);
 
-        if (prepareSendContent(0, callback))
+        if (prepareSendContent(callback))
             new InputStreamWritingCB(in, callback).iterate();
     }
 
@@ -1277,11 +1283,11 @@ public class HttpOutput extends ServletOutputStream
         if (LOG.isDebugEnabled())
             LOG.debug("sendContent(channel={},{})", in, callback);
 
-        if (prepareSendContent(0, callback))
+        if (prepareSendContent(callback))
             new ReadableByteChannelWritingCB(in, callback).iterate();
     }
 
-    private boolean prepareSendContent(int len, Callback callback)
+    private boolean prepareSendContent(Callback callback)
     {
         try (AutoLock ignored = _channelState.lock())
         {
@@ -1317,8 +1323,6 @@ public class HttpOutput extends ServletOutputStream
             if (_apiState != ApiState.BLOCKING)
                 throw new IllegalStateException(lockedStateString());
             _apiState = ApiState.PENDING;
-            if (len > 0)
-                _written += len;
             return true;
         }
     }
@@ -1692,7 +1696,6 @@ public class HttpOutput extends ServletOutputStream
         private final InputStream _in;
         private final RetainableByteBuffer _buffer;
         private boolean _eof;
-        private boolean _closed;
 
         private InputStreamWritingCB(InputStream in, Callback callback)
         {
@@ -1712,8 +1715,6 @@ public class HttpOutput extends ServletOutputStream
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("EOF of {}", this);
-                if (!_closed)
-                    _closed = true;
                 return Action.SUCCEEDED;
             }
 
@@ -1733,7 +1734,6 @@ public class HttpOutput extends ServletOutputStream
             // write what we have
             byteBuffer.position(0);
             byteBuffer.limit(len);
-            _written += len;
             channelWrite(byteBuffer, _eof, this);
             return Action.SCHEDULED;
         }
@@ -1773,7 +1773,6 @@ public class HttpOutput extends ServletOutputStream
         private final ReadableByteChannel _in;
         private final RetainableByteBuffer _buffer;
         private boolean _eof;
-        private boolean _closed;
 
         private ReadableByteChannelWritingCB(ReadableByteChannel in, Callback callback)
         {
@@ -1793,8 +1792,6 @@ public class HttpOutput extends ServletOutputStream
             {
                 if (LOG.isDebugEnabled())
                     LOG.debug("EOF of {}", this);
-                if (!_closed)
-                    _closed = true;
                 return Action.SUCCEEDED;
             }
 
@@ -1809,7 +1806,6 @@ public class HttpOutput extends ServletOutputStream
 
             // write what we have
             BufferUtil.flipToFlush(byteBuffer, 0);
-            _written += byteBuffer.remaining();
             channelWrite(byteBuffer, _eof, this);
 
             return Action.SCHEDULED;

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/HttpOutput.java
@@ -1743,6 +1743,7 @@ public class HttpOutput extends ServletOutputStream
         {
             _buffer.release();
             IO.close(_in);
+            super.onCompleteSuccess();
         }
 
         @Override
@@ -1819,6 +1820,7 @@ public class HttpOutput extends ServletOutputStream
         {
             _buffer.release();
             IO.close(_in);
+            super.onCompleteSuccess();
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -37,7 +37,9 @@ import org.eclipse.jetty.http.MimeTypes;
 import org.eclipse.jetty.server.Response;
 import org.eclipse.jetty.server.handler.ContextResponse;
 import org.eclipse.jetty.session.ManagedSession;
+import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 
 /**
@@ -222,7 +224,14 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
-        super.write(last, content, callback);
+        // Last writes must trigger a close() on the HttpOutput
+        // which itself will make the last write.
+        boolean httpOutputClosed = getHttpOutput().isClosed();
+        if (!httpOutputClosed && last)
+            callback = Callback.from(() -> IO.close(getHttpOutput()), callback);
+
+        getHttpOutput().addBytesWritten(BufferUtil.length(content));
+        super.write(httpOutputClosed, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -224,12 +224,9 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        if (!httpOutput.isClosed())
-        {
-            httpOutput.addBytesWritten(BufferUtil.length(content));
-            if (last)
-                httpOutput.lastWriteComplete();
-        }
+        if (!httpOutput.isClosed() && last)
+            httpOutput.lastWriteComplete();
+        httpOutput.addBytesWritten(BufferUtil.length(content));
         super.write(last, content, callback);
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -226,11 +226,14 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     {
         // Last writes must trigger a close() on the HttpOutput
         // which itself will make the last write.
-        boolean httpOutputClosed = getHttpOutput().isClosed();
-        if (!httpOutputClosed && last)
-            callback = Callback.from(() -> IO.close(getHttpOutput()), callback);
-
-        getHttpOutput().addBytesWritten(BufferUtil.length(content));
+        HttpOutput httpOutput = getHttpOutput();
+        boolean httpOutputClosed = httpOutput.isClosed();
+        if (!httpOutputClosed)
+        {
+            httpOutput.addBytesWritten(BufferUtil.length(content));
+            if (last)
+                callback = Callback.from(() -> IO.close(httpOutput), callback);
+        }
         super.write(httpOutputClosed, content, callback);
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -222,19 +222,41 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     }
 
     @Override
-    public void write(boolean last, ByteBuffer content, Callback callback)
+    public void write(boolean requestLast, ByteBuffer content, Callback callback)
     {
-        // Last write must trigger a close() on the HttpOutput
-        // which will call this method again to do the last write.
+        // When write() is not called from a blocking call, the
+        // last write must trigger a close() on the HttpOutput
+        // which will call this method again to actually do the
+        // last write.
         HttpOutput httpOutput = getHttpOutput();
-        boolean httpOutputClosed = httpOutput.isClosed();
-        if (!httpOutputClosed)
+        boolean forwardLast;
+        if (requestLast)
         {
-            httpOutput.addBytesWritten(BufferUtil.length(content));
-            if (last)
-                callback = Callback.from(() -> IO.close(httpOutput), callback);
+            if (!httpOutput.isClosed())
+            {
+                // The HttpOutput instance can only be blocking if a blocking sendContent()
+                // variant was called; in those cases, sendContent() will close the httpOutput.
+                if (!httpOutput.isBlocking())
+                {
+                    callback = Callback.from(() -> IO.close(httpOutput), callback);
+                    forwardLast = false;
+                }
+                else
+                {
+                    forwardLast = true;
+                }
+            }
+            else
+            {
+                forwardLast = true;
+            }
         }
-        super.write(httpOutputClosed, content, callback);
+        else
+        {
+            forwardLast = false;
+        }
+        httpOutput.addBytesWritten(BufferUtil.length(content));
+        super.write(forwardLast, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -224,9 +224,12 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        if (last && !httpOutput.isClosed())
-            httpOutput.lastWriteComplete();
-        httpOutput.addBytesWritten(BufferUtil.length(content));
+        if (!httpOutput.isClosed())
+        {
+            httpOutput.addBytesWritten(BufferUtil.length(content));
+            if (last)
+                httpOutput.lastWriteComplete();
+        }
         super.write(last, content, callback);
     }
 

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -224,8 +224,8 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean last, ByteBuffer content, Callback callback)
     {
-        // Last writes must trigger a close() on the HttpOutput
-        // which itself will make the last write.
+        // Last write must trigger a close() on the HttpOutput
+        // which will call this method again to do the last write.
         HttpOutput httpOutput = getHttpOutput();
         boolean httpOutputClosed = httpOutput.isClosed();
         if (!httpOutputClosed)

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -223,36 +223,18 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     @Override
     public void write(boolean requestLast, ByteBuffer content, Callback callback)
     {
-        // When write() is not called from a blocking call, the
-        // last write must trigger a close() on the HttpOutput
-        // which will call this method again to actually do the
-        // last write.
         HttpOutput httpOutput = getHttpOutput();
-        boolean forwardLast;
-        if (requestLast)
+        boolean deferLast = requestLast && !httpOutput.isClosed();
+        if (deferLast)
         {
-            if (!httpOutput.isClosed())
+            callback = Callback.from(callback, () ->
             {
-                // The HttpOutput instance can only be blocking if a blocking sendContent()
-                // variant is the caller; in this case, sendContent() closes the httpOutput.
-                callback = Callback.from(callback, () ->
-                {
-                    httpOutput.lastWriteComplete();
-                    super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
-                });
-                forwardLast = false;
-            }
-            else
-            {
-                forwardLast = true;
-            }
-        }
-        else
-        {
-            forwardLast = false;
+                httpOutput.lastWriteComplete();
+                super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+            });
         }
         httpOutput.addBytesWritten(BufferUtil.length(content));
-        super.write(forwardLast, content, callback);
+        super.write(requestLast && !deferLast, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -221,20 +221,13 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
     }
 
     @Override
-    public void write(boolean requestLast, ByteBuffer content, Callback callback)
+    public void write(boolean last, ByteBuffer content, Callback callback)
     {
         HttpOutput httpOutput = getHttpOutput();
-        boolean deferLast = requestLast && !httpOutput.isClosed();
-        if (deferLast)
-        {
-            callback = Callback.from(callback, () ->
-            {
-                httpOutput.lastWriteComplete();
-                super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
-            });
-        }
+        if (last && !httpOutput.isClosed())
+            httpOutput.lastWriteComplete();
         httpOutput.addBytesWritten(BufferUtil.length(content));
-        super.write(requestLast && !deferLast, content, callback);
+        super.write(last, content, callback);
     }
 
     public void closeOutput() throws IOException

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/ServletContextResponse.java
@@ -39,7 +39,6 @@ import org.eclipse.jetty.server.handler.ContextResponse;
 import org.eclipse.jetty.session.ManagedSession;
 import org.eclipse.jetty.util.BufferUtil;
 import org.eclipse.jetty.util.Callback;
-import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 
 /**
@@ -235,16 +234,13 @@ public class ServletContextResponse extends ContextResponse implements ServletCo
             if (!httpOutput.isClosed())
             {
                 // The HttpOutput instance can only be blocking if a blocking sendContent()
-                // variant was called; in those cases, sendContent() will close the httpOutput.
-                if (!httpOutput.isBlocking())
+                // variant is the caller; in this case, sendContent() closes the httpOutput.
+                callback = Callback.from(callback, () ->
                 {
-                    callback = Callback.from(() -> IO.close(httpOutput), callback);
-                    forwardLast = false;
-                }
-                else
-                {
-                    forwardLast = true;
-                }
+                    httpOutput.lastWriteComplete();
+                    super.write(true, BufferUtil.EMPTY_BUFFER, Callback.NOOP);
+                });
+                forwardLast = false;
             }
             else
             {

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/HttpOutputTest.java
@@ -108,7 +108,7 @@ public class HttpOutputTest
     }
 
     @Test
-    public void testSendContentByteBuffer() throws Exception
+    public void testSendContentInDirectByteBuffer() throws Exception
     {
         _server.start();
         byte[] buffer = new byte[16 * 1024];
@@ -116,6 +116,34 @@ public class HttpOutputTest
         Arrays.fill(buffer, 4 * 1024, 12 * 1024, (byte)0x58);
         Arrays.fill(buffer, 12 * 1024, 16 * 1024, (byte)0x66);
         _contentServlet._content = ByteBuffer.wrap(buffer);
+        _contentServlet._content.limit(12 * 1024);
+        _contentServlet._content.position(4 * 1024);
+        String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
+        assertThat(response, containsString("HTTP/1.1 200 OK"));
+        assertThat(response, containsString("\r\nXXXXXXXXXXXXXXXXXXXXXXXXXXX"));
+
+        for (int i = 0; i < 4 * 1024; i++)
+        {
+            assertEquals((byte)0x99, buffer[i], "i=" + i);
+        }
+        for (int i = 12 * 1024; i < 16 * 1024; i++)
+        {
+            assertEquals((byte)0x66, buffer[i], "i=" + i);
+        }
+    }
+
+    @Test
+    public void testSendContentDirectByteBuffer() throws Exception
+    {
+        _server.start();
+        byte[] buffer = new byte[16 * 1024];
+        Arrays.fill(buffer, 0, 4 * 1024, (byte)0x99);
+        Arrays.fill(buffer, 4 * 1024, 12 * 1024, (byte)0x58);
+        Arrays.fill(buffer, 12 * 1024, 16 * 1024, (byte)0x66);
+        _contentServlet._content = ByteBuffer.allocateDirect(buffer.length);
+        BufferUtil.flipToFill(_contentServlet._content);
+        BufferUtil.append(_contentServlet._content, buffer);
+        BufferUtil.flipToFlush(_contentServlet._content, 0);
         _contentServlet._content.limit(12 * 1024);
         _contentServlet._content.position(4 * 1024);
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
@@ -238,7 +266,7 @@ public class HttpOutputTest
     {
         _server.start();
         Resource big = ResourceFactory.of(_servletContextHandler).newClassLoaderResource("simple/big.txt", false);
-        _contentServlet._content = IOResources.toRetainableByteBuffer(big, ByteBufferPool.SIZED_NON_POOLING).getByteBuffer();
+        _contentServlet._content = IOResources.toRetainableByteBuffer(big, new ByteBufferPool.Sized(ByteBufferPool.NON_POOLING, true, -1)).getByteBuffer();
         String response = _connector.getResponse("GET / HTTP/1.0\nHost: localhost:80\n\n");
         assertThat(response, containsString("HTTP/1.1 200 OK"));
         assertThat(response, containsString("Content-Length"));

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResourceServletCompressionCompleteTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ResourceServletCompressionCompleteTest.java
@@ -1,0 +1,148 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(WorkDirExtension.class)
+public class ResourceServletCompressionCompleteTest
+{
+    public WorkDir workDir;
+    private Server server;
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testCompleteAfterDirectResourceWriteDoesNotFail() throws Exception
+    {
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
+        FS.ensureDirExists(contextDir);
+
+        Path file = contextDir.resolve("big.txt");
+        String generatedContent = generateContent(64 * 1024);
+        Files.writeString(file, generatedContent, StandardCharsets.UTF_8);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/context");
+        context.setBaseResourceAsPath(contextDir);
+        context.addServlet(ResourceServlet.class, "/*");
+
+        CompressionHandler compressionHandler = new CompressionHandler(context);
+        compressionHandler.putCompression(new ZstandardCompression());
+
+        AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
+        Handler.Wrapper failureCapture = new Handler.Wrapper(compressionHandler)
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                Callback wrapped = new Callback()
+                {
+                    @Override
+                    public void succeeded()
+                    {
+                        callback.succeeded();
+                    }
+
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        handlerFailure.set(x);
+                        callback.failed(x);
+                    }
+                };
+                return super.handle(request, response, wrapped);
+            }
+        };
+
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+        server.setHandler(failureCapture);
+        server.start();
+
+        try (HttpClient httpClient = new HttpClient())
+        {
+            httpClient.start();
+
+            // HttpClient transparently decodes zstd content and strips the Content-Encoding
+            // header from the final response, so capture it as it arrives on the wire instead.
+            AtomicReference<String> contentEncoding = new AtomicReference<>();
+            ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+                .path("/context/big.txt")
+                .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "zstd"))
+                .onResponseHeader((r, f) ->
+                {
+                    if (f.getHeader() == HttpHeader.CONTENT_ENCODING)
+                        contentEncoding.set(f.getValue());
+                    return true;
+                })
+                .timeout(15, TimeUnit.SECONDS)
+                .send();
+
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+            assertThat(contentEncoding.get(), is("zstd"));
+            assertThat(response.getContentAsString(), is(generatedContent));
+            assertThat(handlerFailure.get(), nullValue());
+        }
+    }
+
+    private String generateContent(int length)
+    {
+        String sample = """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis felis nunc.
+                Quisque suscipit mauris et ante auctor ornare rhoncus lacus aliquet. Pellentesque
+                habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+                """;
+        StringBuilder result = new StringBuilder();
+        while (result.length() < length)
+        {
+            result.append(sample);
+        }
+        result.setLength(length);
+        return result.toString();
+    }
+}

--- a/jetty-ee8/jetty-ee8-servlet/pom.xml
+++ b/jetty-ee8/jetty-ee8-servlet/pom.xml
@@ -61,6 +61,16 @@
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-zstandard</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jetty-ee9/jetty-ee9-servlet/pom.xml
+++ b/jetty-ee9/jetty-ee9-servlet/pom.xml
@@ -59,6 +59,16 @@
       <artifactId>jetty-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-server</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.eclipse.jetty.compression</groupId>
+      <artifactId>jetty-compression-zstandard</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResourceServletCompressionCompleteTest.java
+++ b/jetty-ee9/jetty-ee9-servlet/src/test/java/org/eclipse/jetty/ee9/servlet/ResourceServletCompressionCompleteTest.java
@@ -1,0 +1,148 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee9.servlet;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.eclipse.jetty.client.ContentResponse;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.compression.server.CompressionHandler;
+import org.eclipse.jetty.compression.zstandard.ZstandardCompression;
+import org.eclipse.jetty.http.HttpHeader;
+import org.eclipse.jetty.http.HttpStatus;
+import org.eclipse.jetty.server.Handler;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+import org.eclipse.jetty.toolchain.test.FS;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDir;
+import org.eclipse.jetty.toolchain.test.jupiter.WorkDirExtension;
+import org.eclipse.jetty.util.Callback;
+import org.eclipse.jetty.util.component.LifeCycle;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ExtendWith(WorkDirExtension.class)
+public class ResourceServletCompressionCompleteTest
+{
+    public WorkDir workDir;
+    private Server server;
+
+    @AfterEach
+    public void stopServer()
+    {
+        LifeCycle.stop(server);
+    }
+
+    @Test
+    public void testCompleteAfterDirectResourceWriteDoesNotFail() throws Exception
+    {
+        Path contextDir = workDir.getEmptyPathDir().resolve("context");
+        FS.ensureDirExists(contextDir);
+
+        Path file = contextDir.resolve("big.txt");
+        String generatedContent = generateContent(64 * 1024);
+        Files.writeString(file, generatedContent, StandardCharsets.UTF_8);
+
+        ServletContextHandler context = new ServletContextHandler();
+        context.setContextPath("/context");
+        context.setBaseResourceAsPath(contextDir);
+        context.addServlet(DefaultServlet.class, "/*");
+
+        CompressionHandler compressionHandler = new CompressionHandler(context.getCoreContextHandler());
+        compressionHandler.putCompression(new ZstandardCompression());
+
+        AtomicReference<Throwable> handlerFailure = new AtomicReference<>();
+        Handler.Wrapper failureCapture = new Handler.Wrapper(compressionHandler)
+        {
+            @Override
+            public boolean handle(Request request, Response response, Callback callback) throws Exception
+            {
+                Callback wrapped = new Callback()
+                {
+                    @Override
+                    public void succeeded()
+                    {
+                        callback.succeeded();
+                    }
+
+                    @Override
+                    public void failed(Throwable x)
+                    {
+                        handlerFailure.set(x);
+                        callback.failed(x);
+                    }
+                };
+                return super.handle(request, response, wrapped);
+            }
+        };
+
+        server = new Server();
+        ServerConnector connector = new ServerConnector(server, 1, 1);
+        server.addConnector(connector);
+        server.setHandler(failureCapture);
+        server.start();
+
+        try (HttpClient httpClient = new HttpClient())
+        {
+            httpClient.start();
+
+            // HttpClient transparently decodes zstd content and strips the Content-Encoding
+            // header from the final response, so capture it as it arrives on the wire instead.
+            AtomicReference<String> contentEncoding = new AtomicReference<>();
+            ContentResponse response = httpClient.newRequest("localhost", connector.getLocalPort())
+                .path("/context/big.txt")
+                .headers(h -> h.put(HttpHeader.ACCEPT_ENCODING, "zstd"))
+                .onResponseHeader((r, f) ->
+                {
+                    if (f.getHeader() == HttpHeader.CONTENT_ENCODING)
+                        contentEncoding.set(f.getValue());
+                    return true;
+                })
+                .timeout(15, TimeUnit.SECONDS)
+                .send();
+
+            assertThat(response.getStatus(), is(HttpStatus.OK_200));
+            assertThat(contentEncoding.get(), is("zstd"));
+            assertThat(response.getContentAsString(), is(generatedContent));
+            assertThat(handlerFailure.get(), nullValue());
+        }
+    }
+
+    private String generateContent(int length)
+    {
+        String sample = """
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit. In quis felis nunc.
+                Quisque suscipit mauris et ante auctor ornare rhoncus lacus aliquet. Pellentesque
+                habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.
+                """;
+        StringBuilder result = new StringBuilder();
+        while (result.length() < length)
+        {
+            result.append(sample);
+        }
+        result.setLength(length);
+        return result.toString();
+    }
+}


### PR DESCRIPTION
`ServletContextResponse` and `HttpOutput` should be kept in sync w.r.t how many bytes were written (to apply the content-length logic) and their closed state / last flag handling.

## Problem Description

The problem is exposed by the newly added `ResourceServletCompressionCompleteTest`: when a Core handler (`CompressionHandler` with zstd in this case, but any other handler modifying the output would trigger the bug) wraps a EE10/11 `ServletContextHandler`, any sufficiently large data (larger than the output buffer size) sent by the servlet (`ResourceServlet` serving a 64 KB file in this case) result in the output being corrupted and the `ServletChannel` aborting with `java.io.IOException: Insufficient content written 0 < 65536`.

This happens because the data is sent via the Core `Response.write()` API, bypassing the `HttpOutput` entirely such as it did not see a single byte being written, so when the `ServletChannel` calls `HttpOutput.isContentIncomplete()` that method returns `true` and the servlet channel aborts the request, thinking no byte was written.

This change fixes the problem by ensuring 3 things:

 - Making sure that any data written directly via `ServletContextResponse.write()` is accounted for in `HttpOutput`.
 - Fixing the missing callback completions in `InputStreamWritingCB` and `ReadableByteChannelWritingCB` so that the straight-through `HttpOutput.sendContent()` calls can't deadlock.
 - Closing the `HttpOutput` when `ServletContextResponse.write()` sees the last write being written.

Fixes https://github.com/jetty/jetty.project/issues/15678