### PR TITLE
Issue #15733 Fix cross-context dispatch to use the target context

### DIFF
--- a/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/main/java/org/eclipse/jetty/ee10/servlet/Dispatcher.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
@@ -49,6 +50,7 @@ import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 public class Dispatcher implements RequestDispatcher
@@ -121,7 +123,7 @@ public class Dispatcher implements RequestDispatcher
         HttpServletRequest httpRequest = (request instanceof HttpServletRequest) ? (HttpServletRequest)request : new ServletRequestHttpWrapper(request);
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ErrorRequest(httpRequest), httpResponse);
+        handleInTargetContext(new ErrorRequest(httpRequest), httpResponse, request);
     }
 
     @Override
@@ -132,7 +134,7 @@ public class Dispatcher implements RequestDispatcher
 
         ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
         servletContextRequest.getServletContextResponse().resetForForward();
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ForwardRequest(httpRequest), httpResponse);
+        handleInTargetContext(new ForwardRequest(httpRequest), httpResponse, servletContextRequest);
 
         // If we are not async and not closed already, then close via the possibly wrapped response.
         if (!servletContextRequest.getState().isAsync() && !servletContextRequest.getServletContextResponse().hasLastWrite())
@@ -160,7 +162,7 @@ public class Dispatcher implements RequestDispatcher
         IncludeResponse includeResponse = new IncludeResponse(httpResponse);
         try
         {
-            _mappedServlet.handle(_servletHandler, _decodedPathInContext, new IncludeRequest(httpRequest), includeResponse);
+            handleInTargetContext(new IncludeRequest(httpRequest), includeResponse, request);
         }
         finally
         {
@@ -174,7 +176,53 @@ public class Dispatcher implements RequestDispatcher
         HttpServletRequest httpRequest = (request instanceof HttpServletRequest) ? (HttpServletRequest)request : new ServletRequestHttpWrapper(request);
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new AsyncRequest(httpRequest), httpResponse);
+        handleInTargetContext(new AsyncRequest(httpRequest), httpResponse, request);
+    }
+
+    /**
+     * Runs the dispatch in the scope of the {@link ServletContextHandler} this {@link Dispatcher}
+     * dispatches to, so the target's ClassLoader and current {@link org.eclipse.jetty.server.Context}
+     * apply while its servlet runs. Entering the scope is skipped when the target context is already
+     * the current one, which is every dispatch that stays within a single context.
+     * <p>The request's session is not switched to the target context here. Cross context session
+     * handling is enabled with {@link ServletContextHandler#setCrossContextDispatchSupported(boolean)}
+     * and used through {@link jakarta.servlet.ServletContext#getContext(String)}.</p>
+     */
+    private void handleInTargetContext(HttpServletRequest request, HttpServletResponse response, Object source)
+        throws ServletException, IOException
+    {
+        try
+        {
+            _contextHandler.getContext().call(
+                () -> _mappedServlet.handle(_servletHandler, _decodedPathInContext, request, response),
+                asScopedRequest(source));
+        }
+        catch (ServletException | IOException | RuntimeException | Error e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new ServletException(e);
+        }
+    }
+
+    private static ServletContextRequest asScopedRequest(Object source)
+    {
+        if (source instanceof ServletContextRequest servletContextRequest)
+            return servletContextRequest;
+        if (source instanceof ServletRequest servletRequest)
+        {
+            try
+            {
+                return ServletContextRequest.getServletContextRequest(servletRequest);
+            }
+            catch (IllegalStateException ignored)
+            {
+                // Tell the scope listeners there is no request rather than failing the dispatch.
+            }
+        }
+        return null;
     }
 
     public class ParameterRequestWrapper extends HttpServletRequestWrapper
@@ -268,6 +316,39 @@ public class Dispatcher implements RequestDispatcher
             return vals.toArray(new String[0]);
         }
 
+        /**
+         * @return the {@link ServletContext} this {@link Dispatcher} dispatches to, which is the
+         *     context the request was last dispatched to. It is the same context the wrapped request
+         *     reports unless this dispatcher was obtained from another context's {@code ServletContext}.
+         */
+        @Override
+        public ServletContext getServletContext()
+        {
+            return _contextHandler.getContext().getServletContext();
+        }
+
+        /**
+         * Resolves {@code path} within the context this {@link Dispatcher} dispatches to.
+         * A relative path is resolved against the path of this request, which is the dispatch target
+         * for a forward, error or async dispatch, and remains the original path for an include.
+         */
+        @Override
+        public RequestDispatcher getRequestDispatcher(String path)
+        {
+            if (path == null)
+                return null;
+
+            if (!path.startsWith("/"))
+            {
+                String relTo = URIUtil.addPaths(getServletPath(), getPathInfo());
+                int slash = (relTo == null) ? -1 : relTo.lastIndexOf('/');
+                relTo = (slash > 1) ? relTo.substring(0, slash + 1) : "/";
+                path = URIUtil.addPaths(relTo, path);
+            }
+
+            return _contextHandler.getContext().getServletContext().getRequestDispatcher(path);
+        }
+
         @Override
         public String toString()
         {
@@ -305,6 +386,15 @@ public class Dispatcher implements RequestDispatcher
             if (_servletPathMapping == null)
                 return super.getServletPath();
             return _servletPathMapping.getServletPath();
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            //Servlet Spec 9.4.2 a named dispatcher leaves the request path elements alone
+            if (_named != null)
+                return super.getContextPath();
+            return _contextHandler.getRequestContextPath();
         }
 
         @Override
@@ -470,7 +560,7 @@ public class Dispatcher implements RequestDispatcher
                 case RequestDispatcher.INCLUDE_SERVLET_PATH -> _servletPathMapping.getServletPath();
                 case RequestDispatcher.INCLUDE_PATH_INFO -> _servletPathMapping.getPathInfo();
                 case RequestDispatcher.INCLUDE_REQUEST_URI -> (_uri == null) ? null : _uri.getPath();
-                case RequestDispatcher.INCLUDE_CONTEXT_PATH -> _httpServletRequest.getContextPath();
+                case RequestDispatcher.INCLUDE_CONTEXT_PATH -> _contextHandler.getRequestContextPath();
                 case RequestDispatcher.INCLUDE_QUERY_STRING -> (_uri == null) ? null : _uri.getQuery();
                 case ServletContextRequest.MULTIPART_CONFIG_ELEMENT ->
                 {
@@ -788,6 +878,12 @@ public class Dispatcher implements RequestDispatcher
         }
 
         @Override
+        public String getContextPath()
+        {
+            return _contextHandler.getRequestContextPath();
+        }
+
+        @Override
         public HttpServletMapping getHttpServletMapping()
         {
             // TODO what about a 404 dispatch?
@@ -930,6 +1026,12 @@ public class Dispatcher implements RequestDispatcher
         public String getServletPath()
         {
             return _servletPathMapping.getServletPath();
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            return _contextHandler.getRequestContextPath();
         }
 
         @Override

--- a/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ForeignContextDispatcherTest.java
+++ b/jetty-ee10/jetty-ee10-servlet/src/test/java/org/eclipse/jetty/ee10/servlet/ForeignContextDispatcherTest.java
@@ -1,0 +1,387 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee10.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * <p>Dispatches made through a {@link RequestDispatcher} obtained directly from another
+ * {@link ServletContextHandler}'s own {@link ServletContext}, rather than through
+ * {@link ServletContext#getContext(String)}.</p>
+ * <p>That yields a plain {@link Dispatcher} whose target context differs from the context the
+ * request arrived in, so the dispatched servlet must both see the target context through the request
+ * (context path, {@code getServletContext()}, relative {@code getRequestDispatcher()}) and run in the
+ * target context's scope (its {@code ClassLoader}, current {@link Context} and scope listeners).
+ * Cross context dispatch is deliberately NOT enabled here: this covers the direct handle, not the
+ * {@code CrossContextDispatcher} path covered by {@link CrossContextDispatcherTest}.</p>
+ */
+public class ForeignContextDispatcherTest
+{
+    private static final String NESTED = "org.eclipse.jetty.test.nested";
+
+    private Server _server;
+    private LocalConnector _connector;
+    private ServletContextHandler _contextA;
+    private ServletContextHandler _contextB;
+    private final List<String> _scopeEntersA = new CopyOnWriteArrayList<>();
+    private final List<String> _scopeEntersB = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    public void init() throws Exception
+    {
+        _server = new Server();
+        _connector = new LocalConnector(_server);
+        _connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        _connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        _server.addConnector(_connector);
+
+        ClassLoader parent = ForeignContextDispatcherTest.class.getClassLoader();
+
+        _contextA = new ServletContextHandler();
+        _contextA.setContextPath("/a");
+        _contextA.setClassLoader(new MarkerClassLoader("/a", parent));
+        _contextA.addEventListener(new ScopeRecorder(_scopeEntersA));
+
+        _contextB = new ServletContextHandler();
+        _contextB.setContextPath("/b");
+        _contextB.setClassLoader(new MarkerClassLoader("/b", parent));
+        _contextB.addEventListener(new ScopeRecorder(_scopeEntersB));
+
+        // Both contexts have a /deep/sibling, so a relative dispatch made from within the target
+        // says which context it was resolved against.
+        _contextA.addServlet(new DumpServlet("SIBLING@a"), "/deep/sibling");
+        _contextA.addServlet(new DumpServlet("TARGET@a"), "/deep/target");
+        _contextA.addServlet(new DispatchServlet(_contextB), "/deep/dispatch");
+        _contextA.addServlet(new DispatchServlet(_contextA), "/deep/local");
+
+        _contextB.addServlet(new DumpServlet("SIBLING@b"), "/deep/sibling");
+        _contextB.addServlet(new DumpServlet("TARGET@b"), "/deep/target");
+        _contextB.addServlet(new DumpServlet("ERROR@b"), "/deep/error500");
+        _contextB.addServlet(new ServletHolder("named", new DumpServlet("NAMED@b")), "/deep/named");
+
+        ContextHandlerCollection contexts = new ContextHandlerCollection();
+        contexts.addHandler(_contextA);
+        contexts.addHandler(_contextB);
+        _server.setHandler(contexts);
+
+        _server.start();
+        // Ignore any scope entries logged while starting; only the dispatch matters.
+        _scopeEntersA.clear();
+        _scopeEntersB.clear();
+    }
+
+    @AfterEach
+    public void destroy() throws Exception
+    {
+        _server.stop();
+        _server.join();
+    }
+
+    @Test
+    public void testCrossContextIncludeReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextForwardReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+        assertThat(content, containsString("TARGET@b: contextPath=/b"));
+        assertThat(content, containsString("TARGET@b: requestURI=/b/deep/target"));
+    }
+
+    @Test
+    public void testCrossContextForwardRelativeDispatcherResolvesInTargetContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", "sibling");
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextIncludeRelativeDispatcherResolvesInTargetContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", "sibling");
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextErrorDispatchReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("error", "/deep/error500", "sibling");
+        assertThat(content, containsString("ERROR@b: servletContext=/b"));
+        assertThat(content, containsString("ERROR@b: contextPath=/b"));
+        assertThat(content, containsString("ERROR@b: requestURI=/b/deep/error500"));
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextIncludeKeepsOriginalPathElements() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+
+        // The context the request was last dispatched to.
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+
+        // Servlet spec 9.3: an include leaves the request path elements as the includer's.
+        assertThat(content, containsString("TARGET@b: contextPath=/a"));
+        assertThat(content, containsString("TARGET@b: requestURI=/a/deep/dispatch"));
+        assertThat(content, containsString("TARGET@b: servletPath=/deep/dispatch"));
+
+        // But the include attributes describe the target.
+        assertThat(content, containsString("TARGET@b: include.contextPath=/b"));
+        assertThat(content, containsString("TARGET@b: include.servletPath=/deep/target"));
+        assertThat(content, containsString("TARGET@b: include.requestURI=/b/deep/target"));
+    }
+
+    @Test
+    public void testCrossContextNamedForwardKeepsOriginalPathElements() throws Exception
+    {
+        String content = dispatch("named", "named", "sibling");
+
+        // A named dispatch does not change the request path, so the context path stays the source's.
+        assertThat(content, containsString("NAMED@b: servletContext=/b"));
+        assertThat(content, containsString("NAMED@b: contextPath=/a"));
+        assertThat(content, containsString("NAMED@b: requestURI=/a/deep/dispatch"));
+
+        // A relative dispatch is still resolved in the target context.
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextForwardEntersTargetClassLoaderAndContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: tccl=loader/b"));
+        assertThat(content, containsString("TARGET@b: currentContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextIncludeEntersTargetClassLoaderAndContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: tccl=loader/b"));
+        assertThat(content, containsString("TARGET@b: currentContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextForwardFiresTargetContextScopeListener() throws Exception
+    {
+        dispatch("forward", "/deep/target", null);
+        // The target context's scope was entered exactly once, for the dispatch.
+        assertThat(_scopeEntersB, contains("/b"));
+    }
+
+    @Test
+    public void testSameContextForwardDoesNotEnterAnotherContext() throws Exception
+    {
+        String content = dispatchLocal("forward", "/deep/target", "sibling");
+        assertThat(content, containsString("TARGET@a: servletContext=/a"));
+        assertThat(content, containsString("TARGET@a: contextPath=/a"));
+        assertThat(content, containsString("TARGET@a: requestURI=/a/deep/target"));
+        assertThat(content, containsString("TARGET@a: tccl=loader/a"));
+        assertThat(content, containsString("TARGET@a: currentContext=/a"));
+        assertThat(content, containsString("SIBLING@a:"));
+        assertThat(content, not(containsString("SIBLING@b:")));
+
+        // A dispatch that stays within one context never enters the other context's scope.
+        assertThat(_scopeEntersB, is(empty()));
+    }
+
+    @Test
+    public void testSameContextIncludeUnchanged() throws Exception
+    {
+        String content = dispatchLocal("include", "/deep/target", "sibling");
+        assertThat(content, containsString("TARGET@a: servletContext=/a"));
+        assertThat(content, containsString("TARGET@a: contextPath=/a"));
+        assertThat(content, containsString("TARGET@a: requestURI=/a/deep/local"));
+        assertThat(content, containsString("TARGET@a: include.contextPath=/a"));
+        assertThat(content, containsString("SIBLING@a:"));
+        assertThat(content, not(containsString("SIBLING@b:")));
+    }
+
+    private String dispatch(String type, String path, String nested) throws Exception
+    {
+        return request("/a/deep/dispatch", type, path, nested);
+    }
+
+    private String dispatchLocal(String type, String path, String nested) throws Exception
+    {
+        return request("/a/deep/local", type, path, nested);
+    }
+
+    private String request(String uri, String type, String path, String nested) throws Exception
+    {
+        StringBuilder query = new StringBuilder("?type=").append(type).append("&path=").append(path);
+        if (nested != null)
+            query.append("&nested=").append(nested);
+
+        String rawResponse = _connector.getResponse("""
+            GET %s%s HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """.formatted(uri, query));
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpServletResponse.SC_OK));
+        return response.getContent();
+    }
+
+    /**
+     * Dispatches to a target held as a direct {@link ServletContext} reference, which is how
+     * applications reach another context without {@code ServletContext.getContext(String)}.
+     */
+    public static class DispatchServlet extends HttpServlet
+    {
+        private final ServletContextHandler _target;
+
+        public DispatchServlet(ServletContextHandler target)
+        {
+            _target = target;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            ServletContext target = _target.getServletContext();
+            String nested = request.getParameter("nested");
+            if (nested != null)
+                request.setAttribute(NESTED, nested);
+
+            String path = request.getParameter("path");
+            String type = request.getParameter("type");
+            switch (type)
+            {
+                case "include" -> target.getRequestDispatcher(path).include(request, response);
+                case "forward" -> target.getRequestDispatcher(path).forward(request, response);
+                case "named" -> target.getNamedDispatcher(path).forward(request, response);
+                case "error" -> ((Dispatcher)target.getRequestDispatcher(path)).error(request, response);
+                default -> response.sendError(HttpServletResponse.SC_BAD_REQUEST, "unknown type " + type);
+            }
+        }
+    }
+
+    /**
+     * Dumps the request's view of its context plus the running scope, optionally after a nested
+     * dispatch whose path comes from the {@link #NESTED} attribute.
+     */
+    public static class DumpServlet extends HttpServlet
+    {
+        private final String _tag;
+
+        public DumpServlet(String tag)
+        {
+            _tag = tag;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            String nested = (String)request.getAttribute(NESTED);
+            if (nested != null)
+            {
+                request.removeAttribute(NESTED);
+                request.getRequestDispatcher(nested).include(request, response);
+            }
+
+            Context current = ContextHandler.getCurrentContext();
+            PrintWriter out = response.getWriter();
+            out.println(_tag + ": servletContext=" + request.getServletContext().getContextPath());
+            out.println(_tag + ": contextPath=" + request.getContextPath());
+            out.println(_tag + ": requestURI=" + request.getRequestURI());
+            out.println(_tag + ": servletPath=" + request.getServletPath());
+            out.println(_tag + ": pathInfo=" + request.getPathInfo());
+            out.println(_tag + ": dispatcherType=" + request.getDispatcherType());
+            out.println(_tag + ": tccl=" + Thread.currentThread().getContextClassLoader());
+            out.println(_tag + ": currentContext=" + (current == null ? null : current.getContextPath()));
+            out.println(_tag + ": include.contextPath=" + request.getAttribute(RequestDispatcher.INCLUDE_CONTEXT_PATH));
+            out.println(_tag + ": include.servletPath=" + request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH));
+            out.println(_tag + ": include.requestURI=" + request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI));
+        }
+    }
+
+    /**
+     * A recognizable {@link ClassLoader} so a servlet can report which context's loader is current.
+     */
+    private static class MarkerClassLoader extends ClassLoader
+    {
+        private final String _tag;
+
+        MarkerClassLoader(String tag, ClassLoader parent)
+        {
+            super(parent);
+            _tag = tag;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "loader" + _tag;
+        }
+    }
+
+    /**
+     * Records the context path each time its context scope is entered.
+     */
+    private static class ScopeRecorder implements ContextHandler.ContextScopeListener
+    {
+        private final List<String> _enters;
+
+        ScopeRecorder(List<String> enters)
+        {
+            _enters = enters;
+        }
+
+        @Override
+        public void enterScope(Context context, Request request)
+        {
+            _enters.add(context.getContextPath());
+        }
+    }
+}

--- a/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Dispatcher.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/main/java/org/eclipse/jetty/ee11/servlet/Dispatcher.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 
 import jakarta.servlet.DispatcherType;
 import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.ServletRequest;
@@ -50,6 +51,7 @@ import org.eclipse.jetty.util.Fields;
 import org.eclipse.jetty.util.IO;
 import org.eclipse.jetty.util.StringUtil;
 import org.eclipse.jetty.util.TypeUtil;
+import org.eclipse.jetty.util.URIUtil;
 import org.eclipse.jetty.util.UrlEncoded;
 
 public class Dispatcher implements RequestDispatcher
@@ -122,7 +124,7 @@ public class Dispatcher implements RequestDispatcher
         HttpServletRequest httpRequest = (request instanceof HttpServletRequest) ? (HttpServletRequest)request : new ServletRequestHttpWrapper(request);
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ErrorRequest(httpRequest), httpResponse);
+        handleInTargetContext(new ErrorRequest(httpRequest), httpResponse, request);
     }
 
     @Override
@@ -133,7 +135,7 @@ public class Dispatcher implements RequestDispatcher
 
         ServletContextRequest servletContextRequest = ServletContextRequest.getServletContextRequest(request);
         servletContextRequest.getServletContextResponse().resetForForward();
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new ForwardRequest(httpRequest), httpResponse);
+        handleInTargetContext(new ForwardRequest(httpRequest), httpResponse, servletContextRequest);
 
         // If we are not async and not closed already, then close via the possibly wrapped response.
         if (!servletContextRequest.getState().isAsync() && !servletContextRequest.getServletContextResponse().hasLastWrite())
@@ -161,7 +163,7 @@ public class Dispatcher implements RequestDispatcher
         IncludeResponse includeResponse = new IncludeResponse(httpResponse);
         try
         {
-            _mappedServlet.handle(_servletHandler, _decodedPathInContext, new IncludeRequest(httpRequest), includeResponse);
+            handleInTargetContext(new IncludeRequest(httpRequest), includeResponse, request);
         }
         finally
         {
@@ -175,7 +177,53 @@ public class Dispatcher implements RequestDispatcher
         HttpServletRequest httpRequest = (request instanceof HttpServletRequest) ? (HttpServletRequest)request : new ServletRequestHttpWrapper(request);
         HttpServletResponse httpResponse = (response instanceof HttpServletResponse) ? (HttpServletResponse)response : new ServletResponseHttpWrapper(response);
 
-        _mappedServlet.handle(_servletHandler, _decodedPathInContext, new AsyncRequest(httpRequest), httpResponse);
+        handleInTargetContext(new AsyncRequest(httpRequest), httpResponse, request);
+    }
+
+    /**
+     * Runs the dispatch in the scope of the {@link ServletContextHandler} this {@link Dispatcher}
+     * dispatches to, so the target's ClassLoader and current {@link org.eclipse.jetty.server.Context}
+     * apply while its servlet runs. Entering the scope is skipped when the target context is already
+     * the current one, which is every dispatch that stays within a single context.
+     * <p>The request's session is not switched to the target context here. Cross context session
+     * handling is enabled with {@link ServletContextHandler#setCrossContextDispatchSupported(boolean)}
+     * and used through {@link jakarta.servlet.ServletContext#getContext(String)}.</p>
+     */
+    private void handleInTargetContext(HttpServletRequest request, HttpServletResponse response, Object source)
+        throws ServletException, IOException
+    {
+        try
+        {
+            _contextHandler.getContext().call(
+                () -> _mappedServlet.handle(_servletHandler, _decodedPathInContext, request, response),
+                asScopedRequest(source));
+        }
+        catch (ServletException | IOException | RuntimeException | Error e)
+        {
+            throw e;
+        }
+        catch (Exception e)
+        {
+            throw new ServletException(e);
+        }
+    }
+
+    private static ServletContextRequest asScopedRequest(Object source)
+    {
+        if (source instanceof ServletContextRequest servletContextRequest)
+            return servletContextRequest;
+        if (source instanceof ServletRequest servletRequest)
+        {
+            try
+            {
+                return ServletContextRequest.getServletContextRequest(servletRequest);
+            }
+            catch (IllegalStateException ignored)
+            {
+                // Tell the scope listeners there is no request rather than failing the dispatch.
+            }
+        }
+        return null;
     }
 
     public class ParameterRequestWrapper extends HttpServletRequestWrapper
@@ -269,6 +317,39 @@ public class Dispatcher implements RequestDispatcher
             return vals.toArray(new String[0]);
         }
 
+        /**
+         * @return the {@link ServletContext} this {@link Dispatcher} dispatches to, which is the
+         *     context the request was last dispatched to. It is the same context the wrapped request
+         *     reports unless this dispatcher was obtained from another context's {@code ServletContext}.
+         */
+        @Override
+        public ServletContext getServletContext()
+        {
+            return _contextHandler.getContext().getServletContext();
+        }
+
+        /**
+         * Resolves {@code path} within the context this {@link Dispatcher} dispatches to.
+         * A relative path is resolved against the path of this request, which is the dispatch target
+         * for a forward, error or async dispatch, and remains the original path for an include.
+         */
+        @Override
+        public RequestDispatcher getRequestDispatcher(String path)
+        {
+            if (path == null)
+                return null;
+
+            if (!path.startsWith("/"))
+            {
+                String relTo = URIUtil.addPaths(getServletPath(), getPathInfo());
+                int slash = (relTo == null) ? -1 : relTo.lastIndexOf('/');
+                relTo = (slash > 1) ? relTo.substring(0, slash + 1) : "/";
+                path = URIUtil.addPaths(relTo, path);
+            }
+
+            return _contextHandler.getContext().getServletContext().getRequestDispatcher(path);
+        }
+
         @Override
         public String toString()
         {
@@ -306,6 +387,15 @@ public class Dispatcher implements RequestDispatcher
             if (_servletPathMapping == null)
                 return super.getServletPath();
             return _servletPathMapping.getServletPath();
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            //Servlet Spec 9.4.2 a named dispatcher leaves the request path elements alone
+            if (_named != null)
+                return super.getContextPath();
+            return _contextHandler.getRequestContextPath();
         }
 
         @Override
@@ -471,7 +561,7 @@ public class Dispatcher implements RequestDispatcher
                 case RequestDispatcher.INCLUDE_SERVLET_PATH -> _servletPathMapping.getServletPath();
                 case RequestDispatcher.INCLUDE_PATH_INFO -> _servletPathMapping.getPathInfo();
                 case RequestDispatcher.INCLUDE_REQUEST_URI -> (_uri == null) ? null : _uri.getPath();
-                case RequestDispatcher.INCLUDE_CONTEXT_PATH -> _httpServletRequest.getContextPath();
+                case RequestDispatcher.INCLUDE_CONTEXT_PATH -> _contextHandler.getRequestContextPath();
                 case RequestDispatcher.INCLUDE_QUERY_STRING -> (_uri == null) ? null : _uri.getQuery();
                 case ServletContextRequest.MULTIPART_CONFIG_ELEMENT ->
                 {
@@ -807,6 +897,12 @@ public class Dispatcher implements RequestDispatcher
         }
 
         @Override
+        public String getContextPath()
+        {
+            return _contextHandler.getRequestContextPath();
+        }
+
+        @Override
         public HttpServletMapping getHttpServletMapping()
         {
             // TODO what about a 404 dispatch?
@@ -955,6 +1051,12 @@ public class Dispatcher implements RequestDispatcher
         public String getServletPath()
         {
             return Objects.requireNonNull(_servletPathMapping).getServletPath();
+        }
+
+        @Override
+        public String getContextPath()
+        {
+            return _contextHandler.getRequestContextPath();
         }
 
         @Override

--- a/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ForeignContextDispatcherTest.java
+++ b/jetty-ee11/jetty-ee11-servlet/src/test/java/org/eclipse/jetty/ee11/servlet/ForeignContextDispatcherTest.java
@@ -1,0 +1,387 @@
+//
+// ========================================================================
+// Copyright (c) 1995 Mort Bay Consulting Pty Ltd and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// https://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+// ========================================================================
+//
+
+package org.eclipse.jetty.ee11.servlet;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.ServletContext;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.eclipse.jetty.http.HttpTester;
+import org.eclipse.jetty.server.Context;
+import org.eclipse.jetty.server.HttpConfiguration;
+import org.eclipse.jetty.server.LocalConnector;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.handler.ContextHandler;
+import org.eclipse.jetty.server.handler.ContextHandlerCollection;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * <p>Dispatches made through a {@link RequestDispatcher} obtained directly from another
+ * {@link ServletContextHandler}'s own {@link ServletContext}, rather than through
+ * {@link ServletContext#getContext(String)}.</p>
+ * <p>That yields a plain {@link Dispatcher} whose target context differs from the context the
+ * request arrived in, so the dispatched servlet must both see the target context through the request
+ * (context path, {@code getServletContext()}, relative {@code getRequestDispatcher()}) and run in the
+ * target context's scope (its {@code ClassLoader}, current {@link Context} and scope listeners).
+ * Cross context dispatch is deliberately NOT enabled here: this covers the direct handle, not the
+ * {@code CrossContextDispatcher} path covered by {@link CrossContextDispatcherTest}.</p>
+ */
+public class ForeignContextDispatcherTest
+{
+    private static final String NESTED = "org.eclipse.jetty.test.nested";
+
+    private Server _server;
+    private LocalConnector _connector;
+    private ServletContextHandler _contextA;
+    private ServletContextHandler _contextB;
+    private final List<String> _scopeEntersA = new CopyOnWriteArrayList<>();
+    private final List<String> _scopeEntersB = new CopyOnWriteArrayList<>();
+
+    @BeforeEach
+    public void init() throws Exception
+    {
+        _server = new Server();
+        _connector = new LocalConnector(_server);
+        _connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendServerVersion(false);
+        _connector.getConnectionFactory(HttpConfiguration.ConnectionFactory.class).getHttpConfiguration().setSendDateHeader(false);
+        _server.addConnector(_connector);
+
+        ClassLoader parent = ForeignContextDispatcherTest.class.getClassLoader();
+
+        _contextA = new ServletContextHandler();
+        _contextA.setContextPath("/a");
+        _contextA.setClassLoader(new MarkerClassLoader("/a", parent));
+        _contextA.addEventListener(new ScopeRecorder(_scopeEntersA));
+
+        _contextB = new ServletContextHandler();
+        _contextB.setContextPath("/b");
+        _contextB.setClassLoader(new MarkerClassLoader("/b", parent));
+        _contextB.addEventListener(new ScopeRecorder(_scopeEntersB));
+
+        // Both contexts have a /deep/sibling, so a relative dispatch made from within the target
+        // says which context it was resolved against.
+        _contextA.addServlet(new DumpServlet("SIBLING@a"), "/deep/sibling");
+        _contextA.addServlet(new DumpServlet("TARGET@a"), "/deep/target");
+        _contextA.addServlet(new DispatchServlet(_contextB), "/deep/dispatch");
+        _contextA.addServlet(new DispatchServlet(_contextA), "/deep/local");
+
+        _contextB.addServlet(new DumpServlet("SIBLING@b"), "/deep/sibling");
+        _contextB.addServlet(new DumpServlet("TARGET@b"), "/deep/target");
+        _contextB.addServlet(new DumpServlet("ERROR@b"), "/deep/error500");
+        _contextB.addServlet(new ServletHolder("named", new DumpServlet("NAMED@b")), "/deep/named");
+
+        ContextHandlerCollection contexts = new ContextHandlerCollection();
+        contexts.addHandler(_contextA);
+        contexts.addHandler(_contextB);
+        _server.setHandler(contexts);
+
+        _server.start();
+        // Ignore any scope entries logged while starting; only the dispatch matters.
+        _scopeEntersA.clear();
+        _scopeEntersB.clear();
+    }
+
+    @AfterEach
+    public void destroy() throws Exception
+    {
+        _server.stop();
+        _server.join();
+    }
+
+    @Test
+    public void testCrossContextIncludeReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextForwardReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+        assertThat(content, containsString("TARGET@b: contextPath=/b"));
+        assertThat(content, containsString("TARGET@b: requestURI=/b/deep/target"));
+    }
+
+    @Test
+    public void testCrossContextForwardRelativeDispatcherResolvesInTargetContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", "sibling");
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextIncludeRelativeDispatcherResolvesInTargetContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", "sibling");
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextErrorDispatchReportsTargetServletContext() throws Exception
+    {
+        String content = dispatch("error", "/deep/error500", "sibling");
+        assertThat(content, containsString("ERROR@b: servletContext=/b"));
+        assertThat(content, containsString("ERROR@b: contextPath=/b"));
+        assertThat(content, containsString("ERROR@b: requestURI=/b/deep/error500"));
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextIncludeKeepsOriginalPathElements() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+
+        // The context the request was last dispatched to.
+        assertThat(content, containsString("TARGET@b: servletContext=/b"));
+
+        // Servlet spec 9.3: an include leaves the request path elements as the includer's.
+        assertThat(content, containsString("TARGET@b: contextPath=/a"));
+        assertThat(content, containsString("TARGET@b: requestURI=/a/deep/dispatch"));
+        assertThat(content, containsString("TARGET@b: servletPath=/deep/dispatch"));
+
+        // But the include attributes describe the target.
+        assertThat(content, containsString("TARGET@b: include.contextPath=/b"));
+        assertThat(content, containsString("TARGET@b: include.servletPath=/deep/target"));
+        assertThat(content, containsString("TARGET@b: include.requestURI=/b/deep/target"));
+    }
+
+    @Test
+    public void testCrossContextNamedForwardKeepsOriginalPathElements() throws Exception
+    {
+        String content = dispatch("named", "named", "sibling");
+
+        // A named dispatch does not change the request path, so the context path stays the source's.
+        assertThat(content, containsString("NAMED@b: servletContext=/b"));
+        assertThat(content, containsString("NAMED@b: contextPath=/a"));
+        assertThat(content, containsString("NAMED@b: requestURI=/a/deep/dispatch"));
+
+        // A relative dispatch is still resolved in the target context.
+        assertThat(content, containsString("SIBLING@b:"));
+        assertThat(content, not(containsString("SIBLING@a:")));
+    }
+
+    @Test
+    public void testCrossContextForwardEntersTargetClassLoaderAndContext() throws Exception
+    {
+        String content = dispatch("forward", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: tccl=loader/b"));
+        assertThat(content, containsString("TARGET@b: currentContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextIncludeEntersTargetClassLoaderAndContext() throws Exception
+    {
+        String content = dispatch("include", "/deep/target", null);
+        assertThat(content, containsString("TARGET@b: tccl=loader/b"));
+        assertThat(content, containsString("TARGET@b: currentContext=/b"));
+    }
+
+    @Test
+    public void testCrossContextForwardFiresTargetContextScopeListener() throws Exception
+    {
+        dispatch("forward", "/deep/target", null);
+        // The target context's scope was entered exactly once, for the dispatch.
+        assertThat(_scopeEntersB, contains("/b"));
+    }
+
+    @Test
+    public void testSameContextForwardDoesNotEnterAnotherContext() throws Exception
+    {
+        String content = dispatchLocal("forward", "/deep/target", "sibling");
+        assertThat(content, containsString("TARGET@a: servletContext=/a"));
+        assertThat(content, containsString("TARGET@a: contextPath=/a"));
+        assertThat(content, containsString("TARGET@a: requestURI=/a/deep/target"));
+        assertThat(content, containsString("TARGET@a: tccl=loader/a"));
+        assertThat(content, containsString("TARGET@a: currentContext=/a"));
+        assertThat(content, containsString("SIBLING@a:"));
+        assertThat(content, not(containsString("SIBLING@b:")));
+
+        // A dispatch that stays within one context never enters the other context's scope.
+        assertThat(_scopeEntersB, is(empty()));
+    }
+
+    @Test
+    public void testSameContextIncludeUnchanged() throws Exception
+    {
+        String content = dispatchLocal("include", "/deep/target", "sibling");
+        assertThat(content, containsString("TARGET@a: servletContext=/a"));
+        assertThat(content, containsString("TARGET@a: contextPath=/a"));
+        assertThat(content, containsString("TARGET@a: requestURI=/a/deep/local"));
+        assertThat(content, containsString("TARGET@a: include.contextPath=/a"));
+        assertThat(content, containsString("SIBLING@a:"));
+        assertThat(content, not(containsString("SIBLING@b:")));
+    }
+
+    private String dispatch(String type, String path, String nested) throws Exception
+    {
+        return request("/a/deep/dispatch", type, path, nested);
+    }
+
+    private String dispatchLocal(String type, String path, String nested) throws Exception
+    {
+        return request("/a/deep/local", type, path, nested);
+    }
+
+    private String request(String uri, String type, String path, String nested) throws Exception
+    {
+        StringBuilder query = new StringBuilder("?type=").append(type).append("&path=").append(path);
+        if (nested != null)
+            query.append("&nested=").append(nested);
+
+        String rawResponse = _connector.getResponse("""
+            GET %s%s HTTP/1.1\r
+            Host: local\r
+            Connection: close\r
+            \r
+            """.formatted(uri, query));
+
+        HttpTester.Response response = HttpTester.parseResponse(rawResponse);
+        assertThat(response.getStatus(), is(HttpServletResponse.SC_OK));
+        return response.getContent();
+    }
+
+    /**
+     * Dispatches to a target held as a direct {@link ServletContext} reference, which is how
+     * applications reach another context without {@code ServletContext.getContext(String)}.
+     */
+    public static class DispatchServlet extends HttpServlet
+    {
+        private final ServletContextHandler _target;
+
+        public DispatchServlet(ServletContextHandler target)
+        {
+            _target = target;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            ServletContext target = _target.getServletContext();
+            String nested = request.getParameter("nested");
+            if (nested != null)
+                request.setAttribute(NESTED, nested);
+
+            String path = request.getParameter("path");
+            String type = request.getParameter("type");
+            switch (type)
+            {
+                case "include" -> target.getRequestDispatcher(path).include(request, response);
+                case "forward" -> target.getRequestDispatcher(path).forward(request, response);
+                case "named" -> target.getNamedDispatcher(path).forward(request, response);
+                case "error" -> ((Dispatcher)target.getRequestDispatcher(path)).error(request, response);
+                default -> response.sendError(HttpServletResponse.SC_BAD_REQUEST, "unknown type " + type);
+            }
+        }
+    }
+
+    /**
+     * Dumps the request's view of its context plus the running scope, optionally after a nested
+     * dispatch whose path comes from the {@link #NESTED} attribute.
+     */
+    public static class DumpServlet extends HttpServlet
+    {
+        private final String _tag;
+
+        public DumpServlet(String tag)
+        {
+            _tag = tag;
+        }
+
+        @Override
+        protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException
+        {
+            String nested = (String)request.getAttribute(NESTED);
+            if (nested != null)
+            {
+                request.removeAttribute(NESTED);
+                request.getRequestDispatcher(nested).include(request, response);
+            }
+
+            Context current = ContextHandler.getCurrentContext();
+            PrintWriter out = response.getWriter();
+            out.println(_tag + ": servletContext=" + request.getServletContext().getContextPath());
+            out.println(_tag + ": contextPath=" + request.getContextPath());
+            out.println(_tag + ": requestURI=" + request.getRequestURI());
+            out.println(_tag + ": servletPath=" + request.getServletPath());
+            out.println(_tag + ": pathInfo=" + request.getPathInfo());
+            out.println(_tag + ": dispatcherType=" + request.getDispatcherType());
+            out.println(_tag + ": tccl=" + Thread.currentThread().getContextClassLoader());
+            out.println(_tag + ": currentContext=" + (current == null ? null : current.getContextPath()));
+            out.println(_tag + ": include.contextPath=" + request.getAttribute(RequestDispatcher.INCLUDE_CONTEXT_PATH));
+            out.println(_tag + ": include.servletPath=" + request.getAttribute(RequestDispatcher.INCLUDE_SERVLET_PATH));
+            out.println(_tag + ": include.requestURI=" + request.getAttribute(RequestDispatcher.INCLUDE_REQUEST_URI));
+        }
+    }
+
+    /**
+     * A recognizable {@link ClassLoader} so a servlet can report which context's loader is current.
+     */
+    private static class MarkerClassLoader extends ClassLoader
+    {
+        private final String _tag;
+
+        MarkerClassLoader(String tag, ClassLoader parent)
+        {
+            super(parent);
+            _tag = tag;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "loader" + _tag;
+        }
+    }
+
+    /**
+     * Records the context path each time its context scope is entered.
+     */
+    private static class ScopeRecorder implements ContextHandler.ContextScopeListener
+    {
+        private final List<String> _enters;
+
+        ScopeRecorder(List<String> enters)
+        {
+            _enters = enters;
+        }
+
+        @Override
+        public void enterScope(Context context, Request request)
+        {
+            _enters.add(context.getContextPath());
+        }
+    }
+}


### PR DESCRIPTION
When a RequestDispatcher is obtained from another context's ServletContext,
the dispatched servlet now reports that target context (getServletContext,
getContextPath, relative getRequestDispatcher) and runs in its scope
(ClassLoader, current context, scope listeners), matching ee9 behaviour.
Applies to both ee10 and ee11.

Signed-off-by: Olivier Lamy <olamy@apache.org>
